### PR TITLE
Add @bklit/chart-animation registry item

### DIFF
--- a/.agents/skills/pr-open/SKILL.md
+++ b/.agents/skills/pr-open/SKILL.md
@@ -1,0 +1,264 @@
+---
+name: pr-open
+description: |
+  Open a pull request the bklit-ui way: stage and commit with pre-commit hooks,
+  run ultracite from the repo root, run a production test build, fix failures, push,
+  and create a PR with a structured summary. Use when the user asks to commit, push,
+  open a PR, "ship it", or run the full pre-PR checklist.
+---
+
+# PR Open Skill
+
+End-to-end workflow for committing work and opening a merge-ready PR in **bklit-ui**.
+
+Read this skill when the user wants to add, commit, validate, push, and open a PR — or references `@pr-open`.
+
+---
+
+## Before you start
+
+1. **Confirm branch context**
+   - If the user merged an earlier PR on this branch and there are new changes, branch from latest `main` instead of stacking on a stale feature branch:
+     ```bash
+     git fetch origin main
+     git checkout -b <new-branch-name> origin/main
+     ```
+   - Re-apply or cherry-pick only the intended changes; do not commit unrelated `registry:build` noise (e.g. reformatted `packages/ui/registry/examples/*` unless those edits are intentional).
+
+2. **Never commit secrets** — skip `.env`, credentials, API keys, etc. Warn the user if they ask to commit them.
+
+3. **Git safety** (required)
+   - Do not update git config.
+   - Do not run destructive commands (`push --force`, `reset --hard`) unless the user explicitly asks.
+   - Do not skip hooks (`--no-verify`) unless the user explicitly asks.
+   - Do not `git commit --amend` unless all amend rules in the user's git rules are satisfied (HEAD commit is yours, not pushed, or user requested amend).
+   - If a commit **fails** due to a hook, fix the issue and create a **new** commit — do not amend a failed commit.
+   - Use HEREDOC for commit messages (see below).
+   - Do not push unless the user asked to push or open a PR.
+
+---
+
+## Step 1 — Inspect changes
+
+Run in parallel from the repo root:
+
+```bash
+git status
+git diff
+git diff --staged
+git log -5 --oneline
+```
+
+If opening a PR, also check divergence from base:
+
+```bash
+git fetch origin main
+git log origin/main..HEAD --oneline
+git diff origin/main...HEAD --stat
+```
+
+Draft a commit message that explains **why**, not just what. Match recent repo style (e.g. `feat(charts): …`, `fix(web): …`).
+
+---
+
+## Step 2 — Stage and commit (pre-commit loop)
+
+### Stage
+
+```bash
+git add <paths>   # prefer explicit paths over blind git add -A
+```
+
+### Commit
+
+```bash
+git commit -m "$(cat <<'EOF'
+<subject line>
+
+<optional body — 1–2 sentences on why>
+EOF
+)"
+```
+
+Husky **pre-commit** runs `npx ultracite fix` (see `.husky/pre-commit`).
+
+### If pre-commit fails or leaves unstaged fixes
+
+1. Read the hook output and fix every reported issue (lint correctness, nested ternaries, `biome-ignore` only when justified, etc.).
+2. Re-stage affected files: `git add <paths>`
+3. Commit again with a **new** commit (or amend only if amend rules allow and the previous commit succeeded but the hook auto-modified files).
+
+Repeat until `git commit` succeeds **and** `git status` is clean (no leftover hook formatting).
+
+---
+
+## Step 3 — Ultracite from repo root
+
+After commits are clean, run the root pnpm scripts (not `npx ultracite` directly unless fixing a one-off):
+
+```bash
+pnpm lint          # ultracite check
+```
+
+If check fails:
+
+```bash
+pnpm lint:fix      # ultracite fix (same as pnpm format)
+```
+
+Then:
+
+1. Review `git diff` for unexpected changes.
+2. If files changed: `git add <paths>` → `git commit -m "$(cat <<'EOF'
+Fix lint issues from ultracite
+EOF
+)"`
+3. Re-run `pnpm lint` until it passes with no fixes pending.
+
+Do not open a PR while `pnpm lint` fails or while lint fixes are unstaged.
+
+---
+
+## Step 4 — Test build
+
+Run a production build to catch type and compile errors before the PR.
+
+**Default (whole monorepo):**
+
+```bash
+pnpm build
+```
+
+**Web app only** (faster when changes are confined to `apps/web`):
+
+```bash
+cd apps/web && pnpm build
+```
+
+If the web build OOMs in dev/CI-like environments, retry with more heap:
+
+```bash
+cd apps/web && NODE_OPTIONS='--max-old-space-size=8192' pnpm build
+```
+
+**Optional but recommended** when touching TypeScript:
+
+```bash
+pnpm check-types
+```
+
+### If build fails
+
+1. Fix the root cause (types, imports, missing registry files, etc.).
+2. Re-run the failing command until it passes.
+3. Commit fixes with a clear message, then re-run **Step 3** (`pnpm lint`) if source files changed.
+
+---
+
+## Step 5 — Push
+
+Only when the user asked to push or open a PR:
+
+```bash
+git push -u origin HEAD
+```
+
+If the branch was already pushed and you added commits, `git push` is enough.
+
+---
+
+## Step 6 — Open the PR
+
+Use GitHub CLI from the repo root:
+
+```bash
+gh pr create --title "<PR title>" --body "$(cat <<'EOF'
+## Summary
+
+- <bullet: what changed and why>
+- <bullet: user-facing impact>
+- <bullet: follow-ups or deploy notes if any>
+
+## Test plan
+
+- [ ] `pnpm lint` passes at repo root
+- [ ] `pnpm build` (or `apps/web` build for web-only changes)
+- [ ] <manual verification step 1>
+- [ ] <manual verification step 2>
+
+EOF
+)"
+```
+
+Return the PR URL to the user.
+
+### PR title guidelines
+
+- Short, imperative, scoped (e.g. `Add @bklit/chart-animation registry item`)
+- Match the primary commit subject when possible
+
+### PR body template (copy structure every time)
+
+```markdown
+## Summary
+
+- <1–3 bullets: what and why>
+
+## Test plan
+
+- [ ] `pnpm lint` passes at repo root
+- [ ] Production build succeeds (`pnpm build` or scoped web build)
+- [ ] <feature-specific check>
+- [ ] <regression check if applicable>
+```
+
+Add extra sections only when useful:
+
+- **Context** — link to a merged PR or issue (e.g. "Follow-up to #70")
+- **Deploy notes** — e.g. registry JSON must be live on `ui.bklit.com` for Open in v0
+
+### Repo-specific PR notes
+
+- **Registry changes**: run `pnpm registry:build` from root (or `packages/ui`) before commit; include `apps/web/public/r/` outputs in the commit.
+- **Do not** commit incidental reformats from `registry:build` on `packages/ui/registry/examples/*` unless intentional.
+- Chart/docs work: mention manual checks for docs pages, Studio, or Open in v0 when relevant.
+
+---
+
+## Full checklist (quick reference)
+
+| Step | Command / action | Must pass before next step |
+|------|------------------|----------------------------|
+| 1 | `git status` / `git diff` / `git log` | Understand scope |
+| 2 | `git add` → `git commit` | Pre-commit hook clean; working tree clean |
+| 3 | `pnpm lint` → `pnpm lint:fix` if needed → re-commit | `pnpm lint` exits 0 |
+| 4 | `pnpm build` (and `pnpm check-types` if TS changed) | Build exits 0 |
+| 5 | `git push -u origin HEAD` | Only if user requested push/PR |
+| 6 | `gh pr create` with Summary + Test plan | PR URL returned |
+
+---
+
+## Common failures
+
+| Failure | Fix |
+|---------|-----|
+| Pre-commit biome errors | Fix code; add `biome-ignore` only with a one-line justification |
+| Hook fixed files but commit already succeeded | `git add` + new commit (or amend if allowed) |
+| `pnpm lint` fails after commit | `pnpm lint:fix`, review diff, commit, re-run `pnpm lint` |
+| `Can't resolve './animation'` in registry consumers | Add missing `@bklit/*` registry deps; run `pnpm registry:build` |
+| Web build OOM | `NODE_OPTIONS='--max-old-space-size=8192'` for `apps/web` build |
+| PR branch already merged | New branch from `origin/main`, re-apply only new changes |
+
+---
+
+## Example flow
+
+User: "commit this and open a PR"
+
+1. `git status` + `git diff` + `git log -3`
+2. `git add apps/web packages/ui` → `git commit` (fix pre-commit until clean)
+3. `pnpm lint` → `pnpm lint:fix` if needed → commit → `pnpm lint`
+4. `pnpm build` (fix until green) → commit if needed
+5. `git push -u origin HEAD`
+6. `gh pr create` with Summary + Test plan template
+7. Reply with PR link and one-line summary of what was validated

--- a/apps/web/public/r/area-chart.json
+++ b/apps/web/public/r/area-chart.json
@@ -12,6 +12,7 @@
   ],
   "registryDependencies": [
     "@bklit/chart-context",
+    "@bklit/chart-animation",
     "@bklit/grid",
     "@bklit/x-axis",
     "@bklit/chart-tooltip",

--- a/apps/web/public/r/bar-chart.json
+++ b/apps/web/public/r/bar-chart.json
@@ -12,6 +12,7 @@
   ],
   "registryDependencies": [
     "@bklit/chart-context",
+    "@bklit/chart-animation",
     "@bklit/grid",
     "@bklit/chart-tooltip",
     "@bklit/utils"

--- a/apps/web/public/r/candlestick-chart.json
+++ b/apps/web/public/r/candlestick-chart.json
@@ -12,6 +12,7 @@
   ],
   "registryDependencies": [
     "@bklit/chart-context",
+    "@bklit/chart-animation",
     "@bklit/grid",
     "@bklit/x-axis",
     "@bklit/y-axis",

--- a/apps/web/public/r/chart-animation.json
+++ b/apps/web/public/r/chart-animation.json
@@ -1,0 +1,42 @@
+{
+  "$schema": "https://ui.shadcn.com/schema/registry-item.json",
+  "name": "chart-animation",
+  "type": "registry:component",
+  "title": "Chart Animation",
+  "description": "Shared motion helpers for chart enter transitions, clip reveals, and staggered animations",
+  "dependencies": [
+    "motion"
+  ],
+  "files": [
+    {
+      "path": "src/charts/animation.ts",
+      "content": "import type { Transition } from \"motion/react\";\n\n/** Default clip-reveal easing for cartesian charts. */\nexport const DEFAULT_ANIMATION_EASING = \"cubic-bezier(0.85, 0, 0.15, 1)\";\n\nexport const DEFAULT_ANIMATION_DURATION_MS = 1100;\n\n/** Default enter transition — matches the original line chart reveal. */\nexport const DEFAULT_CHART_ENTER_TRANSITION: Transition = {\n  type: \"tween\",\n  duration: DEFAULT_ANIMATION_DURATION_MS / 1000,\n  ease: [0.85, 0, 0.15, 1],\n};\n\n/**\n * Clip-path width reveal must use tween — spring does not reliably animate SVG width.\n */\nexport function clipRevealTransition(enterTransition?: Transition): Transition {\n  if (enterTransition?.type === \"tween\") {\n    return enterTransition;\n  }\n\n  const duration =\n    typeof enterTransition?.duration === \"number\"\n      ? enterTransition.duration\n      : DEFAULT_ANIMATION_DURATION_MS / 1000;\n\n  return {\n    type: \"tween\",\n    duration,\n    ease: DEFAULT_CHART_ENTER_TRANSITION.ease,\n  };\n}\n",
+      "type": "registry:component",
+      "target": "components/charts/animation.ts"
+    },
+    {
+      "path": "src/charts/motion-utils.ts",
+      "content": "import type { Transition } from \"motion/react\";\nimport { DEFAULT_CHART_ENTER_TRANSITION } from \"./animation\";\n\nexport function transitionWithDelay(\n  transition: Transition | undefined,\n  delaySeconds: number,\n  fallback: Transition = DEFAULT_CHART_ENTER_TRANSITION\n): Transition {\n  const base = transition ?? fallback;\n  return { ...base, delay: delaySeconds };\n}\n\nexport interface SpringOptions {\n  stiffness: number;\n  damping: number;\n  mass?: number;\n}\n\nexport function springOptionsFromTransition(\n  transition?: Transition,\n  fallback: SpringOptions = { stiffness: 60, damping: 20 }\n): SpringOptions {\n  if (!transition) {\n    return fallback;\n  }\n  if (transition.type === \"spring\") {\n    const bounce =\n      typeof transition.bounce === \"number\" ? transition.bounce : undefined;\n    const baseStiffness =\n      typeof transition.stiffness === \"number\"\n        ? transition.stiffness\n        : fallback.stiffness;\n    const baseDamping =\n      typeof transition.damping === \"number\"\n        ? transition.damping\n        : fallback.damping;\n    return {\n      stiffness:\n        bounce == null\n          ? baseStiffness\n          : Math.min(400, Math.max(80, baseStiffness * (1 + bounce * 0.35))),\n      damping:\n        bounce == null\n          ? baseDamping\n          : Math.max(8, baseDamping * (1 - bounce * 0.25)),\n      mass:\n        typeof transition.mass === \"number\" ? transition.mass : fallback.mass,\n    };\n  }\n  const duration =\n    \"duration\" in transition && typeof transition.duration === \"number\"\n      ? transition.duration\n      : 0.8;\n  return {\n    stiffness: Math.min(500, Math.max(40, 280 / duration)),\n    damping: Math.min(40, Math.max(12, 18 + duration * 4)),\n  };\n}\n",
+      "type": "registry:component",
+      "target": "components/charts/motion-utils.ts"
+    },
+    {
+      "path": "src/charts/use-mount-progress.ts",
+      "content": "\"use client\";\n\nimport { animate, type Transition, useMotionValue } from \"motion/react\";\nimport { useEffect, useRef } from \"react\";\nimport { DEFAULT_CHART_ENTER_TRANSITION } from \"./animation\";\n\n/** Drives 0→1 enter progress using the studio motion transition (spring or tween). */\nexport function useMountProgress(\n  enterTransition: Transition | undefined,\n  delaySeconds: number,\n  replayKey: number | string\n) {\n  const progress = useMotionValue(0);\n  const transitionRef = useRef(enterTransition);\n  transitionRef.current = enterTransition;\n\n  // replayKey intentionally retriggers enter when motion settings change\n  // biome-ignore lint/correctness/useExhaustiveDependencies: replayKey\n  useEffect(() => {\n    progress.set(0);\n    const controls = animate(progress, 1, {\n      ...(transitionRef.current ?? DEFAULT_CHART_ENTER_TRANSITION),\n      delay: delaySeconds,\n    });\n    return () => controls.stop();\n  }, [delaySeconds, replayKey, progress]);\n\n  return progress;\n}\n",
+      "type": "registry:component",
+      "target": "components/charts/use-mount-progress.ts"
+    },
+    {
+      "path": "src/charts/chart-reveal-clip.tsx",
+      "content": "\"use client\";\n\nimport type { Transition } from \"motion/react\";\nimport { motion } from \"motion/react\";\nimport { clipRevealTransition } from \"./animation\";\n\nexport interface ChartRevealClipProps {\n  clipPathId: string;\n  height: number;\n  targetWidth: number;\n  enterTransition?: Transition;\n  /** Bumps when motion settings change to replay the reveal. */\n  revealEpoch: number;\n}\n\n/**\n * Left-to-right clip reveal for cartesian series.\n * Grows clip rect width from 0 → full (true LTR; scaleX is avoided — it reveals from center).\n */\nexport function ChartRevealClip({\n  clipPathId,\n  height,\n  targetWidth,\n  enterTransition,\n  revealEpoch,\n}: ChartRevealClipProps) {\n  const transition = clipRevealTransition(enterTransition);\n\n  return (\n    <clipPath id={clipPathId}>\n      <motion.rect\n        animate={{ width: Math.max(0, targetWidth) }}\n        height={height}\n        initial={{ width: 0 }}\n        key={`reveal-${revealEpoch}`}\n        transition={transition}\n        width={Math.max(0, targetWidth)}\n        x={0}\n        y={0}\n      />\n    </clipPath>\n  );\n}\n",
+      "type": "registry:component",
+      "target": "components/charts/chart-reveal-clip.tsx"
+    },
+    {
+      "path": "src/charts/chart-defs.ts",
+      "content": "import {\n  Children,\n  isValidElement,\n  type ReactElement,\n  type ReactNode,\n} from \"react\";\n\nexport function getChartChildComponentName(child: ReactElement): string {\n  const childType = child.type as { displayName?: string; name?: string };\n  return typeof child.type === \"function\"\n    ? childType.displayName || childType.name || \"\"\n    : \"\";\n}\n\nconst VISX_PATTERN_COMPONENT_NAMES = new Set([\n  \"Lines\",\n  \"Circles\",\n  \"Waves\",\n  \"Hexagons\",\n  \"Path\",\n  \"Pattern\",\n]);\n\n/** @visx/pattern default exports use short names (e.g. `Lines`); also match *Pattern* displayNames. */\nexport function isPatternDefComponent(child: ReactElement): boolean {\n  const name = getChartChildComponentName(child);\n  return name.includes(\"Pattern\") || VISX_PATTERN_COMPONENT_NAMES.has(name);\n}\n\nexport function isGradientDefComponent(child: ReactElement): boolean {\n  const name = getChartChildComponentName(child);\n  return (\n    name.includes(\"Gradient\") ||\n    name === \"LinearGradient\" ||\n    name === \"RadialGradient\"\n  );\n}\n\nexport function isChartDefsComponent(child: ReactElement): boolean {\n  return isPatternDefComponent(child) || isGradientDefComponent(child);\n}\n\n/** Split hoisted defs: @visx/pattern nodes already wrap `<defs>` and render at the svg root. */\nexport function partitionChartDefNodes(defNodes: ReactElement[]): {\n  patternDefNodes: ReactElement[];\n  gradientDefNodes: ReactElement[];\n} {\n  const patternDefNodes: ReactElement[] = [];\n  const gradientDefNodes: ReactElement[] = [];\n\n  for (const node of defNodes) {\n    if (isPatternDefComponent(node)) {\n      patternDefNodes.push(node);\n    } else {\n      gradientDefNodes.push(node);\n    }\n  }\n\n  return { patternDefNodes, gradientDefNodes };\n}\n\nexport function collectChartDefsChildren(children: ReactNode): ReactElement[] {\n  const defNodes: ReactElement[] = [];\n\n  Children.forEach(children, (child) => {\n    if (isValidElement(child) && isChartDefsComponent(child)) {\n      defNodes.push(child);\n    }\n  });\n\n  return defNodes;\n}\n",
+      "type": "registry:component",
+      "target": "components/charts/chart-defs.ts"
+    }
+  ]
+}

--- a/apps/web/public/r/choropleth-chart.json
+++ b/apps/web/public/r/choropleth-chart.json
@@ -13,6 +13,7 @@
     "motion"
   ],
   "registryDependencies": [
+    "@bklit/chart-animation",
     "@bklit/utils"
   ],
   "files": [

--- a/apps/web/public/r/funnel-chart.json
+++ b/apps/web/public/r/funnel-chart.json
@@ -8,6 +8,7 @@
     "motion"
   ],
   "registryDependencies": [
+    "@bklit/chart-animation",
     "@bklit/utils"
   ],
   "files": [

--- a/apps/web/public/r/line-chart.json
+++ b/apps/web/public/r/line-chart.json
@@ -11,6 +11,7 @@
   ],
   "registryDependencies": [
     "@bklit/chart-context",
+    "@bklit/chart-animation",
     "@bklit/grid",
     "@bklit/x-axis",
     "@bklit/chart-tooltip",

--- a/apps/web/public/r/pie-chart.json
+++ b/apps/web/public/r/pie-chart.json
@@ -12,6 +12,7 @@
     "motion"
   ],
   "registryDependencies": [
+    "@bklit/chart-animation",
     "@bklit/utils"
   ],
   "files": [

--- a/apps/web/public/r/radar-chart.json
+++ b/apps/web/public/r/radar-chart.json
@@ -10,6 +10,7 @@
     "motion"
   ],
   "registryDependencies": [
+    "@bklit/chart-animation",
     "@bklit/utils"
   ],
   "files": [

--- a/apps/web/public/r/registry.json
+++ b/apps/web/public/r/registry.json
@@ -89,6 +89,42 @@
       ]
     },
     {
+      "name": "chart-animation",
+      "type": "registry:component",
+      "title": "Chart Animation",
+      "description": "Shared motion helpers for chart enter transitions, clip reveals, and staggered animations",
+      "dependencies": [
+        "motion"
+      ],
+      "files": [
+        {
+          "path": "src/charts/animation.ts",
+          "type": "registry:component",
+          "target": "components/charts/animation.ts"
+        },
+        {
+          "path": "src/charts/motion-utils.ts",
+          "type": "registry:component",
+          "target": "components/charts/motion-utils.ts"
+        },
+        {
+          "path": "src/charts/use-mount-progress.ts",
+          "type": "registry:component",
+          "target": "components/charts/use-mount-progress.ts"
+        },
+        {
+          "path": "src/charts/chart-reveal-clip.tsx",
+          "type": "registry:component",
+          "target": "components/charts/chart-reveal-clip.tsx"
+        },
+        {
+          "path": "src/charts/chart-defs.ts",
+          "type": "registry:component",
+          "target": "components/charts/chart-defs.ts"
+        }
+      ]
+    },
+    {
       "name": "grid",
       "type": "registry:component",
       "title": "Chart Grid",
@@ -297,6 +333,7 @@
       "description": "A composable area chart with gradient fills and animations",
       "registryDependencies": [
         "@bklit/chart-context",
+        "@bklit/chart-animation",
         "@bklit/grid",
         "@bklit/x-axis",
         "@bklit/chart-tooltip",
@@ -374,6 +411,7 @@
       "description": "A composable bar chart with horizontal/vertical orientations and animations",
       "registryDependencies": [
         "@bklit/chart-context",
+        "@bklit/chart-animation",
         "@bklit/grid",
         "@bklit/chart-tooltip",
         "@bklit/utils"
@@ -414,6 +452,7 @@
       "description": "A composable line chart with multiple series support",
       "registryDependencies": [
         "@bklit/chart-context",
+        "@bklit/chart-animation",
         "@bklit/grid",
         "@bklit/x-axis",
         "@bklit/chart-tooltip",
@@ -491,6 +530,7 @@
       "description": "A composable OHLC candlestick chart with gradients, patterns, tooltips, and hover interactions",
       "registryDependencies": [
         "@bklit/chart-context",
+        "@bklit/chart-animation",
         "@bklit/grid",
         "@bklit/x-axis",
         "@bklit/y-axis",
@@ -522,6 +562,7 @@
       "title": "Pie Chart",
       "description": "A composable pie chart with animations and customizable slices",
       "registryDependencies": [
+        "@bklit/chart-animation",
         "@bklit/utils"
       ],
       "dependencies": [
@@ -570,6 +611,7 @@
       "title": "Radar Chart",
       "description": "A composable radar/spider chart with multiple data series",
       "registryDependencies": [
+        "@bklit/chart-animation",
         "@bklit/utils"
       ],
       "dependencies": [
@@ -616,6 +658,7 @@
       "title": "Ring Chart",
       "description": "A composable donut/ring chart with progress indicators",
       "registryDependencies": [
+        "@bklit/chart-animation",
         "@bklit/utils"
       ],
       "dependencies": [
@@ -700,6 +743,7 @@
       "title": "Choropleth Map",
       "description": "A geographic map chart with zoom, pan, and data visualization",
       "registryDependencies": [
+        "@bklit/chart-animation",
         "@bklit/utils"
       ],
       "dependencies": [
@@ -749,6 +793,7 @@
       "title": "Funnel Chart",
       "description": "An animated funnel chart with multi-layer halo rings, hover interactions, and staggered entrance animations",
       "registryDependencies": [
+        "@bklit/chart-animation",
         "@bklit/utils"
       ],
       "dependencies": [
@@ -768,6 +813,7 @@
       "title": "Sankey Diagram",
       "description": "A flow diagram for visualizing data transfers between nodes",
       "registryDependencies": [
+        "@bklit/chart-animation",
         "@bklit/utils"
       ],
       "dependencies": [

--- a/apps/web/public/r/ring-chart.json
+++ b/apps/web/public/r/ring-chart.json
@@ -10,6 +10,7 @@
     "motion"
   ],
   "registryDependencies": [
+    "@bklit/chart-animation",
     "@bklit/utils"
   ],
   "files": [

--- a/apps/web/public/r/sankey-chart.json
+++ b/apps/web/public/r/sankey-chart.json
@@ -12,6 +12,7 @@
     "motion"
   ],
   "registryDependencies": [
+    "@bklit/chart-animation",
     "@bklit/utils"
   ],
   "files": [

--- a/packages/ui/registry.json
+++ b/packages/ui/registry.json
@@ -8,7 +8,10 @@
       "type": "registry:lib",
       "title": "Utilities",
       "description": "Utility functions for className merging with clsx and tailwind-merge",
-      "dependencies": ["clsx", "tailwind-merge"],
+      "dependencies": [
+        "clsx",
+        "tailwind-merge"
+      ],
       "files": [
         {
           "path": "src/lib/utils.ts",
@@ -22,7 +25,9 @@
       "type": "registry:component",
       "title": "Chart Context",
       "description": "Shared context and hooks for Bklit chart components",
-      "registryDependencies": ["@bklit/utils"],
+      "registryDependencies": [
+        "@bklit/utils"
+      ],
       "dependencies": [
         "@visx/event@4.0.1-alpha.0",
         "@visx/responsive@4.0.1-alpha.0",
@@ -84,12 +89,52 @@
       ]
     },
     {
+      "name": "chart-animation",
+      "type": "registry:component",
+      "title": "Chart Animation",
+      "description": "Shared motion helpers for chart enter transitions, clip reveals, and staggered animations",
+      "dependencies": [
+        "motion"
+      ],
+      "files": [
+        {
+          "path": "src/charts/animation.ts",
+          "type": "registry:component",
+          "target": "components/charts/animation.ts"
+        },
+        {
+          "path": "src/charts/motion-utils.ts",
+          "type": "registry:component",
+          "target": "components/charts/motion-utils.ts"
+        },
+        {
+          "path": "src/charts/use-mount-progress.ts",
+          "type": "registry:component",
+          "target": "components/charts/use-mount-progress.ts"
+        },
+        {
+          "path": "src/charts/chart-reveal-clip.tsx",
+          "type": "registry:component",
+          "target": "components/charts/chart-reveal-clip.tsx"
+        },
+        {
+          "path": "src/charts/chart-defs.ts",
+          "type": "registry:component",
+          "target": "components/charts/chart-defs.ts"
+        }
+      ]
+    },
+    {
       "name": "grid",
       "type": "registry:component",
       "title": "Chart Grid",
       "description": "Grid lines for charts",
-      "registryDependencies": ["@bklit/chart-context"],
-      "dependencies": ["@visx/grid@4.0.1-alpha.0"],
+      "registryDependencies": [
+        "@bklit/chart-context"
+      ],
+      "dependencies": [
+        "@visx/grid@4.0.1-alpha.0"
+      ],
       "files": [
         {
           "path": "src/charts/grid.tsx",
@@ -103,7 +148,10 @@
       "type": "registry:component",
       "title": "X Axis",
       "description": "X-axis component for time-series charts",
-      "registryDependencies": ["@bklit/chart-context", "@bklit/utils"],
+      "registryDependencies": [
+        "@bklit/chart-context",
+        "@bklit/utils"
+      ],
       "files": [
         {
           "path": "src/charts/x-axis.tsx",
@@ -117,7 +165,10 @@
       "type": "registry:component",
       "title": "Y Axis",
       "description": "Y-axis component for value labels in line and area charts",
-      "registryDependencies": ["@bklit/chart-context", "@bklit/utils"],
+      "registryDependencies": [
+        "@bklit/chart-context",
+        "@bklit/utils"
+      ],
       "files": [
         {
           "path": "src/charts/y-axis.tsx",
@@ -131,8 +182,14 @@
       "type": "registry:component",
       "title": "Chart Tooltip",
       "description": "Composable tooltip components for charts",
-      "registryDependencies": ["@bklit/chart-context", "@bklit/utils"],
-      "dependencies": ["@number-flow/react", "motion"],
+      "registryDependencies": [
+        "@bklit/chart-context",
+        "@bklit/utils"
+      ],
+      "dependencies": [
+        "@number-flow/react",
+        "motion"
+      ],
       "files": [
         {
           "path": "src/charts/tooltip/chart-tooltip.tsx",
@@ -176,8 +233,12 @@
       "type": "registry:component",
       "title": "Chart Legend",
       "description": "Composable legend components for charts",
-      "registryDependencies": ["@bklit/utils"],
-      "dependencies": ["@number-flow/react"],
+      "registryDependencies": [
+        "@bklit/utils"
+      ],
+      "dependencies": [
+        "@number-flow/react"
+      ],
       "cssVars": {
         "light": {
           "--legend": "oklch(1 0 0)",
@@ -272,6 +333,7 @@
       "description": "A composable area chart with gradient fills and animations",
       "registryDependencies": [
         "@bklit/chart-context",
+        "@bklit/chart-animation",
         "@bklit/grid",
         "@bklit/x-axis",
         "@bklit/chart-tooltip",
@@ -349,6 +411,7 @@
       "description": "A composable bar chart with horizontal/vertical orientations and animations",
       "registryDependencies": [
         "@bklit/chart-context",
+        "@bklit/chart-animation",
         "@bklit/grid",
         "@bklit/chart-tooltip",
         "@bklit/utils"
@@ -389,6 +452,7 @@
       "description": "A composable line chart with multiple series support",
       "registryDependencies": [
         "@bklit/chart-context",
+        "@bklit/chart-animation",
         "@bklit/grid",
         "@bklit/x-axis",
         "@bklit/chart-tooltip",
@@ -466,6 +530,7 @@
       "description": "A composable OHLC candlestick chart with gradients, patterns, tooltips, and hover interactions",
       "registryDependencies": [
         "@bklit/chart-context",
+        "@bklit/chart-animation",
         "@bklit/grid",
         "@bklit/x-axis",
         "@bklit/y-axis",
@@ -496,7 +561,10 @@
       "type": "registry:component",
       "title": "Pie Chart",
       "description": "A composable pie chart with animations and customizable slices",
-      "registryDependencies": ["@bklit/utils"],
+      "registryDependencies": [
+        "@bklit/chart-animation",
+        "@bklit/utils"
+      ],
       "dependencies": [
         "@number-flow/react",
         "@visx/responsive@4.0.1-alpha.0",
@@ -542,8 +610,15 @@
       "type": "registry:component",
       "title": "Radar Chart",
       "description": "A composable radar/spider chart with multiple data series",
-      "registryDependencies": ["@bklit/utils"],
-      "dependencies": ["@visx/responsive@4.0.1-alpha.0", "d3-shape", "motion"],
+      "registryDependencies": [
+        "@bklit/chart-animation",
+        "@bklit/utils"
+      ],
+      "dependencies": [
+        "@visx/responsive@4.0.1-alpha.0",
+        "d3-shape",
+        "motion"
+      ],
       "files": [
         {
           "path": "src/charts/radar-chart.tsx",
@@ -582,7 +657,10 @@
       "type": "registry:component",
       "title": "Ring Chart",
       "description": "A composable donut/ring chart with progress indicators",
-      "registryDependencies": ["@bklit/utils"],
+      "registryDependencies": [
+        "@bklit/chart-animation",
+        "@bklit/utils"
+      ],
       "dependencies": [
         "@visx/responsive@4.0.1-alpha.0",
         "@number-flow/react",
@@ -621,7 +699,9 @@
       "type": "registry:component",
       "title": "Gauge",
       "description": "Notch-based radial gauge with PieCenter-style center, patterns, and optional arc gradients",
-      "registryDependencies": ["@bklit/utils"],
+      "registryDependencies": [
+        "@bklit/utils"
+      ],
       "dependencies": [
         "@visx/responsive@4.0.1-alpha.0",
         "@visx/pattern@4.0.1-alpha.0",
@@ -662,7 +742,10 @@
       "type": "registry:component",
       "title": "Choropleth Map",
       "description": "A geographic map chart with zoom, pan, and data visualization",
-      "registryDependencies": ["@bklit/utils"],
+      "registryDependencies": [
+        "@bklit/chart-animation",
+        "@bklit/utils"
+      ],
       "dependencies": [
         "@visx/geo@4.0.1-alpha.0",
         "@visx/responsive@4.0.1-alpha.0",
@@ -709,8 +792,13 @@
       "type": "registry:component",
       "title": "Funnel Chart",
       "description": "An animated funnel chart with multi-layer halo rings, hover interactions, and staggered entrance animations",
-      "registryDependencies": ["@bklit/utils"],
-      "dependencies": ["motion"],
+      "registryDependencies": [
+        "@bklit/chart-animation",
+        "@bklit/utils"
+      ],
+      "dependencies": [
+        "motion"
+      ],
       "files": [
         {
           "path": "src/charts/funnel-chart.tsx",
@@ -724,7 +812,10 @@
       "type": "registry:component",
       "title": "Sankey Diagram",
       "description": "A flow diagram for visualizing data transfers between nodes",
-      "registryDependencies": ["@bklit/utils"],
+      "registryDependencies": [
+        "@bklit/chart-animation",
+        "@bklit/utils"
+      ],
       "dependencies": [
         "@visx/gradient@4.0.1-alpha.0",
         "@visx/pattern@4.0.1-alpha.0",
@@ -857,8 +948,13 @@
       "type": "registry:example",
       "title": "Pie Chart Example",
       "description": "Composable pie-chart demo for Open in v0",
-      "registryDependencies": ["@bklit/pie-chart"],
-      "dependencies": ["@visx/shape@4.0.1-alpha.0", "motion"],
+      "registryDependencies": [
+        "@bklit/pie-chart"
+      ],
+      "dependencies": [
+        "@visx/shape@4.0.1-alpha.0",
+        "motion"
+      ],
       "files": [
         {
           "path": "registry/examples/pie-chart.tsx",
@@ -877,8 +973,13 @@
       "type": "registry:example",
       "title": "Gauge Chart Example",
       "description": "Composable gauge-chart demo for Open in v0",
-      "registryDependencies": ["@bklit/gauge-chart"],
-      "dependencies": ["@visx/shape@4.0.1-alpha.0", "motion"],
+      "registryDependencies": [
+        "@bklit/gauge-chart"
+      ],
+      "dependencies": [
+        "@visx/shape@4.0.1-alpha.0",
+        "motion"
+      ],
       "files": [
         {
           "path": "registry/examples/gauge-chart.tsx",
@@ -897,8 +998,13 @@
       "type": "registry:example",
       "title": "Ring Chart Example",
       "description": "Composable ring-chart demo for Open in v0",
-      "registryDependencies": ["@bklit/ring-chart"],
-      "dependencies": ["@visx/shape@4.0.1-alpha.0", "motion"],
+      "registryDependencies": [
+        "@bklit/ring-chart"
+      ],
+      "dependencies": [
+        "@visx/shape@4.0.1-alpha.0",
+        "motion"
+      ],
       "files": [
         {
           "path": "registry/examples/ring-chart.tsx",
@@ -917,8 +1023,13 @@
       "type": "registry:example",
       "title": "Radar Chart Example",
       "description": "Composable radar-chart demo for Open in v0",
-      "registryDependencies": ["@bklit/radar-chart"],
-      "dependencies": ["@visx/shape@4.0.1-alpha.0", "motion"],
+      "registryDependencies": [
+        "@bklit/radar-chart"
+      ],
+      "dependencies": [
+        "@visx/shape@4.0.1-alpha.0",
+        "motion"
+      ],
       "files": [
         {
           "path": "registry/examples/radar-chart.tsx",
@@ -966,8 +1077,13 @@
       "type": "registry:example",
       "title": "Funnel Chart Example",
       "description": "Composable funnel-chart demo for Open in v0",
-      "registryDependencies": ["@bklit/funnel-chart"],
-      "dependencies": ["@visx/shape@4.0.1-alpha.0", "motion"],
+      "registryDependencies": [
+        "@bklit/funnel-chart"
+      ],
+      "dependencies": [
+        "@visx/shape@4.0.1-alpha.0",
+        "motion"
+      ],
       "files": [
         {
           "path": "registry/examples/funnel-chart.tsx",
@@ -986,7 +1102,9 @@
       "type": "registry:example",
       "title": "Sankey Chart Example",
       "description": "Composable sankey-chart demo for Open in v0",
-      "registryDependencies": ["@bklit/sankey-chart"],
+      "registryDependencies": [
+        "@bklit/sankey-chart"
+      ],
       "dependencies": [
         "@visx/sankey@4.0.1-alpha.0",
         "@visx/shape@4.0.1-alpha.0",
@@ -1017,7 +1135,10 @@
         "@bklit/y-axis",
         "@bklit/chart-tooltip"
       ],
-      "dependencies": ["@visx/shape@4.0.1-alpha.0", "motion"],
+      "dependencies": [
+        "@visx/shape@4.0.1-alpha.0",
+        "motion"
+      ],
       "files": [
         {
           "path": "registry/examples/candlestick-chart.tsx",
@@ -1036,8 +1157,14 @@
       "type": "registry:example",
       "title": "Choropleth Chart Example",
       "description": "Composable choropleth-chart demo for Open in v0",
-      "registryDependencies": ["@bklit/choropleth-chart"],
-      "dependencies": ["@visx/geo@4.0.1-alpha.0", "d3-geo", "topojson-client"],
+      "registryDependencies": [
+        "@bklit/choropleth-chart"
+      ],
+      "dependencies": [
+        "@visx/geo@4.0.1-alpha.0",
+        "d3-geo",
+        "topojson-client"
+      ],
       "files": [
         {
           "path": "registry/examples/choropleth-chart.tsx",

--- a/packages/ui/registry.json
+++ b/packages/ui/registry.json
@@ -8,10 +8,7 @@
       "type": "registry:lib",
       "title": "Utilities",
       "description": "Utility functions for className merging with clsx and tailwind-merge",
-      "dependencies": [
-        "clsx",
-        "tailwind-merge"
-      ],
+      "dependencies": ["clsx", "tailwind-merge"],
       "files": [
         {
           "path": "src/lib/utils.ts",
@@ -25,9 +22,7 @@
       "type": "registry:component",
       "title": "Chart Context",
       "description": "Shared context and hooks for Bklit chart components",
-      "registryDependencies": [
-        "@bklit/utils"
-      ],
+      "registryDependencies": ["@bklit/utils"],
       "dependencies": [
         "@visx/event@4.0.1-alpha.0",
         "@visx/responsive@4.0.1-alpha.0",
@@ -93,9 +88,7 @@
       "type": "registry:component",
       "title": "Chart Animation",
       "description": "Shared motion helpers for chart enter transitions, clip reveals, and staggered animations",
-      "dependencies": [
-        "motion"
-      ],
+      "dependencies": ["motion"],
       "files": [
         {
           "path": "src/charts/animation.ts",
@@ -129,12 +122,8 @@
       "type": "registry:component",
       "title": "Chart Grid",
       "description": "Grid lines for charts",
-      "registryDependencies": [
-        "@bklit/chart-context"
-      ],
-      "dependencies": [
-        "@visx/grid@4.0.1-alpha.0"
-      ],
+      "registryDependencies": ["@bklit/chart-context"],
+      "dependencies": ["@visx/grid@4.0.1-alpha.0"],
       "files": [
         {
           "path": "src/charts/grid.tsx",
@@ -148,10 +137,7 @@
       "type": "registry:component",
       "title": "X Axis",
       "description": "X-axis component for time-series charts",
-      "registryDependencies": [
-        "@bklit/chart-context",
-        "@bklit/utils"
-      ],
+      "registryDependencies": ["@bklit/chart-context", "@bklit/utils"],
       "files": [
         {
           "path": "src/charts/x-axis.tsx",
@@ -165,10 +151,7 @@
       "type": "registry:component",
       "title": "Y Axis",
       "description": "Y-axis component for value labels in line and area charts",
-      "registryDependencies": [
-        "@bklit/chart-context",
-        "@bklit/utils"
-      ],
+      "registryDependencies": ["@bklit/chart-context", "@bklit/utils"],
       "files": [
         {
           "path": "src/charts/y-axis.tsx",
@@ -182,14 +165,8 @@
       "type": "registry:component",
       "title": "Chart Tooltip",
       "description": "Composable tooltip components for charts",
-      "registryDependencies": [
-        "@bklit/chart-context",
-        "@bklit/utils"
-      ],
-      "dependencies": [
-        "@number-flow/react",
-        "motion"
-      ],
+      "registryDependencies": ["@bklit/chart-context", "@bklit/utils"],
+      "dependencies": ["@number-flow/react", "motion"],
       "files": [
         {
           "path": "src/charts/tooltip/chart-tooltip.tsx",
@@ -233,12 +210,8 @@
       "type": "registry:component",
       "title": "Chart Legend",
       "description": "Composable legend components for charts",
-      "registryDependencies": [
-        "@bklit/utils"
-      ],
-      "dependencies": [
-        "@number-flow/react"
-      ],
+      "registryDependencies": ["@bklit/utils"],
+      "dependencies": ["@number-flow/react"],
       "cssVars": {
         "light": {
           "--legend": "oklch(1 0 0)",
@@ -561,10 +534,7 @@
       "type": "registry:component",
       "title": "Pie Chart",
       "description": "A composable pie chart with animations and customizable slices",
-      "registryDependencies": [
-        "@bklit/chart-animation",
-        "@bklit/utils"
-      ],
+      "registryDependencies": ["@bklit/chart-animation", "@bklit/utils"],
       "dependencies": [
         "@number-flow/react",
         "@visx/responsive@4.0.1-alpha.0",
@@ -610,15 +580,8 @@
       "type": "registry:component",
       "title": "Radar Chart",
       "description": "A composable radar/spider chart with multiple data series",
-      "registryDependencies": [
-        "@bklit/chart-animation",
-        "@bklit/utils"
-      ],
-      "dependencies": [
-        "@visx/responsive@4.0.1-alpha.0",
-        "d3-shape",
-        "motion"
-      ],
+      "registryDependencies": ["@bklit/chart-animation", "@bklit/utils"],
+      "dependencies": ["@visx/responsive@4.0.1-alpha.0", "d3-shape", "motion"],
       "files": [
         {
           "path": "src/charts/radar-chart.tsx",
@@ -657,10 +620,7 @@
       "type": "registry:component",
       "title": "Ring Chart",
       "description": "A composable donut/ring chart with progress indicators",
-      "registryDependencies": [
-        "@bklit/chart-animation",
-        "@bklit/utils"
-      ],
+      "registryDependencies": ["@bklit/chart-animation", "@bklit/utils"],
       "dependencies": [
         "@visx/responsive@4.0.1-alpha.0",
         "@number-flow/react",
@@ -699,9 +659,7 @@
       "type": "registry:component",
       "title": "Gauge",
       "description": "Notch-based radial gauge with PieCenter-style center, patterns, and optional arc gradients",
-      "registryDependencies": [
-        "@bklit/utils"
-      ],
+      "registryDependencies": ["@bklit/utils"],
       "dependencies": [
         "@visx/responsive@4.0.1-alpha.0",
         "@visx/pattern@4.0.1-alpha.0",
@@ -742,10 +700,7 @@
       "type": "registry:component",
       "title": "Choropleth Map",
       "description": "A geographic map chart with zoom, pan, and data visualization",
-      "registryDependencies": [
-        "@bklit/chart-animation",
-        "@bklit/utils"
-      ],
+      "registryDependencies": ["@bklit/chart-animation", "@bklit/utils"],
       "dependencies": [
         "@visx/geo@4.0.1-alpha.0",
         "@visx/responsive@4.0.1-alpha.0",
@@ -792,13 +747,8 @@
       "type": "registry:component",
       "title": "Funnel Chart",
       "description": "An animated funnel chart with multi-layer halo rings, hover interactions, and staggered entrance animations",
-      "registryDependencies": [
-        "@bklit/chart-animation",
-        "@bklit/utils"
-      ],
-      "dependencies": [
-        "motion"
-      ],
+      "registryDependencies": ["@bklit/chart-animation", "@bklit/utils"],
+      "dependencies": ["motion"],
       "files": [
         {
           "path": "src/charts/funnel-chart.tsx",
@@ -812,10 +762,7 @@
       "type": "registry:component",
       "title": "Sankey Diagram",
       "description": "A flow diagram for visualizing data transfers between nodes",
-      "registryDependencies": [
-        "@bklit/chart-animation",
-        "@bklit/utils"
-      ],
+      "registryDependencies": ["@bklit/chart-animation", "@bklit/utils"],
       "dependencies": [
         "@visx/gradient@4.0.1-alpha.0",
         "@visx/pattern@4.0.1-alpha.0",
@@ -948,13 +895,8 @@
       "type": "registry:example",
       "title": "Pie Chart Example",
       "description": "Composable pie-chart demo for Open in v0",
-      "registryDependencies": [
-        "@bklit/pie-chart"
-      ],
-      "dependencies": [
-        "@visx/shape@4.0.1-alpha.0",
-        "motion"
-      ],
+      "registryDependencies": ["@bklit/pie-chart"],
+      "dependencies": ["@visx/shape@4.0.1-alpha.0", "motion"],
       "files": [
         {
           "path": "registry/examples/pie-chart.tsx",
@@ -973,13 +915,8 @@
       "type": "registry:example",
       "title": "Gauge Chart Example",
       "description": "Composable gauge-chart demo for Open in v0",
-      "registryDependencies": [
-        "@bklit/gauge-chart"
-      ],
-      "dependencies": [
-        "@visx/shape@4.0.1-alpha.0",
-        "motion"
-      ],
+      "registryDependencies": ["@bklit/gauge-chart"],
+      "dependencies": ["@visx/shape@4.0.1-alpha.0", "motion"],
       "files": [
         {
           "path": "registry/examples/gauge-chart.tsx",
@@ -998,13 +935,8 @@
       "type": "registry:example",
       "title": "Ring Chart Example",
       "description": "Composable ring-chart demo for Open in v0",
-      "registryDependencies": [
-        "@bklit/ring-chart"
-      ],
-      "dependencies": [
-        "@visx/shape@4.0.1-alpha.0",
-        "motion"
-      ],
+      "registryDependencies": ["@bklit/ring-chart"],
+      "dependencies": ["@visx/shape@4.0.1-alpha.0", "motion"],
       "files": [
         {
           "path": "registry/examples/ring-chart.tsx",
@@ -1023,13 +955,8 @@
       "type": "registry:example",
       "title": "Radar Chart Example",
       "description": "Composable radar-chart demo for Open in v0",
-      "registryDependencies": [
-        "@bklit/radar-chart"
-      ],
-      "dependencies": [
-        "@visx/shape@4.0.1-alpha.0",
-        "motion"
-      ],
+      "registryDependencies": ["@bklit/radar-chart"],
+      "dependencies": ["@visx/shape@4.0.1-alpha.0", "motion"],
       "files": [
         {
           "path": "registry/examples/radar-chart.tsx",
@@ -1077,13 +1004,8 @@
       "type": "registry:example",
       "title": "Funnel Chart Example",
       "description": "Composable funnel-chart demo for Open in v0",
-      "registryDependencies": [
-        "@bklit/funnel-chart"
-      ],
-      "dependencies": [
-        "@visx/shape@4.0.1-alpha.0",
-        "motion"
-      ],
+      "registryDependencies": ["@bklit/funnel-chart"],
+      "dependencies": ["@visx/shape@4.0.1-alpha.0", "motion"],
       "files": [
         {
           "path": "registry/examples/funnel-chart.tsx",
@@ -1102,9 +1024,7 @@
       "type": "registry:example",
       "title": "Sankey Chart Example",
       "description": "Composable sankey-chart demo for Open in v0",
-      "registryDependencies": [
-        "@bklit/sankey-chart"
-      ],
+      "registryDependencies": ["@bklit/sankey-chart"],
       "dependencies": [
         "@visx/sankey@4.0.1-alpha.0",
         "@visx/shape@4.0.1-alpha.0",
@@ -1135,10 +1055,7 @@
         "@bklit/y-axis",
         "@bklit/chart-tooltip"
       ],
-      "dependencies": [
-        "@visx/shape@4.0.1-alpha.0",
-        "motion"
-      ],
+      "dependencies": ["@visx/shape@4.0.1-alpha.0", "motion"],
       "files": [
         {
           "path": "registry/examples/candlestick-chart.tsx",
@@ -1157,14 +1074,8 @@
       "type": "registry:example",
       "title": "Choropleth Chart Example",
       "description": "Composable choropleth-chart demo for Open in v0",
-      "registryDependencies": [
-        "@bklit/choropleth-chart"
-      ],
-      "dependencies": [
-        "@visx/geo@4.0.1-alpha.0",
-        "d3-geo",
-        "topojson-client"
-      ],
+      "registryDependencies": ["@bklit/choropleth-chart"],
+      "dependencies": ["@visx/geo@4.0.1-alpha.0", "d3-geo", "topojson-client"],
       "files": [
         {
           "path": "registry/examples/choropleth-chart.tsx",


### PR DESCRIPTION
## Summary

- Adds a new `@bklit/chart-animation` registry item bundling shared motion helpers: `animation.ts`, `motion-utils.ts`, `use-mount-progress.ts`, `chart-reveal-clip.tsx`, and `chart-defs.ts`.
- Wires `@bklit/chart-animation` into chart registry dependencies (bar, area, line, pie, ring, radar, candlestick, funnel, sankey, choropleth) so `shadcn add @bklit/bar-chart` and Open in v0 no longer fail with `Can't resolve './animation'`.
- Rebuilds `apps/web/public/r/` including new `chart-animation.json`.

## Context

Follow-up to #70 — the v0/shadcn work merged without this dependency fix.

## Test plan

- [ ] `pnpm dlx shadcn@latest add @bklit/bar-chart` in a fresh Next app resolves `./animation` and `./motion-utils`
- [ ] Open bar chart in v0 — no module-not-found for `./animation`
- [ ] `pnpm registry:build` in `packages/ui` succeeds


Made with [Cursor](https://cursor.com)