### PR TITLE
Add docs search with Orama and custom header trigger

### DIFF
--- a/apps/web/app/api/search/route.ts
+++ b/apps/web/app/api/search/route.ts
@@ -1,0 +1,6 @@
+import { createFromSource } from "fumadocs-core/search/server";
+import { source } from "@/lib/source";
+
+export const { GET } = createFromSource(source, {
+  language: "english",
+});

--- a/apps/web/components/docs/docs-search-trigger.tsx
+++ b/apps/web/components/docs/docs-search-trigger.tsx
@@ -1,0 +1,61 @@
+"use client";
+
+import { Search01Icon } from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
+import { useSearchContext } from "fumadocs-ui/contexts/search";
+import { useEffect, useState } from "react";
+import { cn } from "@/lib/utils";
+
+function SearchShortcut() {
+  const [modifier, setModifier] = useState("⌘");
+
+  useEffect(() => {
+    if (window.navigator.userAgent.includes("Windows")) {
+      setModifier("Ctrl");
+    }
+  }, []);
+
+  return (
+    <kbd className="pointer-events-none hidden items-center gap-0.5 rounded border border-border bg-background px-1.5 py-0.5 font-medium font-mono text-[0.625rem] text-muted-foreground sm:inline-flex">
+      <span>{modifier}</span>
+      <span>K</span>
+    </kbd>
+  );
+}
+
+interface DocsSearchTriggerProps {
+  className?: string;
+  hideIfDisabled?: boolean;
+}
+
+export function DocsSearchTrigger({
+  className,
+  hideIfDisabled,
+}: DocsSearchTriggerProps) {
+  const { setOpenSearch, enabled } = useSearchContext();
+
+  if (hideIfDisabled && !enabled) {
+    return null;
+  }
+
+  return (
+    <button
+      aria-label="Open search"
+      className={cn(
+        "inline-flex h-7 shrink-0 items-center gap-1.5 rounded-md border border-input bg-input/20 px-2 text-xs/relaxed outline-none transition-colors hover:bg-input/40 focus-visible:border-ring focus-visible:ring-2 focus-visible:ring-ring/30 dark:bg-input/30",
+        className
+      )}
+      data-search-full=""
+      onClick={() => setOpenSearch(true)}
+      type="button"
+    >
+      <HugeiconsIcon
+        className="text-muted-foreground"
+        icon={Search01Icon}
+        size={14}
+        strokeWidth={1.75}
+      />
+      <SearchShortcut />
+    </button>
+  );
+}

--- a/apps/web/components/docs/site-header.tsx
+++ b/apps/web/components/docs/site-header.tsx
@@ -9,6 +9,8 @@ import { BklitLogo } from "../icons/bklit";
 import { DiscordIcon } from "../icons/discord";
 import { GitHubIcon } from "../icons/github";
 import { Button } from "../ui/button";
+import { Separator } from "../ui/separator";
+import { DocsSearchTrigger } from "./docs-search-trigger";
 
 interface NavLink {
   text: string;
@@ -385,22 +387,32 @@ export function SiteHeader({
           </div>
 
           <div className="flex items-center gap-1">
+            <DocsSearchTrigger
+              className="hidden w-44 justify-between md:inline-flex"
+              hideIfDisabled
+            />
             {githubUrl && (
-              <Link
-                aria-label="GitHub"
-                className="hidden md:block"
-                external
-                href={githubUrl}
-              >
-                <Button
-                  className="gap-2 font-light font-mono text-muted-foreground text-xs"
-                  size="default"
-                  variant="ghost"
+              <>
+                <Separator
+                  className="mx-1 hidden h-5 self-center data-vertical:self-center md:block"
+                  orientation="vertical"
+                />
+                <Link
+                  aria-label="GitHub"
+                  className="hidden md:block"
+                  external
+                  href={githubUrl}
                 >
-                  <GitHubIcon />
-                  <GithubStarCount />
-                </Button>
-              </Link>
+                  <Button
+                    className="gap-2 font-light font-mono text-muted-foreground text-xs"
+                    size="default"
+                    variant="ghost"
+                  >
+                    <GitHubIcon />
+                    <GithubStarCount />
+                  </Button>
+                </Link>
+              </>
             )}
             {discordUrl && (
               <Link

--- a/apps/web/components/docs/site-header.tsx
+++ b/apps/web/components/docs/site-header.tsx
@@ -388,7 +388,7 @@ export function SiteHeader({
 
           <div className="flex items-center gap-1">
             <DocsSearchTrigger
-              className="hidden w-44 justify-between md:inline-flex"
+              className="hidden w-30 justify-between md:inline-flex"
               hideIfDisabled
             />
             {githubUrl && (

--- a/apps/web/components/ui/separator.tsx
+++ b/apps/web/components/ui/separator.tsx
@@ -1,0 +1,25 @@
+"use client";
+
+import { Separator as SeparatorPrimitive } from "@base-ui/react/separator";
+
+import { cn } from "@/lib/utils";
+
+function Separator({
+  className,
+  orientation = "horizontal",
+  ...props
+}: SeparatorPrimitive.Props) {
+  return (
+    <SeparatorPrimitive
+      className={cn(
+        "shrink-0 bg-border data-horizontal:h-px data-horizontal:w-full data-vertical:w-px data-vertical:self-stretch",
+        className
+      )}
+      data-slot="separator"
+      orientation={orientation}
+      {...props}
+    />
+  );
+}
+
+export { Separator };


### PR DESCRIPTION
## Summary

- Wire Fumadocs Orama search via `/api/search` so Cmd+K and the search dialog return real doc results.
- Add a custom header search control (input-style, icon + shortcut) with a Base UI vertical separator before GitHub.
- Add `@base-ui/react` shadcn `Separator` component; remove Fumadocs sidebar search toggle in favor of header-only entry.

## Test plan

- [x] `pnpm lint` passes at repo root
- [x] `apps/web` production build succeeds
- [ ] Header search opens dialog; ⌘K / Ctrl+K works on docs pages
- [ ] Search returns pages (e.g. "installation", "area chart") via `/api/search?query=...`
- [ ] Separator aligns vertically between search and GitHub on desktop


Made with [Cursor](https://cursor.com)