### PR TITLE
fix(registry): complete npm deps for v0 and shadcn chart installs

### DIFF
--- a/apps/web/components/docs/component-preview.tsx
+++ b/apps/web/components/docs/component-preview.tsx
@@ -39,8 +39,8 @@ export function ComponentPreview({
             Preview
           </h2>
           <div className="flex shrink-0 flex-wrap items-center justify-end gap-2">
-            <OpenInV0Button registryJsonUrl={registryJsonUrl} />
             {studioSlug ? <OpenInStudioButton slug={studioSlug} /> : null}
+            <OpenInV0Button registryJsonUrl={registryJsonUrl} />
           </div>
         </div>
       ) : null}

--- a/apps/web/components/docs/open-in-studio-button.tsx
+++ b/apps/web/components/docs/open-in-studio-button.tsx
@@ -5,7 +5,10 @@ import { studioChartHref } from "@/lib/studio/chart-links";
 
 export function OpenInStudioButton({ slug }: { slug: ChartSlug }) {
   return (
-    <Button asChild className="h-8 px-3 text-xs" variant="outline">
+    <Button
+      asChild
+      className="h-8 gap-1 rounded-[6px] bg-black px-3 text-white text-xs hover:bg-black hover:text-white dark:bg-white dark:text-black"
+    >
       <Link href={studioChartHref(slug)}>Open in Studio</Link>
     </Button>
   );

--- a/apps/web/components/docs/open-in-v0-button.tsx
+++ b/apps/web/components/docs/open-in-v0-button.tsx
@@ -12,11 +12,7 @@ export function OpenInV0Button({
   registryJsonUrl: string;
 }) {
   return (
-    <Button
-      aria-label="Open in v0"
-      asChild
-      className="h-8 gap-1 rounded-[6px] bg-black px-3 text-white text-xs hover:bg-black hover:text-white dark:bg-white dark:text-black"
-    >
+    <Button aria-label="Open in v0" asChild className="h-8 gap-1 px-3 text-xs" variant="outline">
       <a href={openInV0Href(registryJsonUrl)} rel="noreferrer" target="_blank">
         Open in <V0Icon className="h-5 w-5" />
       </a>

--- a/apps/web/components/docs/open-in-v0-button.tsx
+++ b/apps/web/components/docs/open-in-v0-button.tsx
@@ -12,7 +12,12 @@ export function OpenInV0Button({
   registryJsonUrl: string;
 }) {
   return (
-    <Button aria-label="Open in v0" asChild className="h-8 gap-1 px-3 text-xs" variant="outline">
+    <Button
+      aria-label="Open in v0"
+      asChild
+      className="h-8 gap-1 px-3 text-xs"
+      variant="outline"
+    >
       <a href={openInV0Href(registryJsonUrl)} rel="noreferrer" target="_blank">
         Open in <V0Icon className="h-5 w-5" />
       </a>

--- a/apps/web/public/r/chart-context.json
+++ b/apps/web/public/r/chart-context.json
@@ -8,7 +8,8 @@
     "@visx/event@4.0.1-alpha.0",
     "@visx/responsive@4.0.1-alpha.0",
     "@visx/scale@4.0.1-alpha.0",
-    "d3-array"
+    "d3-array",
+    "motion"
   ],
   "registryDependencies": [
     "@bklit/utils"

--- a/apps/web/public/r/choropleth-chart.json
+++ b/apps/web/public/r/choropleth-chart.json
@@ -5,6 +5,7 @@
   "title": "Choropleth Map",
   "description": "A geographic map chart with zoom, pan, and data visualization",
   "dependencies": [
+    "@types/geojson",
     "@visx/geo@4.0.1-alpha.0",
     "@visx/responsive@4.0.1-alpha.0",
     "@visx/zoom@4.0.1-alpha.0",

--- a/apps/web/public/r/legend.json
+++ b/apps/web/public/r/legend.json
@@ -5,6 +5,7 @@
   "title": "Chart Legend",
   "description": "Composable legend components for charts",
   "dependencies": [
+    "@base-ui/react",
     "@number-flow/react"
   ],
   "registryDependencies": [

--- a/apps/web/public/r/pie-chart.json
+++ b/apps/web/public/r/pie-chart.json
@@ -6,6 +6,7 @@
   "description": "A composable pie chart with animations and customizable slices",
   "dependencies": [
     "@number-flow/react",
+    "@visx/group@4.0.1-alpha.0",
     "@visx/responsive@4.0.1-alpha.0",
     "@visx/shape@4.0.1-alpha.0",
     "d3-shape",

--- a/apps/web/public/r/radar-chart.json
+++ b/apps/web/public/r/radar-chart.json
@@ -5,7 +5,10 @@
   "title": "Radar Chart",
   "description": "A composable radar/spider chart with multiple data series",
   "dependencies": [
+    "@visx/group@4.0.1-alpha.0",
     "@visx/responsive@4.0.1-alpha.0",
+    "@visx/scale@4.0.1-alpha.0",
+    "@visx/shape@4.0.1-alpha.0",
     "d3-shape",
     "motion"
   ],

--- a/apps/web/public/r/registry.json
+++ b/apps/web/public/r/registry.json
@@ -32,7 +32,8 @@
         "@visx/event@4.0.1-alpha.0",
         "@visx/responsive@4.0.1-alpha.0",
         "@visx/scale@4.0.1-alpha.0",
-        "d3-array"
+        "d3-array",
+        "motion"
       ],
       "cssVars": {
         "light": {
@@ -237,6 +238,7 @@
         "@bklit/utils"
       ],
       "dependencies": [
+        "@base-ui/react",
         "@number-flow/react"
       ],
       "cssVars": {
@@ -753,6 +755,7 @@
         "@bklit/utils"
       ],
       "dependencies": [
+        "@types/geojson",
         "@visx/geo@4.0.1-alpha.0",
         "@visx/responsive@4.0.1-alpha.0",
         "@visx/zoom@4.0.1-alpha.0",
@@ -823,10 +826,12 @@
         "@bklit/utils"
       ],
       "dependencies": [
+        "@visx/event@4.0.1-alpha.0",
         "@visx/gradient@4.0.1-alpha.0",
         "@visx/pattern@4.0.1-alpha.0",
         "@visx/responsive@4.0.1-alpha.0",
         "@visx/sankey@4.0.1-alpha.0",
+        "d3-sankey",
         "motion"
       ],
       "files": [

--- a/apps/web/public/r/registry.json
+++ b/apps/web/public/r/registry.json
@@ -567,6 +567,7 @@
       ],
       "dependencies": [
         "@number-flow/react",
+        "@visx/group@4.0.1-alpha.0",
         "@visx/responsive@4.0.1-alpha.0",
         "@visx/shape@4.0.1-alpha.0",
         "d3-shape",
@@ -615,7 +616,10 @@
         "@bklit/utils"
       ],
       "dependencies": [
+        "@visx/group@4.0.1-alpha.0",
         "@visx/responsive@4.0.1-alpha.0",
+        "@visx/scale@4.0.1-alpha.0",
+        "@visx/shape@4.0.1-alpha.0",
         "d3-shape",
         "motion"
       ],
@@ -662,7 +666,9 @@
         "@bklit/utils"
       ],
       "dependencies": [
+        "@visx/group@4.0.1-alpha.0",
         "@visx/responsive@4.0.1-alpha.0",
+        "@visx/shape@4.0.1-alpha.0",
         "@number-flow/react",
         "motion"
       ],

--- a/apps/web/public/r/ring-chart.json
+++ b/apps/web/public/r/ring-chart.json
@@ -5,7 +5,9 @@
   "title": "Ring Chart",
   "description": "A composable donut/ring chart with progress indicators",
   "dependencies": [
+    "@visx/group@4.0.1-alpha.0",
     "@visx/responsive@4.0.1-alpha.0",
+    "@visx/shape@4.0.1-alpha.0",
     "@number-flow/react",
     "motion"
   ],

--- a/apps/web/public/r/sankey-chart.json
+++ b/apps/web/public/r/sankey-chart.json
@@ -5,10 +5,12 @@
   "title": "Sankey Diagram",
   "description": "A flow diagram for visualizing data transfers between nodes",
   "dependencies": [
+    "@visx/event@4.0.1-alpha.0",
     "@visx/gradient@4.0.1-alpha.0",
     "@visx/pattern@4.0.1-alpha.0",
     "@visx/responsive@4.0.1-alpha.0",
     "@visx/sankey@4.0.1-alpha.0",
+    "d3-sankey",
     "motion"
   ],
   "registryDependencies": [

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -18,7 +18,7 @@
   "scripts": {
     "lint": "eslint . --max-warnings 0",
     "check-types": "tsc --noEmit",
-    "registry:build": "node scripts/generate-v0-examples.mjs && shadcn build --output ../../apps/web/public/r && cp registry.json ../../apps/web/public/r/registry.json"
+    "registry:build": "node scripts/verify-registry-deps.mjs && node scripts/generate-v0-examples.mjs && shadcn build --output ../../apps/web/public/r && cp registry.json ../../apps/web/public/r/registry.json"
   },
   "devDependencies": {
     "@bklitui/eslint-config": "workspace:*",

--- a/packages/ui/registry.json
+++ b/packages/ui/registry.json
@@ -27,7 +27,8 @@
         "@visx/event@4.0.1-alpha.0",
         "@visx/responsive@4.0.1-alpha.0",
         "@visx/scale@4.0.1-alpha.0",
-        "d3-array"
+        "d3-array",
+        "motion"
       ],
       "cssVars": {
         "light": {
@@ -211,7 +212,7 @@
       "title": "Chart Legend",
       "description": "Composable legend components for charts",
       "registryDependencies": ["@bklit/utils"],
-      "dependencies": ["@number-flow/react"],
+      "dependencies": ["@base-ui/react", "@number-flow/react"],
       "cssVars": {
         "light": {
           "--legend": "oklch(1 0 0)",
@@ -712,6 +713,7 @@
       "description": "A geographic map chart with zoom, pan, and data visualization",
       "registryDependencies": ["@bklit/chart-animation", "@bklit/utils"],
       "dependencies": [
+        "@types/geojson",
         "@visx/geo@4.0.1-alpha.0",
         "@visx/responsive@4.0.1-alpha.0",
         "@visx/zoom@4.0.1-alpha.0",
@@ -774,10 +776,12 @@
       "description": "A flow diagram for visualizing data transfers between nodes",
       "registryDependencies": ["@bklit/chart-animation", "@bklit/utils"],
       "dependencies": [
+        "@visx/event@4.0.1-alpha.0",
         "@visx/gradient@4.0.1-alpha.0",
         "@visx/pattern@4.0.1-alpha.0",
         "@visx/responsive@4.0.1-alpha.0",
         "@visx/sankey@4.0.1-alpha.0",
+        "d3-sankey",
         "motion"
       ],
       "files": [

--- a/packages/ui/registry.json
+++ b/packages/ui/registry.json
@@ -8,10 +8,7 @@
       "type": "registry:lib",
       "title": "Utilities",
       "description": "Utility functions for className merging with clsx and tailwind-merge",
-      "dependencies": [
-        "clsx",
-        "tailwind-merge"
-      ],
+      "dependencies": ["clsx", "tailwind-merge"],
       "files": [
         {
           "path": "src/lib/utils.ts",
@@ -25,9 +22,7 @@
       "type": "registry:component",
       "title": "Chart Context",
       "description": "Shared context and hooks for Bklit chart components",
-      "registryDependencies": [
-        "@bklit/utils"
-      ],
+      "registryDependencies": ["@bklit/utils"],
       "dependencies": [
         "@visx/event@4.0.1-alpha.0",
         "@visx/responsive@4.0.1-alpha.0",
@@ -93,9 +88,7 @@
       "type": "registry:component",
       "title": "Chart Animation",
       "description": "Shared motion helpers for chart enter transitions, clip reveals, and staggered animations",
-      "dependencies": [
-        "motion"
-      ],
+      "dependencies": ["motion"],
       "files": [
         {
           "path": "src/charts/animation.ts",
@@ -129,12 +122,8 @@
       "type": "registry:component",
       "title": "Chart Grid",
       "description": "Grid lines for charts",
-      "registryDependencies": [
-        "@bklit/chart-context"
-      ],
-      "dependencies": [
-        "@visx/grid@4.0.1-alpha.0"
-      ],
+      "registryDependencies": ["@bklit/chart-context"],
+      "dependencies": ["@visx/grid@4.0.1-alpha.0"],
       "files": [
         {
           "path": "src/charts/grid.tsx",
@@ -148,10 +137,7 @@
       "type": "registry:component",
       "title": "X Axis",
       "description": "X-axis component for time-series charts",
-      "registryDependencies": [
-        "@bklit/chart-context",
-        "@bklit/utils"
-      ],
+      "registryDependencies": ["@bklit/chart-context", "@bklit/utils"],
       "files": [
         {
           "path": "src/charts/x-axis.tsx",
@@ -165,10 +151,7 @@
       "type": "registry:component",
       "title": "Y Axis",
       "description": "Y-axis component for value labels in line and area charts",
-      "registryDependencies": [
-        "@bklit/chart-context",
-        "@bklit/utils"
-      ],
+      "registryDependencies": ["@bklit/chart-context", "@bklit/utils"],
       "files": [
         {
           "path": "src/charts/y-axis.tsx",
@@ -182,14 +165,8 @@
       "type": "registry:component",
       "title": "Chart Tooltip",
       "description": "Composable tooltip components for charts",
-      "registryDependencies": [
-        "@bklit/chart-context",
-        "@bklit/utils"
-      ],
-      "dependencies": [
-        "@number-flow/react",
-        "motion"
-      ],
+      "registryDependencies": ["@bklit/chart-context", "@bklit/utils"],
+      "dependencies": ["@number-flow/react", "motion"],
       "files": [
         {
           "path": "src/charts/tooltip/chart-tooltip.tsx",
@@ -233,12 +210,8 @@
       "type": "registry:component",
       "title": "Chart Legend",
       "description": "Composable legend components for charts",
-      "registryDependencies": [
-        "@bklit/utils"
-      ],
-      "dependencies": [
-        "@number-flow/react"
-      ],
+      "registryDependencies": ["@bklit/utils"],
+      "dependencies": ["@number-flow/react"],
       "cssVars": {
         "light": {
           "--legend": "oklch(1 0 0)",
@@ -561,10 +534,7 @@
       "type": "registry:component",
       "title": "Pie Chart",
       "description": "A composable pie chart with animations and customizable slices",
-      "registryDependencies": [
-        "@bklit/chart-animation",
-        "@bklit/utils"
-      ],
+      "registryDependencies": ["@bklit/chart-animation", "@bklit/utils"],
       "dependencies": [
         "@number-flow/react",
         "@visx/group@4.0.1-alpha.0",
@@ -611,10 +581,7 @@
       "type": "registry:component",
       "title": "Radar Chart",
       "description": "A composable radar/spider chart with multiple data series",
-      "registryDependencies": [
-        "@bklit/chart-animation",
-        "@bklit/utils"
-      ],
+      "registryDependencies": ["@bklit/chart-animation", "@bklit/utils"],
       "dependencies": [
         "@visx/group@4.0.1-alpha.0",
         "@visx/responsive@4.0.1-alpha.0",
@@ -661,10 +628,7 @@
       "type": "registry:component",
       "title": "Ring Chart",
       "description": "A composable donut/ring chart with progress indicators",
-      "registryDependencies": [
-        "@bklit/chart-animation",
-        "@bklit/utils"
-      ],
+      "registryDependencies": ["@bklit/chart-animation", "@bklit/utils"],
       "dependencies": [
         "@visx/group@4.0.1-alpha.0",
         "@visx/responsive@4.0.1-alpha.0",
@@ -705,9 +669,7 @@
       "type": "registry:component",
       "title": "Gauge",
       "description": "Notch-based radial gauge with PieCenter-style center, patterns, and optional arc gradients",
-      "registryDependencies": [
-        "@bklit/utils"
-      ],
+      "registryDependencies": ["@bklit/utils"],
       "dependencies": [
         "@visx/responsive@4.0.1-alpha.0",
         "@visx/pattern@4.0.1-alpha.0",
@@ -748,10 +710,7 @@
       "type": "registry:component",
       "title": "Choropleth Map",
       "description": "A geographic map chart with zoom, pan, and data visualization",
-      "registryDependencies": [
-        "@bklit/chart-animation",
-        "@bklit/utils"
-      ],
+      "registryDependencies": ["@bklit/chart-animation", "@bklit/utils"],
       "dependencies": [
         "@visx/geo@4.0.1-alpha.0",
         "@visx/responsive@4.0.1-alpha.0",
@@ -798,13 +757,8 @@
       "type": "registry:component",
       "title": "Funnel Chart",
       "description": "An animated funnel chart with multi-layer halo rings, hover interactions, and staggered entrance animations",
-      "registryDependencies": [
-        "@bklit/chart-animation",
-        "@bklit/utils"
-      ],
-      "dependencies": [
-        "motion"
-      ],
+      "registryDependencies": ["@bklit/chart-animation", "@bklit/utils"],
+      "dependencies": ["motion"],
       "files": [
         {
           "path": "src/charts/funnel-chart.tsx",
@@ -818,10 +772,7 @@
       "type": "registry:component",
       "title": "Sankey Diagram",
       "description": "A flow diagram for visualizing data transfers between nodes",
-      "registryDependencies": [
-        "@bklit/chart-animation",
-        "@bklit/utils"
-      ],
+      "registryDependencies": ["@bklit/chart-animation", "@bklit/utils"],
       "dependencies": [
         "@visx/gradient@4.0.1-alpha.0",
         "@visx/pattern@4.0.1-alpha.0",
@@ -954,13 +905,8 @@
       "type": "registry:example",
       "title": "Pie Chart Example",
       "description": "Composable pie-chart demo for Open in v0",
-      "registryDependencies": [
-        "@bklit/pie-chart"
-      ],
-      "dependencies": [
-        "@visx/shape@4.0.1-alpha.0",
-        "motion"
-      ],
+      "registryDependencies": ["@bklit/pie-chart"],
+      "dependencies": ["@visx/shape@4.0.1-alpha.0", "motion"],
       "files": [
         {
           "path": "registry/examples/pie-chart.tsx",
@@ -979,13 +925,8 @@
       "type": "registry:example",
       "title": "Gauge Chart Example",
       "description": "Composable gauge-chart demo for Open in v0",
-      "registryDependencies": [
-        "@bklit/gauge-chart"
-      ],
-      "dependencies": [
-        "@visx/shape@4.0.1-alpha.0",
-        "motion"
-      ],
+      "registryDependencies": ["@bklit/gauge-chart"],
+      "dependencies": ["@visx/shape@4.0.1-alpha.0", "motion"],
       "files": [
         {
           "path": "registry/examples/gauge-chart.tsx",
@@ -1004,13 +945,8 @@
       "type": "registry:example",
       "title": "Ring Chart Example",
       "description": "Composable ring-chart demo for Open in v0",
-      "registryDependencies": [
-        "@bklit/ring-chart"
-      ],
-      "dependencies": [
-        "@visx/shape@4.0.1-alpha.0",
-        "motion"
-      ],
+      "registryDependencies": ["@bklit/ring-chart"],
+      "dependencies": ["@visx/shape@4.0.1-alpha.0", "motion"],
       "files": [
         {
           "path": "registry/examples/ring-chart.tsx",
@@ -1029,13 +965,8 @@
       "type": "registry:example",
       "title": "Radar Chart Example",
       "description": "Composable radar-chart demo for Open in v0",
-      "registryDependencies": [
-        "@bklit/radar-chart"
-      ],
-      "dependencies": [
-        "@visx/shape@4.0.1-alpha.0",
-        "motion"
-      ],
+      "registryDependencies": ["@bklit/radar-chart"],
+      "dependencies": ["@visx/shape@4.0.1-alpha.0", "motion"],
       "files": [
         {
           "path": "registry/examples/radar-chart.tsx",
@@ -1083,13 +1014,8 @@
       "type": "registry:example",
       "title": "Funnel Chart Example",
       "description": "Composable funnel-chart demo for Open in v0",
-      "registryDependencies": [
-        "@bklit/funnel-chart"
-      ],
-      "dependencies": [
-        "@visx/shape@4.0.1-alpha.0",
-        "motion"
-      ],
+      "registryDependencies": ["@bklit/funnel-chart"],
+      "dependencies": ["@visx/shape@4.0.1-alpha.0", "motion"],
       "files": [
         {
           "path": "registry/examples/funnel-chart.tsx",
@@ -1108,9 +1034,7 @@
       "type": "registry:example",
       "title": "Sankey Chart Example",
       "description": "Composable sankey-chart demo for Open in v0",
-      "registryDependencies": [
-        "@bklit/sankey-chart"
-      ],
+      "registryDependencies": ["@bklit/sankey-chart"],
       "dependencies": [
         "@visx/sankey@4.0.1-alpha.0",
         "@visx/shape@4.0.1-alpha.0",
@@ -1141,10 +1065,7 @@
         "@bklit/y-axis",
         "@bklit/chart-tooltip"
       ],
-      "dependencies": [
-        "@visx/shape@4.0.1-alpha.0",
-        "motion"
-      ],
+      "dependencies": ["@visx/shape@4.0.1-alpha.0", "motion"],
       "files": [
         {
           "path": "registry/examples/candlestick-chart.tsx",
@@ -1163,14 +1084,8 @@
       "type": "registry:example",
       "title": "Choropleth Chart Example",
       "description": "Composable choropleth-chart demo for Open in v0",
-      "registryDependencies": [
-        "@bklit/choropleth-chart"
-      ],
-      "dependencies": [
-        "@visx/geo@4.0.1-alpha.0",
-        "d3-geo",
-        "topojson-client"
-      ],
+      "registryDependencies": ["@bklit/choropleth-chart"],
+      "dependencies": ["@visx/geo@4.0.1-alpha.0", "d3-geo", "topojson-client"],
       "files": [
         {
           "path": "registry/examples/choropleth-chart.tsx",

--- a/packages/ui/registry.json
+++ b/packages/ui/registry.json
@@ -8,7 +8,10 @@
       "type": "registry:lib",
       "title": "Utilities",
       "description": "Utility functions for className merging with clsx and tailwind-merge",
-      "dependencies": ["clsx", "tailwind-merge"],
+      "dependencies": [
+        "clsx",
+        "tailwind-merge"
+      ],
       "files": [
         {
           "path": "src/lib/utils.ts",
@@ -22,7 +25,9 @@
       "type": "registry:component",
       "title": "Chart Context",
       "description": "Shared context and hooks for Bklit chart components",
-      "registryDependencies": ["@bklit/utils"],
+      "registryDependencies": [
+        "@bklit/utils"
+      ],
       "dependencies": [
         "@visx/event@4.0.1-alpha.0",
         "@visx/responsive@4.0.1-alpha.0",
@@ -88,7 +93,9 @@
       "type": "registry:component",
       "title": "Chart Animation",
       "description": "Shared motion helpers for chart enter transitions, clip reveals, and staggered animations",
-      "dependencies": ["motion"],
+      "dependencies": [
+        "motion"
+      ],
       "files": [
         {
           "path": "src/charts/animation.ts",
@@ -122,8 +129,12 @@
       "type": "registry:component",
       "title": "Chart Grid",
       "description": "Grid lines for charts",
-      "registryDependencies": ["@bklit/chart-context"],
-      "dependencies": ["@visx/grid@4.0.1-alpha.0"],
+      "registryDependencies": [
+        "@bklit/chart-context"
+      ],
+      "dependencies": [
+        "@visx/grid@4.0.1-alpha.0"
+      ],
       "files": [
         {
           "path": "src/charts/grid.tsx",
@@ -137,7 +148,10 @@
       "type": "registry:component",
       "title": "X Axis",
       "description": "X-axis component for time-series charts",
-      "registryDependencies": ["@bklit/chart-context", "@bklit/utils"],
+      "registryDependencies": [
+        "@bklit/chart-context",
+        "@bklit/utils"
+      ],
       "files": [
         {
           "path": "src/charts/x-axis.tsx",
@@ -151,7 +165,10 @@
       "type": "registry:component",
       "title": "Y Axis",
       "description": "Y-axis component for value labels in line and area charts",
-      "registryDependencies": ["@bklit/chart-context", "@bklit/utils"],
+      "registryDependencies": [
+        "@bklit/chart-context",
+        "@bklit/utils"
+      ],
       "files": [
         {
           "path": "src/charts/y-axis.tsx",
@@ -165,8 +182,14 @@
       "type": "registry:component",
       "title": "Chart Tooltip",
       "description": "Composable tooltip components for charts",
-      "registryDependencies": ["@bklit/chart-context", "@bklit/utils"],
-      "dependencies": ["@number-flow/react", "motion"],
+      "registryDependencies": [
+        "@bklit/chart-context",
+        "@bklit/utils"
+      ],
+      "dependencies": [
+        "@number-flow/react",
+        "motion"
+      ],
       "files": [
         {
           "path": "src/charts/tooltip/chart-tooltip.tsx",
@@ -210,8 +233,12 @@
       "type": "registry:component",
       "title": "Chart Legend",
       "description": "Composable legend components for charts",
-      "registryDependencies": ["@bklit/utils"],
-      "dependencies": ["@number-flow/react"],
+      "registryDependencies": [
+        "@bklit/utils"
+      ],
+      "dependencies": [
+        "@number-flow/react"
+      ],
       "cssVars": {
         "light": {
           "--legend": "oklch(1 0 0)",
@@ -534,9 +561,13 @@
       "type": "registry:component",
       "title": "Pie Chart",
       "description": "A composable pie chart with animations and customizable slices",
-      "registryDependencies": ["@bklit/chart-animation", "@bklit/utils"],
+      "registryDependencies": [
+        "@bklit/chart-animation",
+        "@bklit/utils"
+      ],
       "dependencies": [
         "@number-flow/react",
+        "@visx/group@4.0.1-alpha.0",
         "@visx/responsive@4.0.1-alpha.0",
         "@visx/shape@4.0.1-alpha.0",
         "d3-shape",
@@ -580,8 +611,18 @@
       "type": "registry:component",
       "title": "Radar Chart",
       "description": "A composable radar/spider chart with multiple data series",
-      "registryDependencies": ["@bklit/chart-animation", "@bklit/utils"],
-      "dependencies": ["@visx/responsive@4.0.1-alpha.0", "d3-shape", "motion"],
+      "registryDependencies": [
+        "@bklit/chart-animation",
+        "@bklit/utils"
+      ],
+      "dependencies": [
+        "@visx/group@4.0.1-alpha.0",
+        "@visx/responsive@4.0.1-alpha.0",
+        "@visx/scale@4.0.1-alpha.0",
+        "@visx/shape@4.0.1-alpha.0",
+        "d3-shape",
+        "motion"
+      ],
       "files": [
         {
           "path": "src/charts/radar-chart.tsx",
@@ -620,9 +661,14 @@
       "type": "registry:component",
       "title": "Ring Chart",
       "description": "A composable donut/ring chart with progress indicators",
-      "registryDependencies": ["@bklit/chart-animation", "@bklit/utils"],
+      "registryDependencies": [
+        "@bklit/chart-animation",
+        "@bklit/utils"
+      ],
       "dependencies": [
+        "@visx/group@4.0.1-alpha.0",
         "@visx/responsive@4.0.1-alpha.0",
+        "@visx/shape@4.0.1-alpha.0",
         "@number-flow/react",
         "motion"
       ],
@@ -659,7 +705,9 @@
       "type": "registry:component",
       "title": "Gauge",
       "description": "Notch-based radial gauge with PieCenter-style center, patterns, and optional arc gradients",
-      "registryDependencies": ["@bklit/utils"],
+      "registryDependencies": [
+        "@bklit/utils"
+      ],
       "dependencies": [
         "@visx/responsive@4.0.1-alpha.0",
         "@visx/pattern@4.0.1-alpha.0",
@@ -700,7 +748,10 @@
       "type": "registry:component",
       "title": "Choropleth Map",
       "description": "A geographic map chart with zoom, pan, and data visualization",
-      "registryDependencies": ["@bklit/chart-animation", "@bklit/utils"],
+      "registryDependencies": [
+        "@bklit/chart-animation",
+        "@bklit/utils"
+      ],
       "dependencies": [
         "@visx/geo@4.0.1-alpha.0",
         "@visx/responsive@4.0.1-alpha.0",
@@ -747,8 +798,13 @@
       "type": "registry:component",
       "title": "Funnel Chart",
       "description": "An animated funnel chart with multi-layer halo rings, hover interactions, and staggered entrance animations",
-      "registryDependencies": ["@bklit/chart-animation", "@bklit/utils"],
-      "dependencies": ["motion"],
+      "registryDependencies": [
+        "@bklit/chart-animation",
+        "@bklit/utils"
+      ],
+      "dependencies": [
+        "motion"
+      ],
       "files": [
         {
           "path": "src/charts/funnel-chart.tsx",
@@ -762,7 +818,10 @@
       "type": "registry:component",
       "title": "Sankey Diagram",
       "description": "A flow diagram for visualizing data transfers between nodes",
-      "registryDependencies": ["@bklit/chart-animation", "@bklit/utils"],
+      "registryDependencies": [
+        "@bklit/chart-animation",
+        "@bklit/utils"
+      ],
       "dependencies": [
         "@visx/gradient@4.0.1-alpha.0",
         "@visx/pattern@4.0.1-alpha.0",
@@ -895,8 +954,13 @@
       "type": "registry:example",
       "title": "Pie Chart Example",
       "description": "Composable pie-chart demo for Open in v0",
-      "registryDependencies": ["@bklit/pie-chart"],
-      "dependencies": ["@visx/shape@4.0.1-alpha.0", "motion"],
+      "registryDependencies": [
+        "@bklit/pie-chart"
+      ],
+      "dependencies": [
+        "@visx/shape@4.0.1-alpha.0",
+        "motion"
+      ],
       "files": [
         {
           "path": "registry/examples/pie-chart.tsx",
@@ -915,8 +979,13 @@
       "type": "registry:example",
       "title": "Gauge Chart Example",
       "description": "Composable gauge-chart demo for Open in v0",
-      "registryDependencies": ["@bklit/gauge-chart"],
-      "dependencies": ["@visx/shape@4.0.1-alpha.0", "motion"],
+      "registryDependencies": [
+        "@bklit/gauge-chart"
+      ],
+      "dependencies": [
+        "@visx/shape@4.0.1-alpha.0",
+        "motion"
+      ],
       "files": [
         {
           "path": "registry/examples/gauge-chart.tsx",
@@ -935,8 +1004,13 @@
       "type": "registry:example",
       "title": "Ring Chart Example",
       "description": "Composable ring-chart demo for Open in v0",
-      "registryDependencies": ["@bklit/ring-chart"],
-      "dependencies": ["@visx/shape@4.0.1-alpha.0", "motion"],
+      "registryDependencies": [
+        "@bklit/ring-chart"
+      ],
+      "dependencies": [
+        "@visx/shape@4.0.1-alpha.0",
+        "motion"
+      ],
       "files": [
         {
           "path": "registry/examples/ring-chart.tsx",
@@ -955,8 +1029,13 @@
       "type": "registry:example",
       "title": "Radar Chart Example",
       "description": "Composable radar-chart demo for Open in v0",
-      "registryDependencies": ["@bklit/radar-chart"],
-      "dependencies": ["@visx/shape@4.0.1-alpha.0", "motion"],
+      "registryDependencies": [
+        "@bklit/radar-chart"
+      ],
+      "dependencies": [
+        "@visx/shape@4.0.1-alpha.0",
+        "motion"
+      ],
       "files": [
         {
           "path": "registry/examples/radar-chart.tsx",
@@ -1004,8 +1083,13 @@
       "type": "registry:example",
       "title": "Funnel Chart Example",
       "description": "Composable funnel-chart demo for Open in v0",
-      "registryDependencies": ["@bklit/funnel-chart"],
-      "dependencies": ["@visx/shape@4.0.1-alpha.0", "motion"],
+      "registryDependencies": [
+        "@bklit/funnel-chart"
+      ],
+      "dependencies": [
+        "@visx/shape@4.0.1-alpha.0",
+        "motion"
+      ],
       "files": [
         {
           "path": "registry/examples/funnel-chart.tsx",
@@ -1024,7 +1108,9 @@
       "type": "registry:example",
       "title": "Sankey Chart Example",
       "description": "Composable sankey-chart demo for Open in v0",
-      "registryDependencies": ["@bklit/sankey-chart"],
+      "registryDependencies": [
+        "@bklit/sankey-chart"
+      ],
       "dependencies": [
         "@visx/sankey@4.0.1-alpha.0",
         "@visx/shape@4.0.1-alpha.0",
@@ -1055,7 +1141,10 @@
         "@bklit/y-axis",
         "@bklit/chart-tooltip"
       ],
-      "dependencies": ["@visx/shape@4.0.1-alpha.0", "motion"],
+      "dependencies": [
+        "@visx/shape@4.0.1-alpha.0",
+        "motion"
+      ],
       "files": [
         {
           "path": "registry/examples/candlestick-chart.tsx",
@@ -1074,8 +1163,14 @@
       "type": "registry:example",
       "title": "Choropleth Chart Example",
       "description": "Composable choropleth-chart demo for Open in v0",
-      "registryDependencies": ["@bklit/choropleth-chart"],
-      "dependencies": ["@visx/geo@4.0.1-alpha.0", "d3-geo", "topojson-client"],
+      "registryDependencies": [
+        "@bklit/choropleth-chart"
+      ],
+      "dependencies": [
+        "@visx/geo@4.0.1-alpha.0",
+        "d3-geo",
+        "topojson-client"
+      ],
       "files": [
         {
           "path": "registry/examples/choropleth-chart.tsx",

--- a/packages/ui/scripts/verify-registry-deps.mjs
+++ b/packages/ui/scripts/verify-registry-deps.mjs
@@ -1,0 +1,169 @@
+#!/usr/bin/env node
+/**
+ * Verifies registry item `dependencies` cover all npm imports in the item's
+ * file tree plus transitive @bklit registryDependencies (shadcn / v0 install closure).
+ */
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const uiRoot = path.join(__dirname, "..");
+const registryPath = path.join(uiRoot, "registry.json");
+
+const registry = JSON.parse(fs.readFileSync(registryPath, "utf8"));
+const byName = Object.fromEntries(
+  registry.items.map((item) => [item.name, item])
+);
+
+const importRe =
+  /(?:import|export)\s+(?:type\s+)?(?:[^'"]+\s+from\s+)?['"]([^'"]+)['"]/g;
+const DEP_VERSION_SUFFIX_RE = /@[\d.]+(-[\w.]+)?$/;
+const BKLIT_REGISTRY_DEP_RE = /^@bklit\/(.+)$/;
+
+function getPackageName(spec) {
+  if (spec.startsWith(".") || spec.startsWith("@/")) {
+    return null;
+  }
+  if (spec.startsWith("@")) {
+    const parts = spec.split("/");
+    return `${parts[0]}/${parts[1]}`;
+  }
+  return spec.split("/")[0];
+}
+
+function normalizeDep(dep) {
+  return dep.replace(DEP_VERSION_SUFFIX_RE, "");
+}
+
+/** Import specifiers that are satisfied by @types/* registry dependencies. */
+const TYPES_ALIASES = {
+  geojson: ["geojson", "@types/geojson"],
+};
+
+function isDeclared(pkg, declared) {
+  if (declared.has(pkg)) {
+    return true;
+  }
+  const aliases = TYPES_ALIASES[pkg];
+  if (aliases) {
+    return aliases.some((name) => declared.has(name));
+  }
+  return false;
+}
+
+function scanFiles(files) {
+  const used = new Set();
+  for (const file of files ?? []) {
+    const fullPath = path.join(uiRoot, file.path);
+    if (!fs.existsSync(fullPath)) {
+      throw new Error(`Registry file not found: ${file.path}`);
+    }
+    const content = fs.readFileSync(fullPath, "utf8");
+    importRe.lastIndex = 0;
+    let match = importRe.exec(content);
+    while (match) {
+      const pkg = getPackageName(match[1]);
+      if (pkg && pkg !== "react" && pkg !== "react-dom") {
+        used.add(pkg);
+      }
+      match = importRe.exec(content);
+    }
+  }
+  return used;
+}
+
+function getRegistryDepName(dep) {
+  const m = dep.match(BKLIT_REGISTRY_DEP_RE);
+  return m ? m[1] : null;
+}
+
+function collectDeclared(name, visited = new Set()) {
+  const declared = new Set();
+  const visit = (itemName) => {
+    if (visited.has(itemName)) {
+      return;
+    }
+    visited.add(itemName);
+    const item = byName[itemName];
+    if (!item) {
+      return;
+    }
+    for (const dep of item.dependencies ?? []) {
+      declared.add(normalizeDep(dep));
+    }
+    for (const regDep of item.registryDependencies ?? []) {
+      const nested = getRegistryDepName(regDep);
+      if (nested) {
+        visit(nested);
+      }
+    }
+  };
+  visit(name);
+  return declared;
+}
+
+function collectUsed(name, visited = new Set()) {
+  const used = new Set();
+  const visit = (itemName) => {
+    if (visited.has(itemName)) {
+      return;
+    }
+    visited.add(itemName);
+    const item = byName[itemName];
+    if (!item) {
+      return;
+    }
+    for (const pkg of scanFiles(item.files)) {
+      used.add(pkg);
+    }
+    for (const regDep of item.registryDependencies ?? []) {
+      const nested = getRegistryDepName(regDep);
+      if (nested) {
+        visit(nested);
+      }
+    }
+  };
+  visit(name);
+  return used;
+}
+
+const chartItems = registry.items.filter(
+  (item) =>
+    item.type === "registry:component" &&
+    (item.name.endsWith("-chart") ||
+      item.name === "chart-context" ||
+      item.name === "chart-animation")
+);
+
+const utilityItems = registry.items.filter((item) =>
+  ["grid", "x-axis", "y-axis", "chart-tooltip", "legend", "markers"].includes(
+    item.name
+  )
+);
+
+const failures = [];
+
+for (const item of [...chartItems, ...utilityItems]) {
+  const declared = collectDeclared(item.name);
+  const used = collectUsed(item.name);
+  const missing = [...used].filter((pkg) => !isDeclared(pkg, declared)).sort();
+  if (missing.length > 0) {
+    failures.push({ name: item.name, missing });
+  }
+}
+
+if (failures.length > 0) {
+  console.error("Registry dependency closure check failed:\n");
+  for (const { name, missing } of failures) {
+    console.error(`  ${name}: missing ${missing.join(", ")}`);
+  }
+  console.error(
+    "\nAdd missing packages to `dependencies` in packages/ui/registry.json (on the item or a registryDependency)."
+  );
+  process.exit(1);
+}
+
+console.log(
+  `Registry dependency closure OK (${chartItems.length + utilityItems.length} items checked).`
+);


### PR DESCRIPTION
## Summary

- Fix missing npm dependencies on pie, ring, and radar charts (`@visx/group`, `@visx/shape`, `@visx/scale`) so Open in v0 and `shadcn add @bklit/pie-chart` resolve modules correctly.
- Audit all chart registry install closures and add gaps on chart-context (`motion`), legend (`@base-ui/react`), choropleth (`@types/geojson`), and sankey (`@visx/event`, `d3-sankey`).
- Add `verify-registry-deps.mjs` to `registry:build` so future registry changes fail CI if a chart’s dependency closure is incomplete.

## Context

Follow-up v0/shadcn install fixes after #70 and #71 (chart-animation). Caught via pie-chart `Can't resolve '@visx/group'` and a full closure pass across all charts.

## Test plan

- [x] `pnpm lint` passes at repo root
- [x] `pnpm build` succeeds
- [ ] `node packages/ui/scripts/verify-registry-deps.mjs` passes
- [ ] Open pie chart in v0 — no `@visx/group` module error
- [ ] `pnpm dlx shadcn@latest add @bklit/pie-chart` in a fresh app installs and builds
- [ ] Spot-check sankey and choropleth in v0 after deploy (`ui.bklit.com/r/*`)

## Deploy notes

Registry JSON under `apps/web/public/r/` must be deployed for live Open in v0 links to pick up new `dependencies` arrays.


Made with [Cursor](https://cursor.com)