### PR TITLE
fix(studio): widen chart resize limit and clean up recording prep

### DIFF
--- a/apps/web/components/studio/studio-chart-frame.tsx
+++ b/apps/web/components/studio/studio-chart-frame.tsx
@@ -19,6 +19,8 @@ import { cn } from "@/lib/utils";
 
 export const STUDIO_CHART_FRAME_HEIGHT = 400;
 export const STUDIO_CHART_FRAME_WIDTH = 720;
+export const STUDIO_CHART_FRAME_MAX_WIDTH = 1000;
+export const STUDIO_CHART_FRAME_MAX_HEIGHT = 800;
 export const STUDIO_EXPORT_ROOT_ATTR = "data-studio-export-root";
 
 const MIN_WIDTH = 280;
@@ -67,11 +69,11 @@ function clampFrameSize(
   const safeH = finiteOr(height, STUDIO_CHART_FRAME_HEIGHT);
   const maxW = Math.max(
     MIN_WIDTH,
-    finiteOr(maxWidth, STUDIO_CHART_FRAME_WIDTH * 2)
+    finiteOr(maxWidth, STUDIO_CHART_FRAME_MAX_WIDTH)
   );
   const maxH = Math.max(
     MIN_HEIGHT,
-    finiteOr(maxHeight, STUDIO_CHART_FRAME_HEIGHT * 2)
+    finiteOr(maxHeight, STUDIO_CHART_FRAME_MAX_HEIGHT)
   );
 
   return {
@@ -139,15 +141,15 @@ export const StudioChartFrame = forwardRef<
   const draggingRef = useRef(false);
   const [isDragging, setIsDragging] = useState(false);
   const [maxSize, setMaxSize] = useState({
-    width: STUDIO_CHART_FRAME_WIDTH * 2,
-    height: STUDIO_CHART_FRAME_HEIGHT * 2,
+    width: STUDIO_CHART_FRAME_MAX_WIDTH,
+    height: STUDIO_CHART_FRAME_MAX_HEIGHT,
   });
   const [size, setSize] = useState<FrameSize>(() =>
     clampFrameSize(
       width,
       height,
-      STUDIO_CHART_FRAME_WIDTH * 2,
-      STUDIO_CHART_FRAME_HEIGHT * 2
+      STUDIO_CHART_FRAME_MAX_WIDTH,
+      STUDIO_CHART_FRAME_MAX_HEIGHT
     )
   );
 
@@ -160,8 +162,11 @@ export const StudioChartFrame = forwardRef<
     }
     const update = () => {
       setMaxSize({
-        width: Math.max(bounds.clientWidth, STUDIO_CHART_FRAME_WIDTH),
-        height: Math.max(bounds.clientHeight, STUDIO_CHART_FRAME_HEIGHT),
+        width: STUDIO_CHART_FRAME_MAX_WIDTH,
+        height: Math.min(
+          STUDIO_CHART_FRAME_MAX_HEIGHT,
+          Math.max(bounds.clientHeight, STUDIO_CHART_FRAME_HEIGHT)
+        ),
       });
     };
     update();

--- a/apps/web/components/studio/studio-preview.tsx
+++ b/apps/web/components/studio/studio-preview.tsx
@@ -6,6 +6,7 @@ import { useReducedMotion } from "motion/react";
 import { useCallback, useMemo, useRef, useState } from "react";
 import { PresetSelect } from "@/components/studio/controls/preset-select";
 import {
+  STUDIO_CHART_FRAME_MAX_WIDTH,
   STUDIO_EXPORT_ROOT_ATTR,
   StudioChartFrame,
 } from "@/components/studio/studio-chart-frame";
@@ -57,7 +58,9 @@ export function StudioPreview() {
   const frameSizeBeforeRecording = useRef<{ w: number; h: number } | null>(
     null
   );
+  const recordingPrepStartedRef = useRef(false);
   const [capturePrepared, setCapturePrepared] = useState(false);
+  const [recordingChartHeld, setRecordingChartHeld] = useState(false);
   const reducedMotion = useReducedMotion();
   const {
     phase,
@@ -76,6 +79,30 @@ export function StudioPreview() {
   const replay = useCallback(() => {
     setAnimationKey((k) => k + 1);
   }, []);
+
+  const replayForRecording = useCallback(() => {
+    setRecordingChartHeld(false);
+    setAnimationKey((k) => k + 1);
+  }, []);
+
+  const restorePreviewChart = useCallback(() => {
+    setRecordingChartHeld(false);
+    replay();
+  }, [replay]);
+
+  const handleRecordPopoverOpenChange = useCallback(
+    (open: boolean) => {
+      if (open) {
+        setRecordingChartHeld(true);
+        return;
+      }
+      if (recordingPrepStartedRef.current || isRecording || capturePrepared) {
+        return;
+      }
+      restorePreviewChart();
+    },
+    [capturePrepared, isRecording, restorePreviewChart]
+  );
 
   const patternDefs = useMemo(
     () => <StudioPatternDefs preset={displayState.pattern} />,
@@ -104,6 +131,7 @@ export function StudioPreview() {
         return;
       }
 
+      recordingPrepStartedRef.current = true;
       const saved = { w: state.frameW, h: state.frameH };
       const dimensions = getRecordingCaptureDimensions(
         state.frameW,
@@ -111,6 +139,7 @@ export function StudioPreview() {
         aspect
       );
 
+      setRecordingChartHeld(true);
       setCapturePrepared(true);
 
       if (aspect === "16:9") {
@@ -132,7 +161,7 @@ export function StudioPreview() {
           height: dimensions.captureHeight,
           state: displayState,
           chart: state.chart,
-          replay,
+          replay: replayForRecording,
           interactionMs,
           format,
           onFinished: () => {
@@ -142,15 +171,19 @@ export function StudioPreview() {
               frameSizeBeforeRecording.current = null;
             }
             setCapturePrepared(false);
+            recordingPrepStartedRef.current = false;
+            restorePreviewChart();
           },
         });
       } finally {
         setCapturePrepared(false);
+        recordingPrepStartedRef.current = false;
       }
     },
     [
       displayState,
-      replay,
+      replayForRecording,
+      restorePreviewChart,
       setFrameSize,
       startRecording,
       state.chart,
@@ -160,7 +193,7 @@ export function StudioPreview() {
   );
 
   const recordingBlocked = reducedMotion === true;
-  const controlsDisabled = isRecording || capturePrepared;
+  const controlsDisabled = isRecording || capturePrepared || recordingChartHeld;
   const showCaptureLayout = isRecording || capturePrepared;
   const showRecordingChrome = isRecording && timeline;
 
@@ -211,6 +244,7 @@ export function StudioPreview() {
           <StudioRecordPopover
             disabled={recordingBlocked}
             isRecording={isRecording}
+            onOpenChange={handleRecordPopoverOpenChange}
             onStart={handleStartRecording}
             onStop={stopRecording}
           />
@@ -255,10 +289,13 @@ export function StudioPreview() {
           <div
             className={cn(
               "relative z-2 flex min-h-0 w-full flex-1 flex-col",
-              showCaptureLayout
-                ? "gap-4"
-                : "max-w-3xl items-center justify-center gap-5"
+              showCaptureLayout ? "gap-4" : "items-center justify-center gap-5"
             )}
+            style={
+              showCaptureLayout
+                ? undefined
+                : { maxWidth: STUDIO_CHART_FRAME_MAX_WIDTH }
+            }
           >
             <div
               className="relative flex min-h-0 w-full flex-1 items-center justify-center"
@@ -309,21 +346,23 @@ export function StudioPreview() {
                     width={state.frameW}
                   >
                     <div className="flex size-full min-h-0 items-center justify-center">
-                      <StudioChartViewport>
-                        {(frame) => {
-                          const renderCtx: StudioRenderContext = {
-                            animationKey,
-                            isRecording: isRecording || capturePrepared,
-                            motionRemountKey,
-                            committedState: state,
-                            motionCurveDragging,
-                            patternDefs,
-                            patternFill,
-                            frame,
-                          };
-                          return config.render(displayState, renderCtx);
-                        }}
-                      </StudioChartViewport>
+                      {recordingChartHeld ? null : (
+                        <StudioChartViewport>
+                          {(frame) => {
+                            const renderCtx: StudioRenderContext = {
+                              animationKey,
+                              isRecording,
+                              motionRemountKey,
+                              committedState: state,
+                              motionCurveDragging,
+                              patternDefs,
+                              patternFill,
+                              frame,
+                            };
+                            return config.render(displayState, renderCtx);
+                          }}
+                        </StudioChartViewport>
+                      )}
                     </div>
                   </StudioChartFrame>
                 </div>

--- a/apps/web/components/studio/studio-record-popover.tsx
+++ b/apps/web/components/studio/studio-record-popover.tsx
@@ -28,11 +28,13 @@ import { cn } from "@/lib/utils";
 export function StudioRecordPopover({
   disabled,
   isRecording,
+  onOpenChange,
   onStart,
   onStop,
 }: {
   disabled?: boolean;
   isRecording: boolean;
+  onOpenChange?: (open: boolean) => void;
   onStart: (
     interactionMs: StudioRecordingInteractionMs,
     aspect: StudioRecordingAspect,
@@ -63,7 +65,13 @@ export function StudioRecordPopover({
   }
 
   return (
-    <Popover onOpenChange={setOpen} open={open}>
+    <Popover
+      onOpenChange={(nextOpen) => {
+        setOpen(nextOpen);
+        onOpenChange?.(nextOpen);
+      }}
+      open={open}
+    >
       <Tooltip>
         <TooltipTrigger render={<span className="inline-flex" />}>
           <PopoverTrigger asChild>
@@ -177,8 +185,8 @@ export function StudioRecordPopover({
         <Button
           className="mt-4 w-full"
           onClick={() => {
-            setOpen(false);
             onStart(interactionMs, aspect, format);
+            setOpen(false);
           }}
           type="button"
         >


### PR DESCRIPTION
## Summary

- Raise the studio chart frame max width from 768px to 1000px so users can resize wider during design and export.
- Hold the chart empty while the record popover is open and through recording setup, then remount at the timeline replay point so captured videos start from a clean reveal instead of a spurious pre-animation.
- Stop applying linear recording motion during capture prep, which was causing a fast in/out flash before the real enter animation.

## Test plan

- [x] `pnpm lint` passes at repo root
- [x] `apps/web` production build succeeds
- [ ] Studio chart frame can be resized up to ~1000px wide
- [ ] Open record popover clears the chart; closing without recording restores preview animation
- [ ] Start a recording and confirm the video intro holds on an empty frame, then animates in smoothly at the replay marker


Made with [Cursor](https://cursor.com)