### PR TITLE
Unify preview cards and refine dark theme surfaces

### DIFF
--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -143,13 +143,13 @@
   /* Shadcn dark variables */
   --background: oklch(0.14 0.0047 263.79);
   --foreground: oklch(0.987 0.002 197.1);
-  --card: oklch(0.19 0.0087 223.98);
+  --card: oklch(0.17 0.0065 271.01);
   --card-foreground: oklch(0.987 0.002 197.1);
   --popover: oklch(0.21 0.0058 285.9);
   --popover-foreground: oklch(0.987 0.002 197.1);
   --primary: oklch(0.925 0.005 214.3);
   --primary-foreground: oklch(0.218 0.008 223.9);
-  --secondary: oklch(0.275 0.011 216.9);
+  --secondary: oklch(0.26 0.0134 272.84);
   --secondary-foreground: oklch(0.987 0.002 197.1);
   --muted: oklch(0.26 0.0134 272.84);
   --muted-foreground: oklch(0.723 0.014 214.4);

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -141,22 +141,22 @@
 
 .dark {
   /* Shadcn dark variables */
-  --background: oklch(0.148 0.004 228.8);
+  --background: oklch(0.14 0.0047 263.79);
   --foreground: oklch(0.987 0.002 197.1);
-  --card: oklch(0.218 0.008 223.9);
+  --card: oklch(0.19 0.0087 223.98);
   --card-foreground: oklch(0.987 0.002 197.1);
-  --popover: oklch(0.218 0.008 223.9);
+  --popover: oklch(0.21 0.0058 285.9);
   --popover-foreground: oklch(0.987 0.002 197.1);
   --primary: oklch(0.925 0.005 214.3);
   --primary-foreground: oklch(0.218 0.008 223.9);
   --secondary: oklch(0.275 0.011 216.9);
   --secondary-foreground: oklch(0.987 0.002 197.1);
-  --muted: oklch(0.275 0.011 216.9);
+  --muted: oklch(0.26 0.0134 272.84);
   --muted-foreground: oklch(0.723 0.014 214.4);
-  --accent: oklch(0.275 0.011 216.9);
+  --accent: oklch(0.26 0.0134 272.84);
   --accent-foreground: oklch(0.987 0.002 197.1);
   --destructive: oklch(0.704 0.191 22.216);
-  --border: oklch(1 0 0 / 10%);
+  --border: oklch(0.56 0.0195 267.65 / 0.1);
   --input: oklch(1 0 0 / 15%);
   --ring: oklch(0.56 0.021 213.5);
   --chart-1: oklch(0.865 0.127 207.078);
@@ -177,8 +177,8 @@
   --chart-background: oklch(0.145 0 0);
   --chart-foreground: oklch(0.45 0 0);
   --chart-foreground-muted: oklch(0.65 0.01 260);
-  --chart-crosshair: oklch(1 0 0);
-  --chart-grid: oklch(0.25 0 0);
+  --chart-crosshair: oklch(0.72 0.0158 281.84);
+  --chart-grid: oklch(0.31 0.006 258.35);
   --chart-indicator-color: oklch(1 0 0);
   --chart-indicator-secondary-color: oklch(0.145 0 0);
   --chart-marker-background: oklch(0.25 0.01 260);
@@ -326,9 +326,9 @@
   --color-fd-primary-foreground: var(--primary-foreground);
 }
 
-/* Component preview styles */
+/* Legacy MDX hook — previews use Card + previewCardClassName in component-preview.tsx */
 .component-preview {
-  @apply rounded-xl border border-border bg-card p-6 shadow-sm;
+  @apply rounded-xl border border-border bg-card shadow-sm ring-0;
 }
 
 .component-preview-dark {

--- a/apps/web/components/docs/component-preview.tsx
+++ b/apps/web/components/docs/component-preview.tsx
@@ -3,6 +3,12 @@ import { isChartSlug } from "@/components/charts/chart-slugs";
 import { OpenInStudioButton } from "@/components/docs/open-in-studio-button";
 import { OpenInV0Button } from "@/components/docs/open-in-v0-button";
 import {
+  Card,
+  CardContent,
+  previewCardClassName,
+  previewCardContentClassName,
+} from "@/components/ui/card";
+import {
   registryJsonUrlForName,
   registryV0ExampleJsonUrl,
 } from "@/lib/studio/chart-links";
@@ -44,9 +50,15 @@ export function ComponentPreview({
           </div>
         </div>
       ) : null}
-      <div className="flex min-h-[200px] items-center justify-center rounded-xl border border-border bg-card p-8 shadow-sm">
-        {children}
-      </div>
+      <Card className={cn("flex flex-col", previewCardClassName)}>
+        <CardContent
+          className={cn(previewCardContentClassName, "min-h-[200px] shrink-0")}
+        >
+          <div className="flex w-full items-center justify-center">
+            {children}
+          </div>
+        </CardContent>
+      </Card>
     </div>
   );
 }

--- a/apps/web/components/docs/component-showcase.tsx
+++ b/apps/web/components/docs/component-showcase.tsx
@@ -69,7 +69,9 @@ export function ComponentShowcase({
         className={cn(previewCardContentClassName, "shrink-0")}
         style={{ minHeight: previewMinHeight }}
       >
-        <div className="flex w-full items-center justify-center">{children}</div>
+        <div className="flex w-full items-center justify-center">
+          {children}
+        </div>
       </CardContent>
 
       {hasCode ? (

--- a/apps/web/components/docs/component-showcase.tsx
+++ b/apps/web/components/docs/component-showcase.tsx
@@ -3,6 +3,12 @@
 import { DynamicCodeBlock } from "fumadocs-ui/components/dynamic-codeblock";
 import { type ReactNode, useState } from "react";
 import {
+  Card,
+  CardContent,
+  previewCardClassName,
+  previewCardContentClassName,
+} from "@/components/ui/card";
+import {
   Collapsible,
   CollapsibleContent,
   CollapsibleTrigger,
@@ -25,9 +31,17 @@ interface ComponentShowcaseProps {
   previewMinHeight?: number;
 }
 
+const codePanelContentClassName = cn(
+  "relative overflow-hidden transition-all duration-300",
+  "data-[state=closed]:max-h-[120px]",
+  "[&_figure]:my-0! [&_figure]:rounded-none! [&_figure]:border-0!",
+  "[&_pre]:my-0! [&_pre]:rounded-none! [&_pre]:border-0!",
+  "[&_[data-rehype-pretty-code-figure]]:mt-0!"
+);
+
 /**
- * A component showcase that displays a preview above an expandable code section.
- * Matches the shadcn/ui documentation pattern.
+ * Preview + collapsible code (shadcn docs pattern). Used for variant sections in MDX.
+ * Primary hero preview with Open in v0 / Studio uses {@link ComponentPreview} instead.
  *
  * @see https://github.com/shadcn-ui/ui/blob/main/apps/v4/components/code-collapsible-wrapper.tsx
  */
@@ -44,39 +58,27 @@ export function ComponentShowcase({
   const hasCode = code || codeBlock;
 
   return (
-    <div
+    <Card
       className={cn(
-        "not-prose my-6 overflow-hidden rounded-xl border border-border bg-card shadow-sm",
+        "not-prose my-6 flex flex-col overflow-hidden",
+        previewCardClassName,
         className
       )}
     >
-      {/* Preview Section */}
-      <div
-        className="flex items-center justify-center bg-card p-8"
+      <CardContent
+        className={cn(previewCardContentClassName, "shrink-0")}
         style={{ minHeight: previewMinHeight }}
       >
-        {children}
-      </div>
+        <div className="flex w-full items-center justify-center">{children}</div>
+      </CardContent>
 
-      {/* Code Section */}
-      {hasCode && (
+      {hasCode ? (
         <Collapsible
-          className="group/collapsible relative"
+          className="group/collapsible relative border-border border-t"
           onOpenChange={setIsOpen}
           open={isOpen}
         >
-          {/* Code content with forceMount for smooth transitions */}
-          <CollapsibleContent
-            className={cn(
-              "relative overflow-hidden transition-all duration-300",
-              "data-[state=closed]:max-h-[120px]",
-              // Style adjustments for embedded code blocks from fumadocs
-              "[&_figure]:!my-0 [&_figure]:!rounded-none [&_figure]:!border-0",
-              "[&_pre]:!my-0 [&_pre]:!rounded-none [&_pre]:!border-0",
-              "[&_[data-rehype-pretty-code-figure]]:!mt-0"
-            )}
-            forceMount
-          >
+          <CollapsibleContent className={codePanelContentClassName} forceMount>
             {codeBlock || (
               <DynamicCodeBlock
                 code={code || ""}
@@ -86,12 +88,11 @@ export function ComponentShowcase({
             )}
           </CollapsibleContent>
 
-          {/* Bottom gradient with View Code - only visible when collapsed */}
           <CollapsibleTrigger
             className={cn(
               "absolute inset-x-0 -bottom-px flex h-16 items-center justify-center",
-              "bg-gradient-to-t from-fd-secondary via-fd-secondary/80 to-transparent",
-              "font-medium text-fd-muted-foreground text-sm",
+              "bg-linear-to-t from-card via-card/80 to-transparent",
+              "font-medium text-muted-foreground text-sm",
               "cursor-pointer rounded-b-xl",
               "group-data-[state=open]/collapsible:hidden"
             )}
@@ -99,13 +100,12 @@ export function ComponentShowcase({
             View Code
           </CollapsibleTrigger>
 
-          {/* Collapse button at bottom left - only visible when expanded */}
           <CollapsibleTrigger
             className={cn(
               "absolute right-3 bottom-3 z-10",
               "rounded-md px-2.5 py-1 font-medium text-xs",
-              "text-fd-muted-foreground hover:text-fd-foreground",
-              "bg-fd-muted/80 hover:bg-fd-muted",
+              "text-muted-foreground hover:text-foreground",
+              "bg-muted/80 hover:bg-muted",
               "cursor-pointer transition-colors",
               "group-data-[state=closed]/collapsible:hidden"
             )}
@@ -113,7 +113,7 @@ export function ComponentShowcase({
             Collapse
           </CollapsibleTrigger>
         </Collapsible>
-      )}
-    </div>
+      ) : null}
+    </Card>
   );
 }

--- a/apps/web/components/home-components.tsx
+++ b/apps/web/components/home-components.tsx
@@ -34,13 +34,22 @@ import {
   SankeyNode,
   XAxis,
 } from "@bklitui/ui/charts";
+import { Refresh01Icon } from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
 import { curveStep } from "@visx/curve";
 import { AnimatePresence, motion, useReducedMotion } from "motion/react";
 import Link from "next/link";
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import type { ChartSlug } from "@/components/charts/chart-slugs";
 import { useWorldDataStandalone } from "@/components/docs/use-world-data";
 import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  previewCardClassName,
+  previewCardContentClassName,
+  previewCardContentFillClassName,
+} from "@/components/ui/card";
 import { studioChartDocsHref, studioChartHref } from "@/lib/studio/chart-links";
 import { cn } from "@/lib/utils";
 
@@ -48,6 +57,65 @@ const easeOutQuint = [0.23, 1, 0.32, 1] as const;
 const actionEnterDuration = 0.2;
 const actionExitDuration = 0.16;
 const actionStagger = 0.04;
+
+function ShowcaseReplayAction({
+  index,
+  visible,
+  reducedMotion,
+  onReplay,
+}: {
+  index: number;
+  visible: boolean;
+  reducedMotion: boolean | null;
+  onReplay: () => void;
+}) {
+  return (
+    <AnimatePresence>
+      {visible && (
+        <motion.div
+          animate={
+            reducedMotion
+              ? { opacity: 1, y: 0 }
+              : {
+                  opacity: 1,
+                  y: 0,
+                  transition: {
+                    duration: actionEnterDuration,
+                    ease: easeOutQuint,
+                    delay: index * actionStagger,
+                  },
+                }
+          }
+          exit={
+            reducedMotion
+              ? undefined
+              : {
+                  opacity: 0,
+                  y: 4,
+                  transition: {
+                    duration: actionExitDuration,
+                    ease: easeOutQuint,
+                  },
+                }
+          }
+          initial={reducedMotion ? false : { opacity: 0, y: 6 }}
+        >
+          <Button
+            aria-label="Replay animation"
+            className="size-7 [&_svg]:size-3.5"
+            onClick={onReplay}
+            size="icon-sm"
+            title="Replay animation"
+            type="button"
+            variant="outline"
+          >
+            <HugeiconsIcon icon={Refresh01Icon} size={14} strokeWidth={1.5} />
+          </Button>
+        </motion.div>
+      )}
+    </AnimatePresence>
+  );
+}
 
 function CardAction({
   href,
@@ -117,6 +185,11 @@ function ShowcaseCard({
   const [hoverFine, setHoverFine] = useState(false);
   const [focused, setFocused] = useState(false);
   const [coarsePointer, setCoarsePointer] = useState(false);
+  const [replayKey, setReplayKey] = useState(0);
+
+  const replay = useCallback(() => {
+    setReplayKey((k) => k + 1);
+  }, []);
 
   useEffect(() => {
     const mq = window.matchMedia("(hover: hover) and (pointer: fine)");
@@ -130,9 +203,10 @@ function ShowcaseCard({
     reducedMotion === true || coarsePointer || hoverFine || focused;
 
   return (
-    <article
+    <Card
       className={cn(
-        "relative flex items-center justify-center overflow-hidden rounded-xl border border-border/50 bg-muted/30 p-6",
+        "relative flex min-h-0 flex-1 flex-col overflow-hidden",
+        previewCardClassName,
         className
       )}
       onBlurCapture={(e) => {
@@ -144,10 +218,18 @@ function ShowcaseCard({
       onPointerEnter={() => setHoverFine(true)}
       onPointerLeave={() => setHoverFine(false)}
     >
+      <div className="absolute top-3 left-3 z-10">
+        <ShowcaseReplayAction
+          index={0}
+          onReplay={replay}
+          reducedMotion={reducedMotion}
+          visible={showActions}
+        />
+      </div>
       <div className="absolute top-3 right-3 z-10 flex items-center gap-2">
         <CardAction
           href={studioChartDocsHref(chart)}
-          index={0}
+          index={1}
           label="Docs"
           reducedMotion={reducedMotion}
           variant="outline"
@@ -155,15 +237,27 @@ function ShowcaseCard({
         />
         <CardAction
           href={studioChartHref(chart)}
-          index={1}
+          index={2}
           label="Open in Studio"
           reducedMotion={reducedMotion}
           variant="default"
           visible={showActions}
         />
       </div>
-      {children}
-    </article>
+      <CardContent
+        className={cn(
+          previewCardContentClassName,
+          previewCardContentFillClassName
+        )}
+      >
+        <div
+          className="flex size-full min-h-0 items-center justify-center"
+          key={replayKey}
+        >
+          {children}
+        </div>
+      </CardContent>
+    </Card>
   );
 }
 
@@ -392,7 +486,7 @@ export function HomeComponents() {
 
       <ShowcaseCard
         chart="sankey-chart"
-        className="col-span-full min-h-[200px] flex-1 p-8 sm:col-span-7"
+        className="col-span-full min-h-[200px] flex-1 sm:col-span-7"
       >
         <SankeyChart
           data={sankeyData}

--- a/apps/web/components/ui/card.tsx
+++ b/apps/web/components/ui/card.tsx
@@ -11,8 +11,7 @@ export const previewCardContentClassName =
   "flex w-full items-center justify-center p-8";
 
 /** Fills a flex/grid cell when the preview card should stretch (homepage grid). */
-export const previewCardContentFillClassName =
-  "min-h-0 size-full flex-1";
+export const previewCardContentFillClassName = "min-h-0 size-full flex-1";
 
 function Card({
   className,

--- a/apps/web/components/ui/card.tsx
+++ b/apps/web/components/ui/card.tsx
@@ -2,6 +2,18 @@ import type * as React from "react";
 
 import { cn } from "@/lib/utils";
 
+/** Chart demos and docs previews — use on `Card` + `CardContent`. */
+export const previewCardClassName =
+  "gap-0 rounded-xl border border-border py-0 shadow-sm ring-0";
+
+/** Centered chart area inside a preview card (docs + homepage). */
+export const previewCardContentClassName =
+  "flex w-full items-center justify-center p-8";
+
+/** Fills a flex/grid cell when the preview card should stretch (homepage grid). */
+export const previewCardContentFillClassName =
+  "min-h-0 size-full flex-1";
+
 function Card({
   className,
   size = "default",


### PR DESCRIPTION
## Summary

- Align homepage showcase tiles, docs `ComponentPreview`, and `ComponentShowcase` on shared shadcn `Card` preview classes (`--card` fill, consistent border/shadow/centering).
- Add homepage chart replay on hover (top-left, staggered with Docs/Studio actions) via remount key.
- Tune dark mode tokens (background, card, popover, muted/accent, border, chart crosshair/grid) for clearer surface hierarchy.

## Test plan

- [x] `pnpm lint` passes at repo root
- [x] `apps/web` production build succeeds
- [ ] Homepage: chart cards use card surface, charts centered, Replay/Docs/Studio on hover
- [ ] Docs: component preview + showcase match card styling; View Code / collapse still work
- [ ] Dark mode: backgrounds and chart grid/crosshair look correct vs main


Made with [Cursor](https://cursor.com)