### PR TITLE
Studio recording fixes and export options

### DIFF
--- a/apps/web/components/mode-toggle.tsx
+++ b/apps/web/components/mode-toggle.tsx
@@ -2,8 +2,21 @@
 
 import { MoonIcon, SunIcon } from "lucide-react";
 import { useTheme } from "next-themes";
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { Button } from "./ui/button";
+
+function isTypingTarget(target: EventTarget | null): boolean {
+  if (!(target instanceof HTMLElement)) {
+    return false;
+  }
+  const tag = target.tagName;
+  return (
+    target.isContentEditable ||
+    tag === "INPUT" ||
+    tag === "TEXTAREA" ||
+    tag === "SELECT"
+  );
+}
 
 export function ModeToggle() {
   const { setTheme, resolvedTheme } = useTheme();
@@ -12,6 +25,33 @@ export function ModeToggle() {
   useEffect(() => {
     setMounted(true);
   }, []);
+
+  const toggleTheme = useCallback(() => {
+    setTheme(resolvedTheme === "dark" ? "light" : "dark");
+  }, [resolvedTheme, setTheme]);
+
+  useEffect(() => {
+    if (!mounted) {
+      return;
+    }
+
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key !== "d" && event.key !== "D") {
+        return;
+      }
+      if (event.metaKey || event.ctrlKey || event.altKey) {
+        return;
+      }
+      if (isTypingTarget(event.target)) {
+        return;
+      }
+      event.preventDefault();
+      toggleTheme();
+    };
+
+    window.addEventListener("keydown", onKeyDown);
+    return () => window.removeEventListener("keydown", onKeyDown);
+  }, [mounted, toggleTheme]);
 
   if (!mounted) {
     return (
@@ -25,9 +65,11 @@ export function ModeToggle() {
 
   return (
     <Button
+      aria-keyshortcuts="D"
       aria-label={`Switch to ${isDark ? "light" : "dark"} mode`}
-      onClick={() => setTheme(isDark ? "light" : "dark")}
+      onClick={toggleTheme}
       size="default"
+      title={`Switch to ${isDark ? "light" : "dark"} mode (D)`}
       variant="ghost"
     >
       {isDark ? <SunIcon /> : <MoonIcon />}

--- a/apps/web/components/studio/charts/funnel-studio-preview.tsx
+++ b/apps/web/components/studio/charts/funnel-studio-preview.tsx
@@ -21,7 +21,9 @@ export function FunnelStudioPreview({
   const widthOverHeight =
     state.funnelOrientation === "horizontal" ? 2.2 : 1 / 1.8;
   const { width, height } = studioFitAspectSize(ctx.frame, widthOverHeight);
-  const motionEnter = getStudioMotionEnterProps(state);
+  const motionEnter = getStudioMotionEnterProps(state, {
+    linear: ctx.isRecording,
+  });
   return (
     <div className="shrink-0" style={{ width, height }}>
       <FunnelChart

--- a/apps/web/components/studio/charts/gauge-studio-preview.tsx
+++ b/apps/web/components/studio/charts/gauge-studio-preview.tsx
@@ -24,7 +24,9 @@ export function GaugeStudioPreview({
   ctx: StudioRenderContext;
 }) {
   const { width, height } = studioFitAspectSize(ctx.frame, 21 / 16);
-  const motionEnter = getStudioMotionEnterProps(state);
+  const motionEnter = getStudioMotionEnterProps(state, {
+    linear: ctx.isRecording,
+  });
 
   return (
     <Gauge

--- a/apps/web/components/studio/charts/pie-studio-preview.tsx
+++ b/apps/web/components/studio/charts/pie-studio-preview.tsx
@@ -25,7 +25,9 @@ export function PieStudioPreview({
   ctx: StudioRenderContext;
 }) {
   const useLines = state.pieFillMode === "lines";
-  const motionEnter = getStudioMotionEnterProps(state);
+  const motionEnter = getStudioMotionEnterProps(state, {
+    linear: ctx.isRecording,
+  });
 
   return (
     <StudioRadialCenter frame={ctx.frame}>

--- a/apps/web/components/studio/charts/ring-studio-preview.tsx
+++ b/apps/web/components/studio/charts/ring-studio-preview.tsx
@@ -20,7 +20,9 @@ export function RingStudioPreview({
   state: StudioUrlState;
   ctx: StudioRenderContext;
 }) {
-  const motionEnter = getStudioMotionEnterProps(state);
+  const motionEnter = getStudioMotionEnterProps(state, {
+    linear: ctx.isRecording,
+  });
 
   return (
     <StudioRadialCenter frame={ctx.frame}>

--- a/apps/web/components/studio/studio-chart-frame.tsx
+++ b/apps/web/components/studio/studio-chart-frame.tsx
@@ -263,41 +263,37 @@ export const StudioChartFrame = forwardRef<
       )}
       ref={wrapRef}
     >
-      {isRecording ? (
-        <motion.div
-          animate={{ width: size.width, height: size.height }}
-          className="relative overflow-hidden bg-card"
-          layout
-          ref={captureRef}
-          style={style}
-          transition={{ duration: 0 }}
-        >
-          {frameContent}
-        </motion.div>
-      ) : (
-        <motion.div
-          animate={{ width: size.width, height: size.height }}
-          className={cn(
-            "relative overflow-hidden rounded-lg border-2 bg-card shadow-sm transition-[border-color,border-style]",
-            isDragging
-              ? "border-foreground/50 border-dotted"
-              : "border-border hover:border-foreground/35"
-          )}
-          layout
-          ref={captureRef}
-          style={style}
-          transition={
-            isDragging || reducedMotion
-              ? { duration: 0 }
-              : { ...frameSpring, layout: frameSpring }
-          }
-        >
-          {frameContent}
-          <ResizeHandle edge="right" onPointerDown={startDrag("right")} />
-          <ResizeHandle edge="bottom" onPointerDown={startDrag("bottom")} />
-          <ResizeHandle edge="corner" onPointerDown={startDrag("corner")} />
-        </motion.div>
-      )}
+      <motion.div
+        animate={{ width: size.width, height: size.height }}
+        className={cn(
+          "relative overflow-hidden border-2 bg-card",
+          isRecording
+            ? "border-transparent shadow-none"
+            : cn(
+                "rounded-lg shadow-sm transition-[border-color,border-style]",
+                isDragging
+                  ? "border-foreground/50 border-dotted"
+                  : "border-border hover:border-foreground/35"
+              )
+        )}
+        layout={!isRecording}
+        ref={captureRef}
+        style={style}
+        transition={
+          isDragging || reducedMotion || isRecording
+            ? { duration: 0 }
+            : { ...frameSpring, layout: frameSpring }
+        }
+      >
+        {frameContent}
+        {isRecording ? null : (
+          <>
+            <ResizeHandle edge="right" onPointerDown={startDrag("right")} />
+            <ResizeHandle edge="bottom" onPointerDown={startDrag("bottom")} />
+            <ResizeHandle edge="corner" onPointerDown={startDrag("corner")} />
+          </>
+        )}
+      </motion.div>
       <AnimatePresence initial={false}>
         {isDragging ? (
           <>

--- a/apps/web/components/studio/studio-preview.tsx
+++ b/apps/web/components/studio/studio-preview.tsx
@@ -45,6 +45,7 @@ export function StudioPreview() {
   const frameSizeBeforeRecording = useRef<{ w: number; h: number } | null>(
     null
   );
+  const [capturePrepared, setCapturePrepared] = useState(false);
   const reducedMotion = useReducedMotion();
   const {
     phase,
@@ -97,6 +98,8 @@ export function StudioPreview() {
         aspect
       );
 
+      setCapturePrepared(true);
+
       if (aspect === "16:9") {
         frameSizeBeforeRecording.current = saved;
         setFrameSize(dimensions.frameWidth, dimensions.frameHeight);
@@ -109,22 +112,27 @@ export function StudioPreview() {
         frameSizeBeforeRecording.current = null;
       }
 
-      await startRecording({
-        element,
-        width: dimensions.captureWidth,
-        height: dimensions.captureHeight,
-        state: displayState,
-        chart: state.chart,
-        replay,
-        interactionMs,
-        onFinished: () => {
-          const previous = frameSizeBeforeRecording.current;
-          if (previous) {
-            setFrameSize(previous.w, previous.h);
-            frameSizeBeforeRecording.current = null;
-          }
-        },
-      });
+      try {
+        await startRecording({
+          element,
+          width: dimensions.captureWidth,
+          height: dimensions.captureHeight,
+          state: displayState,
+          chart: state.chart,
+          replay,
+          interactionMs,
+          onFinished: () => {
+            const previous = frameSizeBeforeRecording.current;
+            if (previous) {
+              setFrameSize(previous.w, previous.h);
+              frameSizeBeforeRecording.current = null;
+            }
+            setCapturePrepared(false);
+          },
+        });
+      } finally {
+        setCapturePrepared(false);
+      }
     },
     [
       displayState,
@@ -138,7 +146,8 @@ export function StudioPreview() {
   );
 
   const recordingBlocked = reducedMotion === true;
-  const controlsDisabled = isRecording;
+  const controlsDisabled = isRecording || capturePrepared;
+  const showCaptureLayout = isRecording || capturePrepared;
   const showRecordingChrome = isRecording && timeline;
 
   return (
@@ -185,11 +194,11 @@ export function StudioPreview() {
       <div
         className={cn(
           "studio-preview-canvas relative flex min-h-0 flex-1 flex-col overflow-auto p-6 pt-16",
-          isRecording ? "gap-4" : "items-center justify-center gap-5"
+          showCaptureLayout ? "gap-4" : "items-center justify-center gap-5"
         )}
         ref={canvasRef}
       >
-        {isRecording ? (
+        {showCaptureLayout ? (
           <div
             aria-hidden
             className="pointer-events-none absolute inset-0 z-1 bg-zinc-950/88"
@@ -199,7 +208,7 @@ export function StudioPreview() {
         <div
           className={cn(
             "relative z-2 flex min-h-0 w-full flex-1 flex-col",
-            isRecording
+            showCaptureLayout
               ? "gap-4"
               : "max-w-3xl items-center justify-center gap-5"
           )}
@@ -209,20 +218,20 @@ export function StudioPreview() {
             ref={chartAreaRef}
           >
             <StudioRecordingMask
-              active={isRecording}
+              active={showCaptureLayout}
               containerRef={chartAreaRef}
               targetRef={recordCaptureRef}
             />
 
             <div
               className={cn(
-                isRecording
+                showCaptureLayout
                   ? "studio-recording-capture relative shrink-0"
                   : "inline-flex"
               )}
               ref={recordCaptureRef}
               style={
-                isRecording
+                showCaptureLayout
                   ? {
                       width:
                         state.frameW + STUDIO_RECORDING_CAPTURE_INSET_PX * 2,
@@ -233,13 +242,10 @@ export function StudioPreview() {
               }
             >
               <div
-                className={cn(
-                  isRecording && "absolute",
-                  !isRecording && "contents"
-                )}
                 style={
-                  isRecording
+                  showCaptureLayout
                     ? {
+                        position: "absolute",
                         top: STUDIO_RECORDING_CAPTURE_INSET_PX,
                         left: STUDIO_RECORDING_CAPTURE_INSET_PX,
                       }

--- a/apps/web/components/studio/studio-preview.tsx
+++ b/apps/web/components/studio/studio-preview.tsx
@@ -23,6 +23,7 @@ import {
   getRecordingCaptureDimensions,
   STUDIO_RECORDING_CAPTURE_INSET_PX,
   type StudioRecordingAspect,
+  type StudioRecordingFormat,
   type StudioRecordingInteractionMs,
 } from "@/lib/studio/studio-recording";
 import { cn } from "@/lib/utils";
@@ -84,7 +85,8 @@ export function StudioPreview() {
   const handleStartRecording = useCallback(
     async (
       interactionMs: StudioRecordingInteractionMs,
-      aspect: StudioRecordingAspect
+      aspect: StudioRecordingAspect,
+      format: StudioRecordingFormat
     ) => {
       const element = recordCaptureRef.current;
       if (!element) {
@@ -121,6 +123,7 @@ export function StudioPreview() {
           chart: state.chart,
           replay,
           interactionMs,
+          format,
           onFinished: () => {
             const previous = frameSizeBeforeRecording.current;
             if (previous) {
@@ -266,6 +269,7 @@ export function StudioPreview() {
                       {(frame) => {
                         const renderCtx: StudioRenderContext = {
                           animationKey,
+                          isRecording: isRecording || capturePrepared,
                           motionRemountKey,
                           committedState: state,
                           motionCurveDragging,

--- a/apps/web/components/studio/studio-record-popover.tsx
+++ b/apps/web/components/studio/studio-record-popover.tsx
@@ -3,15 +3,19 @@
 import { VideoCameraIcon } from "@heroicons/react/24/outline";
 import { useState } from "react";
 import { Button } from "@/components/ui/button";
+import { Label } from "@/components/ui/label";
 import {
   Popover,
   PopoverContent,
   PopoverTrigger,
 } from "@/components/ui/popover";
+import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
 import {
   STUDIO_RECORDING_ASPECT_OPTIONS,
+  STUDIO_RECORDING_FORMAT_OPTIONS,
   STUDIO_RECORDING_INTERACTION_OPTIONS,
   type StudioRecordingAspect,
+  type StudioRecordingFormat,
   type StudioRecordingInteractionMs,
 } from "@/lib/studio/studio-recording";
 import { cn } from "@/lib/utils";
@@ -26,7 +30,8 @@ export function StudioRecordPopover({
   isRecording: boolean;
   onStart: (
     interactionMs: StudioRecordingInteractionMs,
-    aspect: StudioRecordingAspect
+    aspect: StudioRecordingAspect,
+    format: StudioRecordingFormat
   ) => void;
   onStop: () => void;
 }) {
@@ -34,6 +39,7 @@ export function StudioRecordPopover({
   const [interactionMs, setInteractionMs] =
     useState<StudioRecordingInteractionMs>(5000);
   const [aspect, setAspect] = useState<StudioRecordingAspect>("16:9");
+  const [format, setFormat] = useState<StudioRecordingFormat>("webm");
 
   if (isRecording) {
     return (
@@ -131,11 +137,37 @@ export function StudioRecordPopover({
           </div>
         </div>
 
+        <div className="mt-4">
+          <p className="mb-2 font-medium text-[11px] text-muted-foreground uppercase tracking-wide">
+            Export format
+          </p>
+          <RadioGroup
+            className="flex flex-row items-center gap-4"
+            onValueChange={(value) => setFormat(value as StudioRecordingFormat)}
+            value={format}
+          >
+            {STUDIO_RECORDING_FORMAT_OPTIONS.map((opt) => (
+              <div className="flex items-center gap-2" key={opt.value}>
+                <RadioGroupItem
+                  id={`studio-format-${opt.value}`}
+                  value={opt.value}
+                />
+                <Label
+                  className="cursor-pointer font-normal text-xs"
+                  htmlFor={`studio-format-${opt.value}`}
+                >
+                  {opt.label}
+                </Label>
+              </div>
+            ))}
+          </RadioGroup>
+        </div>
+
         <Button
           className="mt-4 w-full"
           onClick={() => {
             setOpen(false);
-            onStart(interactionMs, aspect);
+            onStart(interactionMs, aspect, format);
           }}
           type="button"
         >

--- a/apps/web/components/studio/studio-recording-timeline.tsx
+++ b/apps/web/components/studio/studio-recording-timeline.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { PauseIcon, PlayIcon } from "@heroicons/react/24/outline";
-import { motion, useReducedMotion } from "motion/react";
+import { motion } from "motion/react";
 import { useMemo } from "react";
 import { Button } from "@/components/ui/button";
 import {
@@ -112,7 +112,6 @@ export function StudioRecordingTimeline({
   onPause?: () => void;
   onResume?: () => void;
 }) {
-  const reducedMotion = useReducedMotion();
   const progress = Math.min(1, elapsedMs / timeline.totalMs);
   const markers = useMemo(
     () => getStudioRecordingMarkers(timeline),
@@ -228,15 +227,9 @@ export function StudioRecordingTimeline({
         </motion.div>
 
         <motion.div className="relative space-y-1.5">
-          <motion.div
-            animate={{ left: `${progress * 100}%` }}
+          <div
             className="pointer-events-none absolute top-0 bottom-0 z-20 w-px bg-foreground/85"
-            initial={false}
-            transition={
-              reducedMotion
-                ? { duration: 0 }
-                : { type: "spring", stiffness: 140, damping: 22 }
-            }
+            style={{ left: `${progress * 100}%` }}
           />
 
           {tracks.map((track) => (
@@ -250,12 +243,12 @@ export function StudioRecordingTimeline({
           ))}
         </motion.div>
 
-        <motion.div className="mt-3 h-1 overflow-hidden rounded-full bg-muted/30">
-          <motion.div
+        <div className="mt-3 h-1 overflow-hidden rounded-full bg-muted/30">
+          <div
             className="h-full bg-foreground/80"
             style={{ width: `${progress * 100}%` }}
           />
-        </motion.div>
+        </div>
       </motion.div>
     </motion.div>
   );

--- a/apps/web/components/studio/use-studio-recording.ts
+++ b/apps/web/components/studio/use-studio-recording.ts
@@ -93,9 +93,9 @@ export function useStudioRecording() {
       setElapsedMs(0);
       isPausedRef.current = false;
       setIsPaused(false);
-      setPhase("capturing");
 
       const useStream = canRecordChartStream();
+      const onCaptureReady = () => setPhase("capturing");
 
       try {
         if (useStream) {
@@ -108,6 +108,7 @@ export function useStudioRecording() {
             signal: controller.signal,
             onProgress: setProgress,
             isPaused: () => isPausedRef.current,
+            onCaptureReady,
           });
         } else {
           const frames = await captureChartFrames({
@@ -119,6 +120,7 @@ export function useStudioRecording() {
             onTimelineTick: setElapsedMs,
             signal: controller.signal,
             isPaused: () => isPausedRef.current,
+            onCaptureReady,
             onProgress: (captureProgress) => {
               setProgress(captureProgress * 0.7);
             },

--- a/apps/web/components/studio/use-studio-recording.ts
+++ b/apps/web/components/studio/use-studio-recording.ts
@@ -11,6 +11,7 @@ import type { StudioUrlState } from "@/lib/studio/studio-parsers";
 import {
   getStudioRecordingOutputSize,
   getStudioRecordingTimeline,
+  type StudioRecordingFormat,
   type StudioRecordingInteractionMs,
   type StudioRecordingTimeline,
 } from "@/lib/studio/studio-recording";
@@ -26,6 +27,7 @@ export interface StartStudioRecordingParams {
   chart: ChartSlug;
   replay: () => void;
   interactionMs?: StudioRecordingInteractionMs;
+  format?: StudioRecordingFormat;
   onFinished?: () => void;
 }
 
@@ -74,6 +76,7 @@ export function useStudioRecording() {
         chart,
         replay,
         interactionMs = 0,
+        format = "webm",
         onFinished,
       } = params;
 
@@ -102,6 +105,7 @@ export function useStudioRecording() {
           await recordChartStream({
             element,
             timeline: recordingTimeline,
+            format,
             chartSlug: chart,
             onReplay: replay,
             onTimelineTick: setElapsedMs,
@@ -109,6 +113,7 @@ export function useStudioRecording() {
             onProgress: setProgress,
             isPaused: () => isPausedRef.current,
             onCaptureReady,
+            onEncodingStart: () => setPhase("encoding"),
           });
         } else {
           const frames = await captureChartFrames({
@@ -138,6 +143,7 @@ export function useStudioRecording() {
           await encodeStudioRecording({
             frames,
             timeline: recordingTimeline,
+            format,
             width: outputSize.width,
             height: outputSize.height,
             chartSlug: chart,

--- a/apps/web/components/ui/radio-group.tsx
+++ b/apps/web/components/ui/radio-group.tsx
@@ -1,0 +1,44 @@
+"use client";
+
+import { RadioGroup as RadioGroupPrimitive } from "radix-ui";
+import type * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+function RadioGroup({
+  className,
+  ...props
+}: React.ComponentProps<typeof RadioGroupPrimitive.Root>) {
+  return (
+    <RadioGroupPrimitive.Root
+      className={cn("grid w-full gap-3", className)}
+      data-slot="radio-group"
+      {...props}
+    />
+  );
+}
+
+function RadioGroupItem({
+  className,
+  ...props
+}: React.ComponentProps<typeof RadioGroupPrimitive.Item>) {
+  return (
+    <RadioGroupPrimitive.Item
+      className={cn(
+        "group/radio-group-item peer relative flex aspect-square size-4 shrink-0 rounded-full border border-input outline-none after:absolute after:-inset-x-3 after:-inset-y-2 focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 aria-invalid:aria-checked:border-primary data-checked:border-primary data-checked:bg-primary data-checked:text-primary-foreground dark:bg-input/30 dark:data-checked:bg-primary dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40",
+        className
+      )}
+      data-slot="radio-group-item"
+      {...props}
+    >
+      <RadioGroupPrimitive.Indicator
+        className="flex size-4 items-center justify-center"
+        data-slot="radio-group-indicator"
+      >
+        <span className="absolute top-1/2 left-1/2 size-2 -translate-x-1/2 -translate-y-1/2 rounded-full bg-primary-foreground" />
+      </RadioGroupPrimitive.Indicator>
+    </RadioGroupPrimitive.Item>
+  );
+}
+
+export { RadioGroup, RadioGroupItem };

--- a/apps/web/lib/studio/capture-chart-frames.ts
+++ b/apps/web/lib/studio/capture-chart-frames.ts
@@ -62,6 +62,7 @@ export interface CaptureChartFramesOptions {
   signal?: AbortSignal;
   onProgress?: (progress: number) => void;
   isPaused?: () => boolean;
+  onCaptureReady?: () => void;
 }
 
 /**
@@ -82,6 +83,7 @@ export async function captureChartFrames(
     signal,
     onProgress,
     isPaused = () => false,
+    onCaptureReady,
   } = options;
 
   if (signal?.aborted) {
@@ -94,6 +96,7 @@ export async function captureChartFrames(
   const pauseState = createRecordingPauseState();
   let capturing = false;
   let replayFired = false;
+  onCaptureReady?.();
 
   while (true) {
     if (signal?.aborted) {

--- a/apps/web/lib/studio/capture-chart-frames.ts
+++ b/apps/web/lib/studio/capture-chart-frames.ts
@@ -8,6 +8,7 @@ import {
   createRecordingPauseState,
   getRecordingElapsedMs,
 } from "./studio-recording-clock";
+import { readElementBackgroundColor } from "./studio-recording-color";
 
 function sleep(ms: number, signal?: AbortSignal): Promise<void> {
   return new Promise((resolve, reject) => {
@@ -48,6 +49,7 @@ async function captureElementFrame(
     width,
     height,
     scale: getStudioRecordingCaptureScale(),
+    backgroundColor: readElementBackgroundColor(element),
   });
   return canvasToPngBlob(canvas);
 }

--- a/apps/web/lib/studio/chart-animation.ts
+++ b/apps/web/lib/studio/chart-animation.ts
@@ -48,16 +48,17 @@ export function studioEnterStaggerScale(state: StudioUrlState): number {
 
 export function getStudioCssRevealProps(
   state: StudioUrlState,
-  options?: { revealFrom?: StudioUrlState }
+  options?: { revealFrom?: StudioUrlState; linear?: boolean }
 ) {
   const motion = motionSliceFromState(state);
   const revealMotion = options?.revealFrom
     ? motionSliceFromState(options.revealFrom)
     : motion;
+  const linear = options?.linear ?? false;
   return {
     animationDuration: studioAnimationDurationMs(state),
-    animationEasing: studioAnimationEasingCss(motion),
-    enterTransition: studioMotionToTransition(motion),
+    animationEasing: linear ? "linear" : studioAnimationEasingCss(motion),
+    enterTransition: studioMotionToTransition(motion, { linear }),
     revealSignature: motionSignature(revealMotion),
   };
 }
@@ -65,12 +66,15 @@ export function getStudioCssRevealProps(
 /** CSS reveal props for studio preview (live easing, stable reveal while dragging handles). */
 export function getStudioCssRevealPropsForPreview(
   displayState: StudioUrlState,
-  ctx: Pick<StudioRenderContext, "motionCurveDragging" | "committedState">
+  ctx: Pick<
+    StudioRenderContext,
+    "motionCurveDragging" | "committedState" | "isRecording"
+  >
 ) {
-  return getStudioCssRevealProps(
-    displayState,
-    ctx.motionCurveDragging ? { revealFrom: ctx.committedState } : undefined
-  );
+  return getStudioCssRevealProps(displayState, {
+    revealFrom: ctx.motionCurveDragging ? ctx.committedState : undefined,
+    linear: ctx.isRecording,
+  });
 }
 
 /** Chart remount key: manual replay + debounced motion signature. */
@@ -79,12 +83,17 @@ export function studioPreviewChartKey(ctx: StudioRenderContext): string {
 }
 
 /** Motion enter props for charts with spring/tween slice enter (gauge, pie, ring, funnel). */
-export function getStudioMotionEnterProps(state: StudioUrlState): {
+export function getStudioMotionEnterProps(
+  state: StudioUrlState,
+  options?: { linear?: boolean }
+): {
   enterTransition: Transition;
   enterStaggerScale: number;
 } {
   return {
-    enterTransition: studioMotionToTransition(motionSliceFromState(state)),
+    enterTransition: studioMotionToTransition(motionSliceFromState(state), {
+      linear: options?.linear,
+    }),
     enterStaggerScale: studioEnterStaggerScale(state),
   };
 }

--- a/apps/web/lib/studio/encode-studio-recording.ts
+++ b/apps/web/lib/studio/encode-studio-recording.ts
@@ -6,6 +6,7 @@ import {
 } from "@/components/studio/studio-capture-composition";
 import {
   framesForNativeTimeline,
+  type StudioRecordingFormat,
   type StudioRecordingTimeline,
   type TimestampedFrame,
 } from "./studio-recording";
@@ -13,6 +14,7 @@ import {
 export interface EncodeStudioRecordingOptions {
   frames: TimestampedFrame[];
   timeline: StudioRecordingTimeline;
+  format: StudioRecordingFormat;
   width: number;
   height: number;
   chartSlug: string;
@@ -33,8 +35,16 @@ function downloadBlob(blob: Blob, filename: string) {
 export async function encodeStudioRecording(
   options: EncodeStudioRecordingOptions
 ): Promise<void> {
-  const { frames, timeline, width, height, chartSlug, onProgress, signal } =
-    options;
+  const {
+    frames,
+    timeline,
+    format,
+    width,
+    height,
+    chartSlug,
+    onProgress,
+    signal,
+  } = options;
 
   if (frames.length === 0) {
     throw new Error("No frames captured");
@@ -70,9 +80,12 @@ export async function encodeStudioRecording(
         defaultProps: inputProps as unknown as Record<string, unknown>,
       },
       inputProps: inputProps as unknown as Record<string, unknown>,
+      container: format === "webm" ? "webm" : "mp4",
+      videoCodec: format === "webm" ? "vp9" : "h264",
       muted: true,
       videoBitrate: "very-high",
-      hardwareAcceleration: "prefer-hardware",
+      hardwareAcceleration:
+        format === "webm" ? "prefer-hardware" : "prefer-software",
       keyframeIntervalInSeconds: 2,
       signal,
       onProgress: ({ progress }) => {
@@ -82,7 +95,8 @@ export async function encodeStudioRecording(
 
     const blob = await getBlob();
     const timestamp = new Date().toISOString().replace(/[:.]/g, "-");
-    downloadBlob(blob, `bklit-studio-${chartSlug}-${timestamp}.mp4`);
+    const extension = format === "webm" ? "webm" : "mp4";
+    downloadBlob(blob, `bklit-studio-${chartSlug}-${timestamp}.${extension}`);
   } finally {
     for (const url of frameUrls) {
       URL.revokeObjectURL(url);

--- a/apps/web/lib/studio/motion-config.ts
+++ b/apps/web/lib/studio/motion-config.ts
@@ -193,8 +193,19 @@ export function motionSignature(state: MotionStateSlice): string {
   return `e-${duration}-${state.motionEase}-${bezier}`;
 }
 
-export function studioMotionToTransition(state: MotionStateSlice): Transition {
+export function studioMotionToTransition(
+  state: MotionStateSlice,
+  options?: { linear?: boolean }
+): Transition {
   const duration = clampMotionDuration(state.motionDuration);
+
+  if (options?.linear) {
+    return {
+      type: "tween",
+      duration,
+      ease: "linear",
+    };
+  }
 
   if (state.motionType === "ease") {
     return {

--- a/apps/web/lib/studio/record-chart-stream.ts
+++ b/apps/web/lib/studio/record-chart-stream.ts
@@ -61,6 +61,8 @@ export interface RecordChartStreamOptions {
   signal?: AbortSignal;
   onProgress?: (progress: number) => void;
   isPaused?: () => boolean;
+  /** Called once the display stream is cropped and capture is about to begin. */
+  onCaptureReady?: () => void;
 }
 
 /**
@@ -80,6 +82,7 @@ export async function recordChartStream(
     signal,
     onProgress,
     isPaused = () => false,
+    onCaptureReady,
   } = options;
 
   if (!canRecordChartStream()) {
@@ -118,6 +121,7 @@ export async function recordChartStream(
   }
 
   await croppable.cropTo(cropTarget);
+  onCaptureReady?.();
 
   const recorder = new MediaRecorder(stream, {
     mimeType,

--- a/apps/web/lib/studio/record-chart-stream.ts
+++ b/apps/web/lib/studio/record-chart-stream.ts
@@ -1,8 +1,12 @@
-import type { StudioRecordingTimeline } from "./studio-recording";
+import type {
+  StudioRecordingFormat,
+  StudioRecordingTimeline,
+} from "./studio-recording";
 import {
   createRecordingPauseState,
   getRecordingElapsedMs,
 } from "./studio-recording-clock";
+import { transcodeRecordingToMp4 } from "./transcode-recording-to-mp4";
 
 type CropTargetHandle = object;
 
@@ -28,12 +32,12 @@ export function canRecordChartStream(): boolean {
   );
 }
 
+/** WebM only — Chrome MP4 MediaRecorder freezes tab/region capture; MP4 comes from transcode. */
 function pickRecorderMimeType(): string {
   const candidates = [
     "video/webm;codecs=vp9",
     "video/webm;codecs=vp8",
     "video/webm",
-    "video/mp4",
   ];
   return candidates.find((type) => MediaRecorder.isTypeSupported(type)) ?? "";
 }
@@ -55,6 +59,7 @@ function downloadRecordingBlob(
 export interface RecordChartStreamOptions {
   element: HTMLElement;
   timeline: StudioRecordingTimeline;
+  format: StudioRecordingFormat;
   chartSlug: string;
   onReplay: () => void;
   onTimelineTick?: (elapsedMs: number) => void;
@@ -63,6 +68,8 @@ export interface RecordChartStreamOptions {
   isPaused?: () => boolean;
   /** Called once the display stream is cropped and capture is about to begin. */
   onCaptureReady?: () => void;
+  /** Called when WebM capture finished and MP4 transcode begins. */
+  onEncodingStart?: () => void;
 }
 
 /**
@@ -76,6 +83,7 @@ export async function recordChartStream(
   const {
     element,
     timeline,
+    format,
     chartSlug,
     onReplay,
     onTimelineTick,
@@ -83,6 +91,7 @@ export async function recordChartStream(
     onProgress,
     isPaused = () => false,
     onCaptureReady,
+    onEncodingStart,
   } = options;
 
   if (!canRecordChartStream()) {
@@ -209,8 +218,27 @@ export async function recordChartStream(
     if (blob.size === 0) {
       throw new Error("Recording produced no video data.");
     }
-    const extension = mimeType.includes("mp4") ? "mp4" : "webm";
-    downloadRecordingBlob(blob, chartSlug, extension);
+
+    if (format === "webm") {
+      downloadRecordingBlob(blob, chartSlug, "webm");
+      onProgress?.(1);
+      return;
+    }
+
+    onEncodingStart?.();
+    const mp4 = await transcodeRecordingToMp4({
+      blob,
+      signal,
+      onProgress: (encodeProgress) => {
+        onProgress?.(0.85 + encodeProgress * 0.15);
+      },
+    });
+
+    if (aborted || signal?.aborted) {
+      throw new DOMException("Aborted", "AbortError");
+    }
+
+    downloadRecordingBlob(mp4, chartSlug, "mp4");
     onProgress?.(1);
   } catch (caught) {
     if (caught instanceof DOMException && caught.name === "NotAllowedError") {

--- a/apps/web/lib/studio/registry.tsx
+++ b/apps/web/lib/studio/registry.tsx
@@ -367,7 +367,9 @@ const radarConfig: StudioChartConfig = {
   controls: [],
   controlGroups: radarChartControlGroups,
   render: (state, ctx) => {
-    const motionEnter = getStudioMotionEnterProps(state);
+    const motionEnter = getStudioMotionEnterProps(state, {
+      linear: ctx.isRecording,
+    });
     return (
       <StudioRadialCenter frame={ctx.frame}>
         <RadarChart

--- a/apps/web/lib/studio/render-context.ts
+++ b/apps/web/lib/studio/render-context.ts
@@ -4,6 +4,8 @@ import type { StudioUrlState } from "./studio-parsers";
 
 export interface StudioRenderContext {
   animationKey: number;
+  /** Linear enter motion while a studio recording is in progress. */
+  isRecording?: boolean;
   /** Debounced signature of motion URL state — remount charts to replay enter. */
   motionRemountKey: string;
   /** Committed URL state (without slider / bezier preview overrides). */

--- a/apps/web/lib/studio/studio-recording-color.ts
+++ b/apps/web/lib/studio/studio-recording-color.ts
@@ -1,0 +1,68 @@
+import type { VideoSample } from "mediabunny";
+
+/** Full-range sRGB — matches browser UI color on typical displays. */
+export const STUDIO_RECORDING_SRGB_COLOR_SPACE = {
+  primaries: "bt709",
+  transfer: "iec61966-2.1",
+  matrix: "rgb",
+  fullRange: true,
+} as const;
+
+type CanvasContext =
+  | CanvasRenderingContext2D
+  | OffscreenCanvasRenderingContext2D;
+
+function createSrgbCanvas(
+  width: number,
+  height: number
+): OffscreenCanvas | HTMLCanvasElement {
+  if (typeof OffscreenCanvas !== "undefined") {
+    return new OffscreenCanvas(width, height);
+  }
+  const canvas = document.createElement("canvas");
+  canvas.width = width;
+  canvas.height = height;
+  return canvas;
+}
+
+function getSrgbCanvasContext(
+  canvas: OffscreenCanvas | HTMLCanvasElement
+): CanvasContext | null {
+  const context = canvas.getContext("2d", {
+    alpha: false,
+    colorSpace: "srgb",
+  } as CanvasRenderingContext2DSettings);
+  if (
+    context instanceof CanvasRenderingContext2D ||
+    (typeof OffscreenCanvasRenderingContext2D !== "undefined" &&
+      context instanceof OffscreenCanvasRenderingContext2D)
+  ) {
+    return context;
+  }
+  return null;
+}
+
+/** Re-draw decoded frames in sRGB before H.264 encode to reduce color drift. */
+export function drawVideoSampleToSrgbCanvas(
+  sample: VideoSample
+): OffscreenCanvas | HTMLCanvasElement {
+  const width = sample.displayWidth;
+  const height = sample.displayHeight;
+  const canvas = createSrgbCanvas(width, height);
+  const context = getSrgbCanvasContext(canvas);
+  if (!context) {
+    throw new Error("Failed to create sRGB canvas for recording transcode.");
+  }
+  sample.draw(context, 0, 0, width, height);
+  return canvas;
+}
+
+export function readElementBackgroundColor(
+  element: HTMLElement
+): string | null {
+  const bg = getComputedStyle(element).backgroundColor;
+  if (!bg || bg === "transparent" || bg === "rgba(0, 0, 0, 0)") {
+    return null;
+  }
+  return bg;
+}

--- a/apps/web/lib/studio/studio-recording.ts
+++ b/apps/web/lib/studio/studio-recording.ts
@@ -14,12 +14,18 @@ export const STUDIO_RECORDING_INTERACTION_OPTIONS = [
   { value: 0, label: "None" },
   { value: 5000, label: "5 seconds" },
   { value: 10_000, label: "10 seconds" },
-  { value: 15_000, label: "15 seconds" },
-  { value: 30_000, label: "30 seconds" },
 ] as const;
 
 export type StudioRecordingInteractionMs =
   (typeof STUDIO_RECORDING_INTERACTION_OPTIONS)[number]["value"];
+
+export const STUDIO_RECORDING_FORMAT_OPTIONS = [
+  { value: "webm" as const, label: "WebM" },
+  { value: "mp4" as const, label: "MP4" },
+] as const;
+
+export type StudioRecordingFormat =
+  (typeof STUDIO_RECORDING_FORMAT_OPTIONS)[number]["value"];
 
 export const STUDIO_RECORDING_ASPECT_OPTIONS = [
   { value: "frame" as const, label: "Current frame" },

--- a/apps/web/lib/studio/transcode-recording-to-mp4.ts
+++ b/apps/web/lib/studio/transcode-recording-to-mp4.ts
@@ -1,0 +1,82 @@
+import {
+  ALL_FORMATS,
+  BlobSource,
+  BufferTarget,
+  Conversion,
+  Input,
+  Mp4OutputFormat,
+  Output,
+} from "mediabunny";
+import { drawVideoSampleToSrgbCanvas } from "./studio-recording-color";
+
+const STUDIO_RECORDING_MP4_BITRATE = 16_000_000;
+
+export interface TranscodeRecordingToMp4Options {
+  blob: Blob;
+  signal?: AbortSignal;
+  onProgress?: (progress: number) => void;
+}
+
+/** WebM/VP9 capture → H.264 MP4 (MediaRecorder MP4 tab capture is unreliable). */
+export async function transcodeRecordingToMp4(
+  options: TranscodeRecordingToMp4Options
+): Promise<Blob> {
+  const { blob, signal, onProgress } = options;
+
+  if (signal?.aborted) {
+    throw new DOMException("Aborted", "AbortError");
+  }
+
+  const input = new Input({
+    source: new BlobSource(blob),
+    formats: ALL_FORMATS,
+  });
+
+  const output = new Output({
+    format: new Mp4OutputFormat(),
+    target: new BufferTarget(),
+  });
+
+  const conversion = await Conversion.init({
+    input,
+    output,
+    video: {
+      codec: "avc",
+      bitrate: STUDIO_RECORDING_MP4_BITRATE,
+      keyFrameInterval: 2,
+      hardwareAcceleration: "prefer-software",
+      process: (sample) => drawVideoSampleToSrgbCanvas(sample),
+    },
+  });
+
+  if (!conversion.isValid) {
+    throw new Error("This browser cannot convert the recording to MP4.");
+  }
+
+  conversion.onProgress = (progress) => {
+    onProgress?.(progress);
+  };
+
+  const onAbort = () => {
+    conversion.cancel().catch(() => undefined);
+  };
+  signal?.addEventListener("abort", onAbort, { once: true });
+
+  try {
+    await conversion.execute();
+  } catch (caught) {
+    if (signal?.aborted) {
+      throw new DOMException("Aborted", "AbortError");
+    }
+    throw caught;
+  } finally {
+    signal?.removeEventListener("abort", onAbort);
+  }
+
+  const buffer = output.target.buffer;
+  if (!buffer) {
+    throw new Error("MP4 conversion produced no data.");
+  }
+
+  return new Blob([buffer], { type: "video/mp4" });
+}

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -39,6 +39,7 @@
     "fumadocs-mdx": "^11.6.5",
     "fumadocs-ui": "^15.2.9",
     "lucide-react": "^0.562.0",
+    "mediabunny": "1.45.0",
     "modern-screenshot": "^4.7.0",
     "motion": "^12.27.0",
     "next": "^15.3.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -113,6 +113,9 @@ importers:
       lucide-react:
         specifier: ^0.562.0
         version: 0.562.0(react@19.2.0)
+      mediabunny:
+        specifier: 1.45.0
+        version: 1.45.0
       modern-screenshot:
         specifier: ^4.7.0
         version: 4.7.0


### PR DESCRIPTION
## Summary
- Fix chart re-initialize flash when recording starts by keeping a single chart frame element and deferring capture until the display stream is ready.
- Add WebM/MP4 export choice: WebM downloads the Region Capture recording directly; MP4 transcodes via Mediabunny after capture.
- Use linear timeline playhead and linear chart enter motion while recording.
- Trim interaction time options to None, 5s, and 10s; default interaction remains 5s.
- Bind light/dark theme toggle to the `D` keyboard shortcut (ignored while typing in inputs).

## Test plan
- [ ] Start a studio recording in Chrome; confirm enter animation plays and export matches selected format (WebM vs MP4).
- [ ] Confirm MP4 export is not a frozen still frame.
- [ ] Pause/resume recording and verify timeline scrubber moves linearly.
- [ ] Press `D` outside inputs to toggle theme on docs and studio pages.
- [ ] `pnpm test --filter=web` and `pnpm build --filter=web` pass.


Made with [Cursor](https://cursor.com)