### PR TITLE
feat(studio): restyle Get code button and add action tooltips

### DIFF
--- a/apps/web/components/studio/studio-code-sheet.tsx
+++ b/apps/web/components/studio/studio-code-sheet.tsx
@@ -50,8 +50,12 @@ export function StudioCodeSheet({ state }: { state: StudioUrlState }) {
   return (
     <Sheet onOpenChange={setOpen} open={open}>
       <SheetTrigger asChild>
-        <Button className="h-10 px-4 text-sm" type="button" variant="outline">
-          Get code
+        <Button
+          className="h-10 px-4 font-mono text-[11px]"
+          type="button"
+          variant="white"
+        >
+          Get code_
         </Button>
       </SheetTrigger>
       <SheetContent className="overflow-y-auto">

--- a/apps/web/components/studio/studio-export-svg-button.tsx
+++ b/apps/web/components/studio/studio-export-svg-button.tsx
@@ -3,6 +3,11 @@
 import { Download01Icon } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 import { Button } from "@/components/ui/button";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 
 export function StudioExportSvgButton({
   disabled,
@@ -12,17 +17,21 @@ export function StudioExportSvgButton({
   onExport: () => void;
 }) {
   return (
-    <Button
-      aria-label="Export SVG"
-      className="size-10"
-      disabled={disabled}
-      onClick={onExport}
-      size="icon"
-      title="Export SVG"
-      type="button"
-      variant="outline"
-    >
-      <HugeiconsIcon icon={Download01Icon} size={20} strokeWidth={1.5} />
-    </Button>
+    <Tooltip>
+      <TooltipTrigger render={<span className="inline-flex" />}>
+        <Button
+          aria-label="Export as SVG"
+          className="size-10"
+          disabled={disabled}
+          onClick={onExport}
+          size="icon"
+          type="button"
+          variant="outline"
+        >
+          <HugeiconsIcon icon={Download01Icon} size={20} strokeWidth={1.5} />
+        </Button>
+      </TooltipTrigger>
+      <TooltipContent>Export as SVG</TooltipContent>
+    </Tooltip>
   );
 }

--- a/apps/web/components/studio/studio-preview.tsx
+++ b/apps/web/components/studio/studio-preview.tsx
@@ -20,6 +20,12 @@ import { useStudioMotionRemountKey } from "@/components/studio/use-studio-motion
 import { useStudioRecording } from "@/components/studio/use-studio-recording";
 import { useStudioState } from "@/components/studio/use-studio-state";
 import { Button } from "@/components/ui/button";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 import { presetStyle } from "@/lib/studio/color-presets";
 import { StudioPatternDefs, studioPatternFill } from "@/lib/studio/patterns";
 import type { StudioRenderContext } from "@/lib/studio/render-context";
@@ -175,154 +181,168 @@ export function StudioPreview() {
   }, [state.chart, state.frameH, state.frameW]);
 
   return (
-    <StudioPanel className="relative flex h-full min-h-0 min-w-0 flex-col overflow-hidden">
-      <div className="absolute top-6 right-6 z-30 flex items-center gap-2.5">
-        <Button
-          aria-label="Replay animation"
-          className="size-10"
-          disabled={controlsDisabled}
-          onClick={replay}
-          size="icon"
-          title="Replay animation"
-          type="button"
-          variant="outline"
-        >
-          <HugeiconsIcon icon={Refresh01Icon} size={20} strokeWidth={1.5} />
-        </Button>
-        <StudioExportSvgButton
-          disabled={controlsDisabled}
-          onExport={handleExportSvg}
-        />
-        <StudioRecordPopover
-          disabled={recordingBlocked}
-          isRecording={isRecording}
-          onStart={handleStartRecording}
-          onStop={stopRecording}
-        />
-        <PresetSelect
-          disabled={controlsDisabled}
-          onChange={(v) => setParam("preset", v)}
-          value={displayState.preset}
-        />
-        <StudioCodeSheet state={state} />
-      </div>
-
-      {error ? (
-        <div
-          className="absolute top-20 right-6 z-20 max-w-xs rounded-md border border-destructive/40 bg-destructive/10 px-3 py-2 text-destructive text-sm"
-          role="alert"
-        >
-          <p>{error}</p>
-          <button className="mt-1 underline" onClick={clearError} type="button">
-            Dismiss
-          </button>
-        </div>
-      ) : null}
-
-      <div
-        className={cn(
-          "studio-preview-canvas relative flex min-h-0 flex-1 flex-col overflow-auto p-6 pt-16",
-          showCaptureLayout ? "gap-4" : "items-center justify-center gap-5"
-        )}
-        ref={canvasRef}
-      >
-        {showCaptureLayout ? (
-          <div
-            aria-hidden
-            className="pointer-events-none absolute inset-0 z-1 bg-zinc-950/88"
+    <TooltipProvider>
+      <StudioPanel className="relative flex h-full min-h-0 min-w-0 flex-col overflow-hidden">
+        <div className="absolute top-6 right-6 z-30 flex items-center gap-2.5">
+          <Tooltip>
+            <TooltipTrigger render={<span className="inline-flex" />}>
+              <Button
+                aria-label="Replay animation"
+                className="size-10"
+                disabled={controlsDisabled}
+                onClick={replay}
+                size="icon"
+                type="button"
+                variant="outline"
+              >
+                <HugeiconsIcon
+                  icon={Refresh01Icon}
+                  size={20}
+                  strokeWidth={1.5}
+                />
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent>Replay animation</TooltipContent>
+          </Tooltip>
+          <StudioExportSvgButton
+            disabled={controlsDisabled}
+            onExport={handleExportSvg}
           />
+          <StudioRecordPopover
+            disabled={recordingBlocked}
+            isRecording={isRecording}
+            onStart={handleStartRecording}
+            onStop={stopRecording}
+          />
+          <PresetSelect
+            disabled={controlsDisabled}
+            onChange={(v) => setParam("preset", v)}
+            value={displayState.preset}
+          />
+          <StudioCodeSheet state={state} />
+        </div>
+
+        {error ? (
+          <div
+            className="absolute top-20 right-6 z-20 max-w-xs rounded-md border border-destructive/40 bg-destructive/10 px-3 py-2 text-destructive text-sm"
+            role="alert"
+          >
+            <p>{error}</p>
+            <button
+              className="mt-1 underline"
+              onClick={clearError}
+              type="button"
+            >
+              Dismiss
+            </button>
+          </div>
         ) : null}
 
         <div
           className={cn(
-            "relative z-2 flex min-h-0 w-full flex-1 flex-col",
-            showCaptureLayout
-              ? "gap-4"
-              : "max-w-3xl items-center justify-center gap-5"
+            "studio-preview-canvas relative flex min-h-0 flex-1 flex-col overflow-auto p-6 pt-16",
+            showCaptureLayout ? "gap-4" : "items-center justify-center gap-5"
           )}
+          ref={canvasRef}
         >
-          <div
-            className="relative flex min-h-0 w-full flex-1 items-center justify-center"
-            ref={chartAreaRef}
-          >
-            <StudioRecordingMask
-              active={showCaptureLayout}
-              containerRef={chartAreaRef}
-              targetRef={recordCaptureRef}
-            />
-
+          {showCaptureLayout ? (
             <div
-              className={cn(
-                showCaptureLayout
-                  ? "studio-recording-capture relative shrink-0"
-                  : "inline-flex"
-              )}
-              ref={recordCaptureRef}
-              style={
-                showCaptureLayout
-                  ? {
-                      width:
-                        state.frameW + STUDIO_RECORDING_CAPTURE_INSET_PX * 2,
-                      height:
-                        state.frameH + STUDIO_RECORDING_CAPTURE_INSET_PX * 2,
-                    }
-                  : undefined
-              }
+              aria-hidden
+              className="pointer-events-none absolute inset-0 z-1 bg-zinc-950/88"
+            />
+          ) : null}
+
+          <div
+            className={cn(
+              "relative z-2 flex min-h-0 w-full flex-1 flex-col",
+              showCaptureLayout
+                ? "gap-4"
+                : "max-w-3xl items-center justify-center gap-5"
+            )}
+          >
+            <div
+              className="relative flex min-h-0 w-full flex-1 items-center justify-center"
+              ref={chartAreaRef}
             >
+              <StudioRecordingMask
+                active={showCaptureLayout}
+                containerRef={chartAreaRef}
+                targetRef={recordCaptureRef}
+              />
+
               <div
+                className={cn(
+                  showCaptureLayout
+                    ? "studio-recording-capture relative shrink-0"
+                    : "inline-flex"
+                )}
+                ref={recordCaptureRef}
                 style={
                   showCaptureLayout
                     ? {
-                        position: "absolute",
-                        top: STUDIO_RECORDING_CAPTURE_INSET_PX,
-                        left: STUDIO_RECORDING_CAPTURE_INSET_PX,
+                        width:
+                          state.frameW + STUDIO_RECORDING_CAPTURE_INSET_PX * 2,
+                        height:
+                          state.frameH + STUDIO_RECORDING_CAPTURE_INSET_PX * 2,
                       }
                     : undefined
                 }
               >
-                <StudioChartFrame
-                  boundsRef={chartAreaRef}
-                  height={state.frameH}
-                  isRecording={isRecording}
-                  onResize={handleFrameResize}
-                  ref={frameRef}
-                  style={presetStyle(displayState.preset)}
-                  width={state.frameW}
+                <div
+                  style={
+                    showCaptureLayout
+                      ? {
+                          position: "absolute",
+                          top: STUDIO_RECORDING_CAPTURE_INSET_PX,
+                          left: STUDIO_RECORDING_CAPTURE_INSET_PX,
+                        }
+                      : undefined
+                  }
                 >
-                  <div className="flex size-full min-h-0 items-center justify-center">
-                    <StudioChartViewport>
-                      {(frame) => {
-                        const renderCtx: StudioRenderContext = {
-                          animationKey,
-                          isRecording: isRecording || capturePrepared,
-                          motionRemountKey,
-                          committedState: state,
-                          motionCurveDragging,
-                          patternDefs,
-                          patternFill,
-                          frame,
-                        };
-                        return config.render(displayState, renderCtx);
-                      }}
-                    </StudioChartViewport>
-                  </div>
-                </StudioChartFrame>
+                  <StudioChartFrame
+                    boundsRef={chartAreaRef}
+                    height={state.frameH}
+                    isRecording={isRecording}
+                    onResize={handleFrameResize}
+                    ref={frameRef}
+                    style={presetStyle(displayState.preset)}
+                    width={state.frameW}
+                  >
+                    <div className="flex size-full min-h-0 items-center justify-center">
+                      <StudioChartViewport>
+                        {(frame) => {
+                          const renderCtx: StudioRenderContext = {
+                            animationKey,
+                            isRecording: isRecording || capturePrepared,
+                            motionRemountKey,
+                            committedState: state,
+                            motionCurveDragging,
+                            patternDefs,
+                            patternFill,
+                            frame,
+                          };
+                          return config.render(displayState, renderCtx);
+                        }}
+                      </StudioChartViewport>
+                    </div>
+                  </StudioChartFrame>
+                </div>
               </div>
             </div>
-          </div>
 
-          {showRecordingChrome ? (
-            <StudioRecordingTimeline
-              elapsedMs={elapsedMs}
-              isPaused={isPaused}
-              onPause={pauseRecording}
-              onResume={resumeRecording}
-              phase={phase === "encoding" ? "encoding" : "capturing"}
-              timeline={timeline}
-            />
-          ) : null}
+            {showRecordingChrome ? (
+              <StudioRecordingTimeline
+                elapsedMs={elapsedMs}
+                isPaused={isPaused}
+                onPause={pauseRecording}
+                onResume={resumeRecording}
+                phase={phase === "encoding" ? "encoding" : "capturing"}
+                timeline={timeline}
+              />
+            ) : null}
+          </div>
         </div>
-      </div>
-    </StudioPanel>
+      </StudioPanel>
+    </TooltipProvider>
   );
 }

--- a/apps/web/components/studio/studio-record-popover.tsx
+++ b/apps/web/components/studio/studio-record-popover.tsx
@@ -11,6 +11,11 @@ import {
 } from "@/components/ui/popover";
 import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
 import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import {
   STUDIO_RECORDING_ASPECT_OPTIONS,
   STUDIO_RECORDING_FORMAT_OPTIONS,
   STUDIO_RECORDING_INTERACTION_OPTIONS,
@@ -59,20 +64,26 @@ export function StudioRecordPopover({
 
   return (
     <Popover onOpenChange={setOpen} open={open}>
-      <PopoverTrigger asChild>
-        <Button
-          aria-expanded={open}
-          aria-label="Record animation"
-          className="size-10"
-          disabled={disabled}
-          size="icon"
-          title={disabled ? "Recording requires motion" : "Record animation"}
-          type="button"
-          variant="outline"
-        >
-          <VideoCameraIcon aria-hidden className="size-5" />
-        </Button>
-      </PopoverTrigger>
+      <Tooltip>
+        <TooltipTrigger render={<span className="inline-flex" />}>
+          <PopoverTrigger asChild>
+            <Button
+              aria-expanded={open}
+              aria-label="Record animation"
+              className="size-10"
+              disabled={disabled}
+              size="icon"
+              type="button"
+              variant="outline"
+            >
+              <VideoCameraIcon aria-hidden className="size-5" />
+            </Button>
+          </PopoverTrigger>
+        </TooltipTrigger>
+        <TooltipContent>
+          {disabled ? "Recording requires motion" : "Record"}
+        </TooltipContent>
+      </Tooltip>
       <PopoverContent
         align="end"
         className="w-72 p-4"

--- a/apps/web/components/ui/tooltip.tsx
+++ b/apps/web/components/ui/tooltip.tsx
@@ -1,0 +1,66 @@
+"use client";
+
+import { Tooltip as TooltipPrimitive } from "@base-ui/react/tooltip";
+
+import { cn } from "@/lib/utils";
+
+function TooltipProvider({
+  delay = 0,
+  ...props
+}: TooltipPrimitive.Provider.Props) {
+  return (
+    <TooltipPrimitive.Provider
+      data-slot="tooltip-provider"
+      delay={delay}
+      {...props}
+    />
+  );
+}
+
+function Tooltip({ ...props }: TooltipPrimitive.Root.Props) {
+  return <TooltipPrimitive.Root data-slot="tooltip" {...props} />;
+}
+
+function TooltipTrigger({ ...props }: TooltipPrimitive.Trigger.Props) {
+  return <TooltipPrimitive.Trigger data-slot="tooltip-trigger" {...props} />;
+}
+
+function TooltipContent({
+  className,
+  side = "top",
+  sideOffset = 4,
+  align = "center",
+  alignOffset = 0,
+  children,
+  ...props
+}: TooltipPrimitive.Popup.Props &
+  Pick<
+    TooltipPrimitive.Positioner.Props,
+    "align" | "alignOffset" | "side" | "sideOffset"
+  >) {
+  return (
+    <TooltipPrimitive.Portal>
+      <TooltipPrimitive.Positioner
+        align={align}
+        alignOffset={alignOffset}
+        className="isolate z-50"
+        side={side}
+        sideOffset={sideOffset}
+      >
+        <TooltipPrimitive.Popup
+          className={cn(
+            "data-[side=bottom]:slide-in-from-top-2 data-[side=inline-end]:slide-in-from-left-2 data-[side=inline-start]:slide-in-from-right-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-[state=delayed-open]:fade-in-0 data-[state=delayed-open]:zoom-in-95 data-open:fade-in-0 data-open:zoom-in-95 data-closed:fade-out-0 data-closed:zoom-out-95 z-50 inline-flex w-fit max-w-xs origin-(--transform-origin) items-center gap-1.5 rounded-md bg-foreground px-3 py-1.5 text-background text-xs has-data-[slot=kbd]:pr-1.5 data-[state=delayed-open]:animate-in data-closed:animate-out data-open:animate-in **:data-[slot=kbd]:relative **:data-[slot=kbd]:isolate **:data-[slot=kbd]:z-50 **:data-[slot=kbd]:rounded-sm",
+            className
+          )}
+          data-slot="tooltip-content"
+          {...props}
+        >
+          {children}
+          <TooltipPrimitive.Arrow className="z-50 size-2.5 translate-y-[calc(-50%-2px)] rotate-45 rounded-[2px] bg-foreground fill-foreground data-[side=bottom]:top-1 data-[side=inline-end]:top-1/2! data-[side=inline-start]:top-1/2! data-[side=left]:top-1/2! data-[side=right]:top-1/2! data-[side=inline-start]:-right-1 data-[side=left]:-right-1 data-[side=top]:-bottom-2.5 data-[side=inline-end]:-left-1 data-[side=right]:-left-1 data-[side=inline-end]:-translate-y-1/2 data-[side=inline-start]:-translate-y-1/2 data-[side=left]:-translate-y-1/2 data-[side=right]:-translate-y-1/2" />
+        </TooltipPrimitive.Popup>
+      </TooltipPrimitive.Positioner>
+    </TooltipPrimitive.Portal>
+  );
+}
+
+export { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger };


### PR DESCRIPTION
## Summary

- Restyle the studio "Get code" trigger to the white variant with monospace `Get code_` label at a smaller text size while keeping the same button dimensions.
- Add the shadcn Base UI `Tooltip` component and wire tooltips to Replay animation, Export as SVG, and Record controls (including the disabled "Recording requires motion" state).

## Test plan

- [x] `pnpm lint` passes at repo root
- [x] `apps/web` production build succeeds
- [ ] Open `/studio` and confirm the Get code button is white, monospace, and reads `Get code_`
- [ ] Hover replay, export, and record buttons to verify tooltips appear (including when record is disabled with reduced motion)
- [ ] Confirm record popover still opens on click


Made with [Cursor](https://cursor.com)