### PR TITLE
fix(live chart): wrap live chart state updates in startTransition to unblock navigation

### DIFF
--- a/apps/web/components/docs/copy-page-button.tsx
+++ b/apps/web/components/docs/copy-page-button.tsx
@@ -35,7 +35,7 @@ export function CopyPageButton({ content, url }: CopyPageButtonProps) {
     setTimeout(() => setCopied(false), 2000);
   };
 
-  const fullUrl = typeof window !== "undefined" ? window.location.href : url;
+  const fullUrl = typeof window === "undefined" ? url : window.location.href;
 
   return (
     <div className="hidden md:flex">

--- a/apps/web/components/docs/segment-demo.tsx
+++ b/apps/web/components/docs/segment-demo.tsx
@@ -77,7 +77,7 @@ function SegmentBridge({
     onSegmentChange({
       value: endVal,
       change: endVal - startVal,
-      changePct: startVal !== 0 ? ((endVal - startVal) / startVal) * 100 : 0,
+      changePct: startVal === 0 ? 0 : ((endVal - startVal) / startVal) * 100,
       startDate: xAccessor(startPoint),
       endDate: xAccessor(endPoint),
     });

--- a/apps/web/components/ui/card.tsx
+++ b/apps/web/components/ui/card.tsx
@@ -83,10 +83,10 @@ function CardFooter({ className, ...props }: React.ComponentProps<"div">) {
 
 export {
   Card,
-  CardHeader,
-  CardFooter,
-  CardTitle,
   CardAction,
-  CardDescription,
   CardContent,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
 };

--- a/apps/web/components/ui/collapsible.tsx
+++ b/apps/web/components/ui/collapsible.tsx
@@ -8,4 +8,4 @@ const CollapsibleTrigger = CollapsiblePrimitive.CollapsibleTrigger;
 
 const CollapsibleContent = CollapsiblePrimitive.CollapsibleContent;
 
-export { Collapsible, CollapsibleTrigger, CollapsibleContent };
+export { Collapsible, CollapsibleContent, CollapsibleTrigger };

--- a/apps/web/components/ui/dropdown-menu.tsx
+++ b/apps/web/components/ui/dropdown-menu.tsx
@@ -240,18 +240,18 @@ function DropdownMenuSubContent({
 
 export {
   DropdownMenu,
-  DropdownMenuPortal,
-  DropdownMenuTrigger,
+  DropdownMenuCheckboxItem,
   DropdownMenuContent,
   DropdownMenuGroup,
-  DropdownMenuLabel,
   DropdownMenuItem,
-  DropdownMenuCheckboxItem,
+  DropdownMenuLabel,
+  DropdownMenuPortal,
   DropdownMenuRadioGroup,
   DropdownMenuRadioItem,
   DropdownMenuSeparator,
   DropdownMenuShortcut,
   DropdownMenuSub,
-  DropdownMenuSubTrigger,
   DropdownMenuSubContent,
+  DropdownMenuSubTrigger,
+  DropdownMenuTrigger,
 };

--- a/apps/web/components/ui/popover.tsx
+++ b/apps/web/components/ui/popover.tsx
@@ -80,10 +80,10 @@ function PopoverDescription({
 
 export {
   Popover,
-  PopoverTrigger,
-  PopoverContent,
   PopoverAnchor,
+  PopoverContent,
+  PopoverDescription,
   PopoverHeader,
   PopoverTitle,
-  PopoverDescription,
+  PopoverTrigger,
 };

--- a/apps/web/components/ui/sheet.tsx
+++ b/apps/web/components/ui/sheet.tsx
@@ -136,10 +136,10 @@ function SheetDescription({
 
 export {
   Sheet,
-  SheetTrigger,
   SheetClose,
   SheetContent,
+  SheetDescription,
   SheetHeader,
   SheetTitle,
-  SheetDescription,
+  SheetTrigger,
 };

--- a/apps/web/components/ui/tabs.tsx
+++ b/apps/web/components/ui/tabs.tsx
@@ -88,4 +88,4 @@ function TabsContent({
   );
 }
 
-export { Tabs, TabsList, TabsTrigger, TabsContent, tabsListVariants };
+export { Tabs, TabsContent, TabsList, TabsTrigger, tabsListVariants };

--- a/packages/ui/src/charts/choropleth/choropleth-tooltip.tsx
+++ b/packages/ui/src/charts/choropleth/choropleth-tooltip.tsx
@@ -86,15 +86,15 @@ export function ChoroplethTooltip({
   // Default tooltip with optional value
   const value = getFeatureValue?.(feature, tooltipData.featureIndex);
   const rows: TooltipRow[] =
-    value !== undefined
-      ? [
+    value === undefined
+      ? []
+      : [
           {
             color: "var(--chart-1)",
             label: valueLabel,
             value: formatValue(value),
           },
-        ]
-      : [];
+        ];
 
   return (
     <TooltipBox

--- a/packages/ui/src/charts/live-line-chart.tsx
+++ b/packages/ui/src/charts/live-line-chart.tsx
@@ -8,6 +8,7 @@ import {
   Children,
   isValidElement,
   type ReactNode,
+  startTransition,
   useCallback,
   useEffect,
   useMemo,
@@ -293,6 +294,7 @@ function LiveLineChartInner({
 
       const domainEndMsNext = next.now + leadingMs;
       const cursorX = cursorXRef.current;
+      let nextTooltip: TooltipData | null = null;
       if (cursorX !== null && innerWidth > 0 && innerHeight > 0) {
         const xScaleNext = scaleTime({
           domain: [
@@ -320,20 +322,19 @@ function LiveLineChartInner({
         const val = interpolateAtTime(visible, timeSec);
         const key = dataKeyRef.current;
         if (val !== null) {
-          setTooltipData({
+          nextTooltip = {
             point: { date: new Date(timeMs), [key]: val },
             index: 0,
             x: cursorX,
             yPositions: { [key]: yScaleNext(val) ?? 0 },
-          });
-        } else {
-          setTooltipData(null);
+          };
         }
-      } else {
-        setTooltipData(null);
       }
 
-      setFrame(next);
+      startTransition(() => {
+        setTooltipData(nextTooltip);
+        setFrame(next);
+      });
       raf = requestAnimationFrame(tick);
     };
     raf = requestAnimationFrame(tick);

--- a/packages/ui/src/charts/pie-center.tsx
+++ b/packages/ui/src/charts/pie-center.tsx
@@ -73,7 +73,7 @@ export function PieCenter({
 }: PieCenterProps) {
   const { data, hoveredIndex, totalValue, innerRadius } = usePie();
 
-  const hoveredData = hoveredIndex !== null ? data[hoveredIndex] : null;
+  const hoveredData = hoveredIndex === null ? null : data[hoveredIndex];
   const displayValue = hoveredData ? hoveredData.value : totalValue;
   const displayLabel = hoveredData ? hoveredData.label : defaultLabel;
   const isHovered = hoveredIndex !== null;

--- a/packages/ui/src/charts/ring-center.tsx
+++ b/packages/ui/src/charts/ring-center.tsx
@@ -73,7 +73,7 @@ export function RingCenter({
 }: RingCenterProps) {
   const { data, hoveredIndex, totalValue, baseInnerRadius } = useRing();
 
-  const hoveredData = hoveredIndex !== null ? data[hoveredIndex] : null;
+  const hoveredData = hoveredIndex === null ? null : data[hoveredIndex];
   const displayValue = hoveredData ? hoveredData.value : totalValue;
   const displayLabel = hoveredData ? hoveredData.label : defaultLabel;
   const isHovered = hoveredIndex !== null;

--- a/packages/ui/src/charts/tooltip/tooltip-content.tsx
+++ b/packages/ui/src/charts/tooltip/tooltip-content.tsx
@@ -73,7 +73,7 @@ export function TooltipContent({ title, rows, children }: TooltipContentProps) {
     <motion.div
       // Only animate if we have a committed height, otherwise use auto
       animate={
-        committedHeight !== null ? { height: committedHeight } : undefined
+        committedHeight === null ? undefined : { height: committedHeight }
       }
       className="overflow-hidden"
       // Skip initial animation


### PR DESCRIPTION
**Problem**
Clicking navigation links on `/charts/live-line-chart` in the `ChartNav` does nothing. The page has 5 LiveLineChart instances running requestAnimationFrame loops that call setState 60 times per second each (300 total updates/sec). Next.js uses React transitions for navigation, and synchronous state updates interrupt transitions. The rAF loops were starving the navigation transition so it never committed.

**Solution**
Wrapped the setFrame() and setTooltipData() calls in startTransition(). This marks them as low-priority updates so they don't block navigation. The charts still animate smoothly since React processes these as fast as possible, they just yield to higher-priority work like route changes.

**Changes**
Added startTransition import to `live-line-chart.tsx`
Wrapped state updates in the rAF tick function with startTransition()

**Testing**
1. Just go to `/charts/live-line-chart`
2. Click any chart type in the navigation (Line Chart, Radar, etc)
3. Navigation should now work

Edit:
This also fixes the same issue in `/docs/components`