### PR TITLE
fix: improve code readability in light mode and fix React state updat…

### DIFF
--- a/apps/web/lib/code-theme.ts
+++ b/apps/web/lib/code-theme.ts
@@ -5,6 +5,6 @@ import type { BundledTheme } from "shiki";
  * Used by both MDX (source.config.ts) and DynamicCodeBlock components.
  */
 export const codeThemes: { light: BundledTheme; dark: BundledTheme } = {
-  light: "github-dark",
+  light: "github-light",
   dark: "github-dark",
 };

--- a/packages/ui/src/charts/pie-chart.tsx
+++ b/packages/ui/src/charts/pie-chart.tsx
@@ -9,6 +9,7 @@ import {
   type ReactElement,
   type ReactNode,
   useCallback,
+  useEffect,
   useMemo,
   useRef,
   useState,
@@ -194,12 +195,12 @@ function PieChartInner({
   }, [data, startAngle, endAngle, padAngle]);
 
   // Mark as loaded after initial render
-  useState(() => {
+  useEffect(() => {
     const timer = setTimeout(() => {
       setIsLoaded(true);
     }, 100);
     return () => clearTimeout(timer);
-  });
+  }, []);
 
   // Separate children into categories
   const { svgChildren, centerChildren, defsChildren } = useMemo(() => {


### PR DESCRIPTION
## Description

This PR fixes code readability issues in light mode and resolves a React state update error in the PieChart component.

### Changes Made

1. **Light Mode Syntax Highlighting**: Changed code theme from `github-dark` to `github-light` for light mode, ensuring proper contrast and readability of code blocks in documentation.

2. **PieChart React Warning Fix**: Replaced `useState` with `useEffect` for animation timing side effects, resolving the console error: "Can't perform a React state update on a component that hasn't mounted yet."

## Issues Fixed

- Code blocks were using dark theme colors on light backgrounds, making syntax highlighting barely visible
- Console error when rendering PieChart component due to incorrect use of `useState` for side effects

## Visual Changes

### Dark Mode - Working Perfectly ✅
<img width="1085" height="794" alt="image" src="https://github.com/user-attachments/assets/a57b50b7-8ad2-4738-97c4-47135add0a44" />

*Dark mode continues to work perfectly with proper syntax highlighting and contrast*

---

### Light Mode - Before (Unreadable) ❌

<img width="1233" height="901" alt="Screenshot from 2026-02-04 23-45-50" src="https://github.com/user-attachments/assets/91e9d545-6692-47b4-bd09-9e2846748c5b" />

*Some parts of the code appear grey/washed out, making them unreadable due to poor contrast*

---

### Light Mode - After (Fixed) ✅

<img width="1157" height="907" alt="image" src="https://github.com/user-attachments/assets/7801a511-41b8-4a09-b2da-f77444d2b430" />

*Code is now clearly visible with proper syntax highlighting and excellent readability*

## Testing

- [x] Verified code blocks render correctly in light mode
- [x] Verified code blocks still render correctly in dark mode
- [x] Confirmed React warning no longer appears in console
- [x] Tested PieChart animations work as expected

## Breaking Changes

None