### PR TITLE
fix: unify top nav link order across layouts

### DIFF
--- a/apps/web/app/(home)/layout.tsx
+++ b/apps/web/app/(home)/layout.tsx
@@ -1,6 +1,7 @@
 import type { ReactNode } from "react";
 import { SiteFooter } from "@/components/docs/site-footer";
 import { SiteHeader } from "@/components/docs/site-header";
+import { siteNavLinks } from "@/lib/site-nav-links";
 
 export default function Layout({ children }: { children: ReactNode }) {
   return (
@@ -8,32 +9,7 @@ export default function Layout({ children }: { children: ReactNode }) {
       <SiteHeader
         discordUrl="https://discord.com/invite/9yyK8FwPcU"
         githubUrl="https://github.com/bklit/bklit-ui"
-        links={[
-          {
-            text: "Introduction",
-            url: "/docs",
-          },
-          {
-            text: "Installation",
-            url: "/docs/installation",
-          },
-          {
-            text: "Components",
-            url: "/docs/components",
-          },
-          {
-            text: "Theming",
-            url: "/docs/theming",
-          },
-          {
-            text: "Charts",
-            url: "/charts",
-          },
-          {
-            text: "Studio",
-            url: "/studio",
-          },
-        ]}
+        links={[...siteNavLinks]}
       />
       <div className="flex-1 pt-14">{children}</div>
       <SiteFooter />

--- a/apps/web/app/docs/layout.tsx
+++ b/apps/web/app/docs/layout.tsx
@@ -1,6 +1,7 @@
 import { NextProvider } from "fumadocs-core/framework/next";
 import type { ReactNode } from "react";
 import { DocsLayout } from "@/components/docs/docs-layout";
+import { siteNavLinks } from "@/lib/site-nav-links";
 import { source } from "@/lib/source";
 
 export default function Layout({ children }: { children: ReactNode }) {
@@ -8,32 +9,7 @@ export default function Layout({ children }: { children: ReactNode }) {
     <NextProvider>
       <DocsLayout
         nav={{
-          links: [
-            {
-              text: "Introduction",
-              url: "/docs",
-            },
-            {
-              text: "Installation",
-              url: "/docs/installation",
-            },
-            {
-              text: "Theming",
-              url: "/docs/theming",
-            },
-            {
-              text: "Components",
-              url: "/docs/components",
-            },
-            {
-              text: "Charts",
-              url: "/charts",
-            },
-            {
-              text: "Studio",
-              url: "/studio",
-            },
-          ],
+          links: [...siteNavLinks],
           githubUrl: "https://github.com/bklit/bklit-ui",
           discordUrl: "https://discord.com/invite/9yyK8FwPcU",
         }}

--- a/apps/web/app/studio/layout.tsx
+++ b/apps/web/app/studio/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import { NuqsAdapter } from "nuqs/adapters/next/app";
 import type { ReactNode } from "react";
 import { SiteHeader } from "@/components/docs/site-header";
+import { siteNavLinks } from "@/lib/site-nav-links";
 
 export const metadata: Metadata = {
   title: "Studio",
@@ -9,22 +10,13 @@ export const metadata: Metadata = {
     "Interactive chart studio — explore every Bklit chart and tune props in real time.",
 };
 
-const studioNavLinks = [
-  { text: "Introduction", url: "/docs" },
-  { text: "Installation", url: "/docs/installation" },
-  { text: "Components", url: "/docs/components" },
-  { text: "Theming", url: "/docs/theming" },
-  { text: "Charts", url: "/charts" },
-  { text: "Studio", url: "/studio" },
-];
-
 export default function StudioLayout({ children }: { children: ReactNode }) {
   return (
     <div className="flex h-dvh flex-col overflow-hidden">
       <SiteHeader
         discordUrl="https://discord.com/invite/9yyK8FwPcU"
         githubUrl="https://github.com/bklit/bklit-ui"
-        links={studioNavLinks}
+        links={[...siteNavLinks]}
       />
       <main className="flex min-h-0 flex-1 flex-col overflow-hidden pt-14">
         <NuqsAdapter>{children}</NuqsAdapter>

--- a/apps/web/lib/site-nav-links.ts
+++ b/apps/web/lib/site-nav-links.ts
@@ -1,0 +1,8 @@
+export const siteNavLinks = [
+  { text: "Introduction", url: "/docs" },
+  { text: "Installation", url: "/docs/installation" },
+  { text: "Components", url: "/docs/components" },
+  { text: "Theming", url: "/docs/theming" },
+  { text: "Charts", url: "/charts" },
+  { text: "Studio", url: "/studio" },
+] as const;


### PR DESCRIPTION
## Summary

- Fixes [#62](https://github.com/bklit/bklit-ui/issues/62): visiting `/charts` no longer reorders the top nav relative to `/docs`.
- The docs layout had **Theming** before **Components**; charts (`(home)`) and studio had the opposite order.
- Introduces shared `siteNavLinks` in `apps/web/lib/site-nav-links.ts` and uses it in all three `SiteHeader` layouts (docs, home/charts, studio).

## Test plan

- [ ] Open `/docs/components` — nav order: Introduction → Installation → Components → Theming → Charts → Studio
- [ ] Open `/charts/area-chart` — same nav order as docs
- [ ] Open `/studio` — same nav order
- [ ] Mobile menu shows the same main link order on docs and charts routes


Made with [Cursor](https://cursor.com)