### PR TITLE
fix(studio): inline area chart gradient stop colors in SVG export

### DIFF
--- a/apps/web/lib/studio/__tests__/export-studio-chart-svg.test.ts
+++ b/apps/web/lib/studio/__tests__/export-studio-chart-svg.test.ts
@@ -28,6 +28,9 @@ const DIRECT_LABEL_RE = /Direct/;
 const RADAR_SPEED_LABEL_RE = /Speed/;
 const RADAR_LABEL_FILL_RE = /fill="oklch\(0\.65 0\.01 260\)"/;
 const RADAR_LABEL_TRANSFORM_RE = /transform="translate\(120px, 40px\)"/;
+const AREA_GRADIENT_STOP_COLOR_RE = /stop-color="oklch\(0\.65 0\.15 200\)"/;
+const AREA_GRADIENT_STOP_OPACITY_RE = /stop-opacity="0\.4"/;
+const AREA_GRADIENT_INLINE_STYLE_RE = /style="stop-color:/;
 
 function mountDom(html: string) {
   const dom = new JSDOM(html, { pretendToBeVisual: true });
@@ -224,6 +227,31 @@ describe("build-frame-svg", () => {
 
     assert.match(svg, SANKEY_TEXT_FILL_RE);
     assert.match(svg, DIRECT_LABEL_RE);
+
+    unmountDom();
+  });
+
+  it("inlines area gradient stop colors from inline styles", () => {
+    const window = mountDom(
+      `<div id="root" style="width:720px;height:400px;--chart-line-primary:oklch(0.65 0.15 200);">
+        <svg width="720" height="400">
+          <defs>
+            <linearGradient id="area-gradient-desktop-abc" x1="0%" x2="0%" y1="0%" y2="100%">
+              <stop offset="0%" style="stop-color: var(--chart-line-primary); stop-opacity: 0.4" />
+              <stop offset="100%" style="stop-color: var(--chart-line-primary); stop-opacity: 0" />
+            </linearGradient>
+          </defs>
+          <path d="M0,100 L200,50 L400,80 L400,400 L0,400 Z" fill="url(#area-gradient-desktop-abc)" />
+        </svg>
+      </div>`
+    );
+
+    const root = window.document.getElementById("root") as HTMLElement;
+    const svg = buildFrameSvg({ root, width: 720, height: 400 });
+
+    assert.match(svg, AREA_GRADIENT_STOP_COLOR_RE);
+    assert.match(svg, AREA_GRADIENT_STOP_OPACITY_RE);
+    assert.doesNotMatch(svg, AREA_GRADIENT_INLINE_STYLE_RE);
 
     unmountDom();
   });

--- a/apps/web/lib/studio/svg-export/inline-svg-styles.ts
+++ b/apps/web/lib/studio/svg-export/inline-svg-styles.ts
@@ -2,6 +2,8 @@ import { containsCssVar, resolveCssVar } from "./resolve-css-var";
 
 const SVG_NS = "http://www.w3.org/2000/svg";
 const FILL_STYLE_RE = /fill:\s*([^;]+)/;
+const STOP_COLOR_STYLE_RE = /stop-color:\s*([^;]+)/i;
+const STOP_OPACITY_STYLE_RE = /stop-opacity:\s*([^;]+)/i;
 
 const PRESENTATION_ATTRIBUTES = [
   "fill",
@@ -75,6 +77,49 @@ function stripAnimatedPathStyles(clone: Element): void {
   }
 }
 
+function resolveStopPresentation(
+  source: Element,
+  styleSource: Element,
+  property: "stop-color" | "stop-opacity"
+): string | null {
+  const fromAttribute = resolvePresentationAttribute(
+    source,
+    styleSource,
+    property
+  );
+  if (fromAttribute !== null && fromAttribute !== "") {
+    return fromAttribute;
+  }
+
+  const computed = getComputedStyle(source);
+  const computedValue =
+    property === "stop-color" ? computed.stopColor : computed.stopOpacity;
+
+  if (
+    computedValue &&
+    computedValue !== "" &&
+    computedValue !== "initial" &&
+    !containsCssVar(computedValue)
+  ) {
+    return computedValue;
+  }
+
+  const styleValue = source.getAttribute("style");
+  if (!styleValue) {
+    return null;
+  }
+
+  const match = (
+    property === "stop-color" ? STOP_COLOR_STYLE_RE : STOP_OPACITY_STYLE_RE
+  ).exec(styleValue);
+  if (!match?.[1]) {
+    return null;
+  }
+
+  const raw = match[1].trim();
+  return containsCssVar(raw) ? resolveCssVar(styleSource, raw) : raw;
+}
+
 function applyStopPresentation(
   source: Element,
   clone: Element,
@@ -83,13 +128,14 @@ function applyStopPresentation(
   setResolvedAttribute(
     clone,
     "stop-color",
-    resolvePresentationAttribute(source, styleSource, "stop-color")
+    resolveStopPresentation(source, styleSource, "stop-color")
   );
   setResolvedAttribute(
     clone,
     "stop-opacity",
-    resolvePresentationAttribute(source, styleSource, "stop-opacity")
+    resolveStopPresentation(source, styleSource, "stop-opacity")
   );
+  clone.removeAttribute("style");
 }
 
 function applyTextPresentation(


### PR DESCRIPTION
## Summary

- Fix Studio SVG export for Area (and Line) charts where gradient `<stop>` colors were missing because the exporter only read `stop-color` attributes, not inline `style` values with CSS variables
- Resolve stop colors from attributes, computed styles, or inline styles and write them as proper `stop-color` / `stop-opacity` attributes on the exported SVG
- Add regression test covering area gradient stops with `var(--chart-line-primary)`

## Test plan

- [x] `pnpm lint` passes at repo root
- [x] `apps/web` production build succeeds
- [x] `apps/web` unit tests pass (60/60)
- [ ] Export an Area chart from Studio and confirm fill gradient colors match the preview in Figma/Illustrator or a browser
- [ ] Spot-check Line chart SVG export for stroke gradient colors


Made with [Cursor](https://cursor.com)