### PR TITLE
fix(studio): align chart theme presets with preview and SVG export

### DIFF
--- a/apps/web/lib/studio/__tests__/export-studio-chart-svg.test.ts
+++ b/apps/web/lib/studio/__tests__/export-studio-chart-svg.test.ts
@@ -31,6 +31,8 @@ const RADAR_LABEL_TRANSFORM_RE = /transform="translate\(120px, 40px\)"/;
 const AREA_GRADIENT_STOP_COLOR_RE = /stop-color="oklch\(0\.65 0\.15 200\)"/;
 const AREA_GRADIENT_STOP_OPACITY_RE = /stop-opacity="0\.4"/;
 const AREA_GRADIENT_INLINE_STYLE_RE = /style="stop-color:/;
+const EXPORTED_CHART_THEME_VARS_RE = /--chart-1:oklch\(0\.84 0\.18 128\)/;
+const EXPORTED_CHART_FILL_RE = /fill="oklch\(0\.84 0\.18 128\)"/;
 
 function mountDom(html: string) {
   const dom = new JSDOM(html, { pretendToBeVisual: true });
@@ -227,6 +229,24 @@ describe("build-frame-svg", () => {
 
     assert.match(svg, SANKEY_TEXT_FILL_RE);
     assert.match(svg, DIRECT_LABEL_RE);
+
+    unmountDom();
+  });
+
+  it("embeds frame chart palette vars for self-contained exports", () => {
+    const window = mountDom(
+      `<div id="root" style="width:720px;height:400px;--chart-1:oklch(0.84 0.18 128);--chart-line-primary:var(--chart-1);">
+        <svg width="720" height="400">
+          <rect width="100" height="100" fill="var(--chart-1)" />
+        </svg>
+      </div>`
+    );
+
+    const root = window.document.getElementById("root") as HTMLElement;
+    const svg = buildFrameSvg({ root, width: 720, height: 400 });
+
+    assert.match(svg, EXPORTED_CHART_THEME_VARS_RE);
+    assert.match(svg, EXPORTED_CHART_FILL_RE);
 
     unmountDom();
   });

--- a/apps/web/lib/studio/__tests__/resolve-css-var.test.ts
+++ b/apps/web/lib/studio/__tests__/resolve-css-var.test.ts
@@ -1,8 +1,10 @@
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
+import { JSDOM } from "jsdom";
 import {
   containsCssVar,
   parseVarName,
+  resolveCssVar,
   resolveCssVarFromStyle,
 } from "../svg-export/resolve-css-var";
 
@@ -66,6 +68,22 @@ describe("resolve-css-var", () => {
     assert.equal(
       resolveCssVarFromStyle(style, "var(--chart-label, oklch(0.65 0.01 260))"),
       "oklch(0.8 0.02 260)"
+    );
+  });
+
+  it("resolveCssVar resolves semantic aliases from palette overrides", () => {
+    const dom = new JSDOM(
+      '<div id="root" style="--chart-1:oklch(0.84 0.18 128)"><stop id="s" style="stop-color:var(--chart-line-primary)"></stop></div>',
+      { pretendToBeVisual: true }
+    );
+    const { window } = dom;
+    globalThis.getComputedStyle = window.getComputedStyle.bind(window);
+    globalThis.HTMLElement = window.HTMLElement;
+    const stop = window.document.getElementById("s");
+
+    assert.equal(
+      resolveCssVar(stop as Element, "var(--chart-line-primary)"),
+      "oklch(0.84 0.18 128)"
     );
   });
 });

--- a/apps/web/lib/studio/color-presets.ts
+++ b/apps/web/lib/studio/color-presets.ts
@@ -1,4 +1,5 @@
 import type { CSSProperties } from "react";
+import { CHART_PALETTE_DERIVED_VARS } from "./svg-export/chart-var-aliases";
 
 export const COLOR_PRESET_IDS = [
   "default",
@@ -71,7 +72,15 @@ export const COLOR_PRESETS: ColorPreset[] = [
 
 export function presetStyle(id: ColorPresetId): CSSProperties {
   const preset = COLOR_PRESETS.find((p) => p.id === id);
-  return (preset?.vars ?? {}) as CSSProperties;
+  const vars = { ...(preset?.vars ?? {}) };
+
+  // Re-derive semantic line tokens on the frame so palette overrides flow into
+  // Area/Line charts and SVG export even when :root tokens are not re-evaluated.
+  if (Object.keys(vars).length > 0) {
+    Object.assign(vars, CHART_PALETTE_DERIVED_VARS);
+  }
+
+  return vars as CSSProperties;
 }
 
 /** Representative swatch for preset picker (chart-1). */

--- a/apps/web/lib/studio/registry.tsx
+++ b/apps/web/lib/studio/registry.tsx
@@ -436,14 +436,14 @@ const candlestickConfig: StudioChartConfig = {
           {state.candleUseGradient ? (
             <>
               <LinearGradient
-                from="var(--color-lime-400)"
+                from="var(--chart-1)"
                 id="studio-candle-up"
-                to="var(--color-emerald-500)"
+                to="var(--chart-3)"
               />
               <LinearGradient
-                from="var(--color-yellow-400)"
+                from="var(--chart-4)"
                 id="studio-candle-down"
-                to="var(--color-red-500)"
+                to="var(--chart-5)"
               />
             </>
           ) : null}

--- a/apps/web/lib/studio/svg-export/build-frame-svg.ts
+++ b/apps/web/lib/studio/svg-export/build-frame-svg.ts
@@ -1,3 +1,5 @@
+import { CHART_CSS_VAR_NAMES } from "./chart-css-var-names";
+import { CHART_PALETTE_DERIVED_VARS } from "./chart-var-aliases";
 import {
   cloneFunnelLabelLayer,
   cloneHtmlOverlay,
@@ -41,6 +43,52 @@ function appendDocumentTypography(
   svg.insertBefore(style, svg.firstChild);
 }
 
+/** Embed palette + semantic chart vars from the Studio frame for self-contained SVGs. */
+function appendChartThemeVars(svg: SVGSVGElement, root: HTMLElement): void {
+  const rootStyle = getComputedStyle(root);
+  const declarations = new Map<string, string>();
+
+  for (let index = 1; index <= 5; index += 1) {
+    const name = `--chart-${index}`;
+    const value =
+      root.style.getPropertyValue(name) || rootStyle.getPropertyValue(name);
+    if (value) {
+      declarations.set(name, value.trim());
+    }
+  }
+
+  for (const [name, fallback] of Object.entries(CHART_PALETTE_DERIVED_VARS)) {
+    const value =
+      root.style.getPropertyValue(name) ||
+      rootStyle.getPropertyValue(name) ||
+      fallback;
+    if (value) {
+      declarations.set(name, value.trim());
+    }
+  }
+
+  for (const name of CHART_CSS_VAR_NAMES) {
+    if (declarations.has(name)) {
+      continue;
+    }
+    const value =
+      root.style.getPropertyValue(name) || rootStyle.getPropertyValue(name);
+    if (value) {
+      declarations.set(name, value.trim());
+    }
+  }
+
+  if (declarations.size === 0) {
+    return;
+  }
+
+  const style = createSvgElement("style");
+  style.textContent = `:root,svg{${[...declarations.entries()]
+    .map(([name, value]) => `${name}:${value}`)
+    .join(";")}}`;
+  svg.insertBefore(style, svg.firstChild);
+}
+
 /** Build a frame-composite SVG document string from the live Studio chart frame. */
 export function buildFrameSvg({
   root,
@@ -51,6 +99,7 @@ export function buildFrameSvg({
   const fontFamily = getStudioSansFontStack(root);
   const svg = createSvgElement("svg");
   appendDocumentTypography(svg, fontFamily, embeddedFontCss);
+  appendChartThemeVars(svg, root);
   svg.setAttribute("width", String(width));
   svg.setAttribute("height", String(height));
   svg.setAttribute("viewBox", `0 0 ${width} ${height}`);

--- a/apps/web/lib/studio/svg-export/chart-var-aliases.ts
+++ b/apps/web/lib/studio/svg-export/chart-var-aliases.ts
@@ -1,0 +1,11 @@
+/** Semantic chart tokens that derive from the palette when presets override --chart-1 … --chart-5. */
+export const CHART_PALETTE_DERIVED_VARS: Record<string, string> = {
+  "--chart-line-primary": "var(--chart-1)",
+  "--chart-line-secondary": "var(--chart-2)",
+};
+
+/** Fallback resolution when a semantic token is not defined on an ancestor. */
+export const CHART_VAR_ALIASES: Record<string, string> = {
+  "--chart-line-primary": "--chart-1",
+  "--chart-line-secondary": "--chart-2",
+};

--- a/apps/web/lib/studio/svg-export/inline-svg-styles.ts
+++ b/apps/web/lib/studio/svg-export/inline-svg-styles.ts
@@ -292,9 +292,9 @@ function walkElementsInSync(
 export function inlineSvgStyles(
   sourceSvg: Element,
   cloneSvg: Element,
-  styleSource: Element
+  _exportRoot: Element
 ): void {
   walkElementsInSync(sourceSvg, cloneSvg, (source, clone) => {
-    applyComputedPresentation(source, clone, styleSource);
+    applyComputedPresentation(source, clone, source);
   });
 }

--- a/apps/web/lib/studio/svg-export/resolve-css-var.ts
+++ b/apps/web/lib/studio/svg-export/resolve-css-var.ts
@@ -1,4 +1,7 @@
+import { CHART_VAR_ALIASES } from "./chart-var-aliases";
+
 const VAR_REFERENCE = /var\(\s*(--[\w-]+)/;
+const MAX_RESOLVE_DEPTH = 8;
 
 export function containsCssVar(value: string): boolean {
   return value.includes("var(");
@@ -43,9 +46,97 @@ export function parseVarExpression(value: string): {
   return name.startsWith("--") ? { name, fallback: fallback || null } : null;
 }
 
+function getCustomPropertyFromAncestors(
+  element: Element,
+  name: string,
+  aliasDepth = 0
+): string {
+  if (aliasDepth > MAX_RESOLVE_DEPTH) {
+    return "";
+  }
+
+  let current: Element | null = element;
+  while (current) {
+    const inlineValue =
+      current instanceof HTMLElement
+        ? current.style.getPropertyValue(name).trim()
+        : "";
+    if (inlineValue) {
+      return inlineValue;
+    }
+
+    const computedValue = getComputedStyle(current)
+      .getPropertyValue(name)
+      .trim();
+    if (computedValue) {
+      return computedValue;
+    }
+
+    current = current.parentElement;
+  }
+
+  const alias = CHART_VAR_ALIASES[name];
+  if (alias) {
+    return getCustomPropertyFromAncestors(element, alias, aliasDepth + 1);
+  }
+
+  return "";
+}
+
+interface ResolveContext {
+  element?: Element;
+  style: CSSStyleDeclaration;
+}
+
+function getCustomProperty(context: ResolveContext, name: string): string {
+  if (context.element) {
+    return getCustomPropertyFromAncestors(context.element, name);
+  }
+
+  return context.style.getPropertyValue(name).trim();
+}
+
+function resolveNestedValue(
+  context: ResolveContext,
+  value: string,
+  depth: number
+): string {
+  return resolveCssVarFromStyle(context.style, value, depth, context.element);
+}
+
+function resolveMaybeNested(
+  context: ResolveContext,
+  value: string,
+  depth: number
+): string {
+  if (containsCssVar(value)) {
+    return resolveNestedValue(context, value, depth + 1);
+  }
+
+  return value;
+}
+
+function resolveVarToken(
+  context: ResolveContext,
+  parsed: { name: string; fallback: string | null },
+  trimmed: string,
+  depth: number
+): string {
+  const resolved = getCustomProperty(context, parsed.name);
+  if (resolved) {
+    return resolveMaybeNested(context, resolved, depth);
+  }
+
+  if (parsed.fallback) {
+    return resolveMaybeNested(context, parsed.fallback, depth);
+  }
+
+  return trimmed;
+}
+
 /**
  * Resolve a CSS color/value that may contain `var(--token)` references.
- * Uses `getComputedStyle` on `element` so preset overrides on the frame apply.
+ * Walks the element's ancestor chain so preset overrides on the Studio frame apply.
  */
 export function resolveCssVar(element: Element, value: string): string {
   const trimmed = value.trim();
@@ -53,16 +144,16 @@ export function resolveCssVar(element: Element, value: string): string {
     return trimmed;
   }
 
-  const style = getComputedStyle(element);
-  return resolveCssVarFromStyle(style, trimmed);
+  return resolveCssVarFromStyle(getComputedStyle(element), trimmed, 0, element);
 }
 
 export function resolveCssVarFromStyle(
   style: CSSStyleDeclaration,
   value: string,
-  depth = 0
+  depth = 0,
+  element?: Element
 ): string {
-  if (depth > 8) {
+  if (depth > MAX_RESOLVE_DEPTH) {
     return value;
   }
 
@@ -71,29 +162,18 @@ export function resolveCssVarFromStyle(
     return trimmed;
   }
 
+  const context: ResolveContext = { style, element };
+
   if (trimmed.startsWith("var(")) {
     const parsed = parseVarExpression(trimmed);
     if (!parsed) {
       return trimmed;
     }
 
-    const resolved = style.getPropertyValue(parsed.name).trim();
-    if (resolved) {
-      return containsCssVar(resolved)
-        ? resolveCssVarFromStyle(style, resolved, depth + 1)
-        : resolved;
-    }
-
-    if (parsed.fallback) {
-      return containsCssVar(parsed.fallback)
-        ? resolveCssVarFromStyle(style, parsed.fallback, depth + 1)
-        : parsed.fallback;
-    }
-
-    return trimmed;
+    return resolveVarToken(context, parsed, trimmed, depth);
   }
 
   return trimmed.replace(/var\([^)]*(?:\([^)]*\)[^)]*)*\)/g, (match) =>
-    resolveCssVarFromStyle(style, match, depth + 1)
+    resolveNestedValue(context, match, depth)
   );
 }

--- a/packages/ui/src/charts/candlestick.tsx
+++ b/packages/ui/src/charts/candlestick.tsx
@@ -26,8 +26,8 @@ export interface CandlestickProps {
   fadedOpacity?: number;
 }
 
-const SOLID_POSITIVE = "var(--color-emerald-500)";
-const SOLID_NEGATIVE = "var(--color-red-500)";
+const SOLID_POSITIVE = "var(--chart-1)";
+const SOLID_NEGATIVE = "var(--chart-5)";
 
 const WICK_WIDTH = 1.5;
 

--- a/packages/ui/src/charts/gauge.tsx
+++ b/packages/ui/src/charts/gauge.tsx
@@ -8,6 +8,7 @@ import {
   isValidElement,
   type ReactElement,
   type ReactNode,
+  useId,
   useMemo,
 } from "react";
 import { cn } from "@/lib/utils";
@@ -202,6 +203,7 @@ function GaugeInner({
   enterStaggerScale = 1,
 }: GaugeInnerProps) {
   const prefersReducedMotion = useReducedMotion();
+  const themeActiveGradientId = `gauge-theme-active-${useId().replace(/:/g, "")}`;
   const defsChildren = useMemo(() => collectDefsElements(children), [children]);
 
   const notchTransition: Transition = prefersReducedMotion
@@ -241,6 +243,7 @@ function GaugeInner({
   const activeGrad1 = activeGradient?.[1] ?? DEFAULT_ACTIVE_GRADIENT[1];
   const inactiveGrad0 = inactiveGradient?.[0] ?? activeGrad0;
   const inactiveGrad1 = inactiveGradient?.[1] ?? activeGrad1;
+  const useThemePaletteGradient = useGradient && activeGradient === undefined;
 
   const notches = useMemo(() => {
     return Array.from({ length: totalNotches }, (_, i) => {
@@ -276,11 +279,10 @@ function GaugeInner({
 
       const denom = totalNotches > 1 ? totalNotches - 1 : 1;
       const gradientFactor = i / denom;
-      const gradientColor = interpolateHex(
-        activeGrad0,
-        activeGrad1,
-        gradientFactor
-      );
+      const gradientColor =
+        useGradient && !useThemePaletteGradient
+          ? interpolateHex(activeGrad0, activeGrad1, gradientFactor)
+          : "var(--chart-1)";
 
       return {
         index: i,
@@ -303,6 +305,8 @@ function GaugeInner({
     notchLength,
     activeGrad0,
     activeGrad1,
+    useGradient,
+    useThemePaletteGradient,
   ]);
 
   const createNotchPath = (
@@ -371,6 +375,9 @@ function GaugeInner({
     if (hasCustomInactive) {
       return inactiveFill as string;
     }
+    if (useThemePaletteGradient) {
+      return bgFillSolid;
+    }
     if (useGradient) {
       return interpolateHex(inactiveGrad0, inactiveGrad1, notchIndex / denom);
     }
@@ -380,6 +387,9 @@ function GaugeInner({
   const resolveActiveFill = (notch: (typeof notches)[number]) => {
     if (hasCustomActive) {
       return activeFill as string;
+    }
+    if (useThemePaletteGradient) {
+      return `url(#${themeActiveGradientId})`;
     }
     if (useGradient) {
       return notch.gradientColor;
@@ -396,7 +406,23 @@ function GaugeInner({
         viewBox={`0 0 ${width} ${height}`}
         width={width}
       >
-        {defsChildren.length > 0 ? <defs>{defsChildren}</defs> : null}
+        {defsChildren.length > 0 || useThemePaletteGradient ? (
+          <defs>
+            {useThemePaletteGradient ? (
+              <linearGradient
+                id={themeActiveGradientId}
+                x1="0%"
+                x2="100%"
+                y1="0%"
+                y2="0%"
+              >
+                <stop offset="0%" stopColor="var(--chart-1)" />
+                <stop offset="100%" stopColor="var(--chart-5)" />
+              </linearGradient>
+            ) : null}
+            {defsChildren}
+          </defs>
+        ) : null}
         {notches.map((notch) => (
           <motion.path
             animate={{ opacity: 1, scale: 1 }}

--- a/packages/ui/src/charts/live-line.tsx
+++ b/packages/ui/src/charts/live-line.tsx
@@ -147,8 +147,8 @@ export function LiveLine({
   );
 
   const defaultMomentumColors: MomentumColors = {
-    up: "var(--color-emerald-500)",
-    down: "var(--color-red-500)",
+    up: "var(--chart-1)",
+    down: "var(--chart-5)",
     flat: stroke,
   };
   const dotMomentumColors = momentumColors ?? defaultMomentumColors;


### PR DESCRIPTION
## Summary

- Derive `--chart-line-primary` / `--chart-line-secondary` on the Studio frame when a palette preset is active, and resolve CSS variables through the DOM ancestor chain with semantic aliases for export
- Embed the frame’s chart palette vars in exported SVGs and inline colors per-element so exports match the live preview
- Replace hardcoded chart colors in Gauge (gradient mode), Candlestick pattern underlays, Live line momentum dots, and studio candlestick gradients so the theme picker affects those charts

## Context

Follow-up to #78 — fixes charts that stayed on default theme colors and SVG exports that diverged from the Studio preview.

## Test plan

- [x] `pnpm lint` passes at repo root
- [x] `pnpm check-types` passes
- [x] `apps/web` unit tests pass (62/62)
- [x] `apps/web` production build succeeds
- [ ] Switch Studio theme presets on Gauge (gradient on), Candlestick (patterns + gradient), Live line, and Area — preview colors update
- [ ] Export SVG after changing preset — colors match preview


Made with [Cursor](https://cursor.com)