### PR TITLE
docs(charts): add dashed tail sections to line and area docs

### DIFF
--- a/apps/web/content/docs/components/area-chart.mdx
+++ b/apps/web/content/docs/components/area-chart.mdx
@@ -115,8 +115,6 @@ Renders a filled area on the chart with a gradient fill.
 | `fadeEdges` | `boolean` | `false` | Fade area fill at left/right edges |
 | `showMarkers` | `boolean` | `false` | Render scatter-style ring markers at each point |
 | `markers` | `SeriesPointMarkerStyle` | — | Marker styling (same options as [`Scatter`](/docs/components/scatter-chart)) |
-| `dashFromIndex` | `number` | — | Inclusive data index where the dashed tail begins; solid stroke before, dashed through the end |
-| `dashArray` | `string` | `"6,4"` | SVG dash pattern for the tail segment |
 
 ### PatternArea
 
@@ -162,6 +160,27 @@ Renders the tooltip with crosshair, dots, and content box.
 | `showDots` | `boolean` | `true` | Show dots on series |
 | `content` | `(props) => ReactNode` | - | Custom content renderer |
 | `rows` | `(point) => TooltipRow[]` | - | Custom row generator |
+
+## Dashed tail
+
+Set `dashFromIndex` on `Area` to draw a solid stroke through one data point, then a dashed segment through the end of the series. Useful when the final period is still in progress (e.g. yesterday → today).
+
+`dashFromIndex` is **inclusive** — dashing starts at that row and continues through the last point. The dashed segment follows the same curved path as the solid stroke and respects the stroke gradient fade from `fadeEdges`.
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `dashFromIndex` | `number` | — | Inclusive data index where the dashed tail begins |
+| `dashArray` | `string` | `"6,4"` | SVG `stroke-dasharray` pattern for the tail segment |
+
+```tsx
+<Area
+  dataKey="visitors"
+  dashFromIndex={5}
+  dashArray="6,4"
+  fill="var(--chart-line-primary)"
+  fillOpacity={0.35}
+/>
+```
 
 ## Markers
 

--- a/apps/web/content/docs/components/line-chart.mdx
+++ b/apps/web/content/docs/components/line-chart.mdx
@@ -84,8 +84,6 @@ Renders a line on the chart.
 | `showHighlight` | `boolean` | `true` | Show highlight on hover |
 | `showMarkers` | `boolean` | `false` | Render scatter-style ring markers at each point |
 | `markers` | `SeriesPointMarkerStyle` | — | Marker styling (same options as [`Scatter`](/docs/components/scatter-chart)) |
-| `dashFromIndex` | `number` | — | Inclusive data index where the dashed tail begins; solid stroke before, dashed through the end |
-| `dashArray` | `string` | `"6,4"` | SVG dash pattern for the tail segment |
 
 ### Grid
 
@@ -121,6 +119,26 @@ Renders the tooltip with crosshair, dots, and content box.
 | `showDots` | `boolean` | `true` | Show dots on lines |
 | `content` | `(props) => ReactNode` | - | Custom content renderer |
 | `rows` | `(point) => TooltipRow[]` | - | Custom row generator |
+
+## Dashed tail
+
+Set `dashFromIndex` on `Line` to draw a solid stroke through one data point, then a dashed segment through the end of the series. Useful when the final period is still in progress (e.g. yesterday → today).
+
+`dashFromIndex` is **inclusive** — dashing starts at that row and continues through the last point. The dashed segment follows the same curved path as the solid stroke and respects `fadeEdges`.
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `dashFromIndex` | `number` | — | Inclusive data index where the dashed tail begins |
+| `dashArray` | `string` | `"6,4"` | SVG `stroke-dasharray` pattern for the tail segment |
+
+```tsx
+<Line
+  dataKey="visitors"
+  dashFromIndex={5}
+  dashArray="6,4"
+  stroke="var(--chart-line-primary)"
+/>
+```
 
 ## Markers
 


### PR DESCRIPTION
## Summary

- Add dedicated **Dashed tail** sections to the line and area chart docs with brief usage notes and prop tables for `dashFromIndex` and `dashArray`
- Move dash props out of the main `Line` / `Area` tables so the API is easier to find after #85 landed

## Test plan

- [x] `pnpm lint` passes at repo root
- [x] `apps/web` production build succeeds
- [ ] Docs: verify `/docs/components/line-chart#dashed-tail` and `/docs/components/area-chart#dashed-tail` render the new sections