### PR TITLE
perf(charts): decimation, hover batching, and group-layer interaction

### DIFF
--- a/packages/ui/src/charts/__tests__/decimate-time-series.test.ts
+++ b/packages/ui/src/charts/__tests__/decimate-time-series.test.ts
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
 import {
+  decimateOhlcData,
   decimateTimeSeries,
   maxRenderPointsForWidth,
 } from "../decimate-time-series";
@@ -25,6 +26,22 @@ describe("decimateTimeSeries", () => {
     }));
     const sampled = decimateTimeSeries(data, 10, ["v"]);
     assert(sampled.some((point) => point.v === 1000));
+  });
+});
+
+describe("decimateOhlcData", () => {
+  it("preserves bucket high/low extremes", () => {
+    const data = Array.from({ length: 100 }, (_, i) => ({
+      date: new Date(i),
+      open: i,
+      high: i === 50 ? 999 : i + 5,
+      low: i === 50 ? 1 : i - 5,
+      close: i + 1,
+    }));
+    const sampled = decimateOhlcData(data, 10);
+    assert(sampled.some((row) => row.high === 999));
+    assert(sampled.some((row) => row.low === 1));
+    assert.equal(sampled.length, 10);
   });
 });
 

--- a/packages/ui/src/charts/__tests__/decimate-time-series.test.ts
+++ b/packages/ui/src/charts/__tests__/decimate-time-series.test.ts
@@ -1,0 +1,39 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import {
+  decimateTimeSeries,
+  maxRenderPointsForWidth,
+} from "../decimate-time-series";
+
+describe("decimateTimeSeries", () => {
+  it("returns the original array when under the point budget", () => {
+    const data = [{ v: 1 }, { v: 2 }, { v: 3 }];
+    assert.equal(decimateTimeSeries(data, 10), data);
+  });
+
+  it("always keeps the first and last points", () => {
+    const data = Array.from({ length: 100 }, (_, i) => ({ v: i }));
+    const sampled = decimateTimeSeries(data, 20, ["v"]);
+    assert.equal(sampled[0]?.v, 0);
+    assert.equal(sampled.at(-1)?.v, 99);
+    assert.equal(sampled.length, 20);
+  });
+
+  it("preserves spikes in the series", () => {
+    const data = Array.from({ length: 50 }, (_, i) => ({
+      v: i === 25 ? 1000 : i,
+    }));
+    const sampled = decimateTimeSeries(data, 10, ["v"]);
+    assert(sampled.some((point) => point.v === 1000));
+  });
+});
+
+describe("maxRenderPointsForWidth", () => {
+  it("returns at least 64 points", () => {
+    assert.equal(maxRenderPointsForWidth(10), 64);
+  });
+
+  it("scales with chart width", () => {
+    assert.equal(maxRenderPointsForWidth(400), 600);
+  });
+});

--- a/packages/ui/src/charts/area.tsx
+++ b/packages/ui/src/charts/area.tsx
@@ -78,6 +78,7 @@ export function Area({
 }: AreaProps) {
   const {
     data,
+    renderData,
     xScale,
     yScale,
     innerHeight,
@@ -91,7 +92,7 @@ export function Area({
   } = useChart();
 
   const pathRef = useRef<SVGPathElement>(null);
-  const pathMetricsKey = `${data.length}:${innerWidth}:${dashFromIndex}:${showLine}`;
+  const pathMetricsKey = `${renderData.length}:${innerWidth}:${dashFromIndex}:${showLine}`;
   const { pathLength, pathD } = usePathStrokeMetrics(pathRef, pathMetricsKey);
 
   // Unique IDs for this area
@@ -101,7 +102,7 @@ export function Area({
   const edgeMaskId = `area-edge-mask-${dataKey}-${uniqueId}`;
   const edgeGradientId = `${edgeMaskId}-gradient`;
   const revealClipId = `grow-clip-area-${dataKey}-${uniqueId}`;
-  const useRevealClip = animate && data.length > 1 && innerWidth > 0;
+  const useRevealClip = animate && renderData.length > 1 && innerWidth > 0;
 
   const isPatternFill = fill.startsWith("url(");
   const showAreaFill = isPatternFill || fillOpacity > 0;
@@ -175,7 +176,7 @@ export function Area({
             >
               <AreaClosed
                 curve={curve}
-                data={data}
+                data={renderData}
                 fill={areaFill}
                 x={(d) => xScale(xAccessor(d)) ?? 0}
                 y={getY}
@@ -189,7 +190,7 @@ export function Area({
             <>
               <LinePath
                 curve={curve}
-                data={data}
+                data={renderData}
                 innerRef={pathRef}
                 stroke={hasDashTail ? "transparent" : strokePaint}
                 strokeLinecap="round"

--- a/packages/ui/src/charts/bar-chart.tsx
+++ b/packages/ui/src/charts/bar-chart.tsx
@@ -485,6 +485,7 @@ const ChartCore = memo(function ChartCore({
 
   const contextValue = {
     data,
+    renderData: data,
     xScale: fakeTimeScale as unknown as ReturnType<
       typeof import("@visx/scale").scaleTime<number>
     >,

--- a/packages/ui/src/charts/bar-chart.tsx
+++ b/packages/ui/src/charts/bar-chart.tsx
@@ -27,6 +27,7 @@ import {
 } from "./chart-context";
 import { isGradientDefComponent, isPatternDefComponent } from "./chart-defs";
 import { shortDateFmt } from "./chart-formatters";
+import { useScheduledTooltip } from "./use-scheduled-tooltip";
 
 export type BarOrientation = "vertical" | "horizontal";
 
@@ -169,10 +170,11 @@ const ChartCore = memo(function ChartCore({
   children,
   containerRef,
 }: ChartInnerProps) {
-  const [tooltipData, setTooltipData] = useState<TooltipData | null>(null);
+  const { tooltipData, setTooltipData, scheduleTooltip, clearTooltip } =
+    useScheduledTooltip<TooltipData>();
   const [isLoaded, setIsLoaded] = useState(false);
   const [revealEpoch, setRevealEpoch] = useState(0);
-  const [hoveredBarIndex, setHoveredBarIndex] = useState<number | null>(null);
+  const hoveredBarIndex = tooltipData?.index ?? null;
 
   const isHorizontal = orientation === "horizontal";
 
@@ -430,14 +432,13 @@ const ChartCore = memo(function ChartCore({
         tooltipX = barPos + bandWidth / 2;
       }
 
-      setTooltipData({
+      scheduleTooltip({
         point: d,
         index: clampedIndex,
         x: tooltipX,
         yPositions,
         xPositions: Object.keys(xPositions).length > 0 ? xPositions : undefined,
       });
-      setHoveredBarIndex(clampedIndex);
     },
     [
       categoryScale,
@@ -452,13 +453,13 @@ const ChartCore = memo(function ChartCore({
       isHorizontal,
       stacked,
       stackGap,
+      scheduleTooltip,
     ]
   );
 
   const handleMouseLeave = useCallback(() => {
-    setTooltipData(null);
-    setHoveredBarIndex(null);
-  }, []);
+    clearTooltip();
+  }, [clearTooltip]);
 
   const canInteract = isLoaded;
 
@@ -511,7 +512,6 @@ const ChartCore = memo(function ChartCore({
     barScale: categoryScale,
     bandWidth,
     hoveredBarIndex,
-    setHoveredBarIndex,
     barXAccessor: categoryAccessor,
     orientation,
     stacked,

--- a/packages/ui/src/charts/bar.tsx
+++ b/packages/ui/src/charts/bar.tsx
@@ -111,18 +111,20 @@ function AnimatedBar({
     : { width, height, x, y };
 
   return (
-    <motion.rect
-      animate={{
-        ...target,
-        opacity: isFaded ? fadedOpacity : 1,
-      }}
-      fill={fill}
-      initial={initial}
-      key={`grow-${index}-${revealEpoch}`}
-      rx={rx}
-      ry={ry}
-      transition={enterAnim}
-    />
+    <g
+      opacity={isFaded ? fadedOpacity : 1}
+      style={{ transition: "opacity 0.15s ease-in-out" }}
+    >
+      <motion.rect
+        animate={target}
+        fill={fill}
+        initial={initial}
+        key={`grow-${index}-${revealEpoch}`}
+        rx={rx}
+        ry={ry}
+        transition={enterAnim}
+      />
+    </g>
   );
 }
 
@@ -146,7 +148,6 @@ const BarInner = memo(function BarInner({
     innerHeight,
     isLoaded,
     hoveredBarIndex,
-    setHoveredBarIndex,
     lines,
     orientation,
     stacked,
@@ -309,22 +310,16 @@ const BarInner = memo(function BarInner({
 
         // Static bar after animation completes
         return (
-          <motion.rect
-            animate={{
-              opacity: isFaded ? fadedOpacity : 1,
-            }}
+          <rect
             fill={fill}
             height={barHeight}
             key={barKey}
-            onMouseEnter={() => setHoveredBarIndex?.(i)}
-            onMouseLeave={() => setHoveredBarIndex?.(null)}
+            opacity={isFaded ? fadedOpacity : 1}
             rx={effectiveRx}
             ry={effectiveRy}
             style={{
-              cursor: "pointer",
-            }}
-            transition={{
-              opacity: { duration: 0.15 },
+              cursor: "default",
+              transition: "opacity 0.15s ease-in-out",
             }}
             width={barW}
             x={x}

--- a/packages/ui/src/charts/candlestick-chart.tsx
+++ b/packages/ui/src/charts/candlestick-chart.tsx
@@ -245,6 +245,7 @@ const ChartCore = memo(function ChartCore({
 
   const contextValue = {
     data,
+    renderData: data,
     xScale,
     yScale,
     width,

--- a/packages/ui/src/charts/candlestick-chart.tsx
+++ b/packages/ui/src/charts/candlestick-chart.tsx
@@ -19,6 +19,10 @@ import {
 import { cn } from "@/lib/utils";
 import { ChartProvider, type LineConfig, type Margin } from "./chart-context";
 import { shortDateFmt } from "./chart-formatters";
+import {
+  decimateOhlcData,
+  maxRenderPointsForWidth,
+} from "./decimate-time-series";
 import { useChartInteraction } from "./use-chart-interaction";
 
 export interface OHLCDataPoint {
@@ -105,9 +109,6 @@ const ChartCore = memo(function ChartCore({
 }: ChartInnerProps) {
   const [isLoaded, setIsLoaded] = useState(false);
   const [revealEpoch, setRevealEpoch] = useState(0);
-  const [hoveredCandleIndex, setHoveredCandleIndex] = useState<number | null>(
-    null
-  );
 
   const innerWidth = width - margin.left - margin.right;
   const innerHeight = height - margin.top - margin.bottom;
@@ -179,6 +180,11 @@ const ChartCore = memo(function ChartCore({
     []
   );
 
+  const renderData = useMemo(
+    () => decimateOhlcData(data, maxRenderPointsForWidth(innerWidth)),
+    [data, innerWidth]
+  );
+
   const dateLabels = useMemo(
     () => data.map((d) => shortDateFmt.format(xAccessor(d))),
     [data, xAccessor]
@@ -210,10 +216,7 @@ const ChartCore = memo(function ChartCore({
     canInteract: isLoaded,
   });
 
-  // Sync hovered candle index from tooltip (so Candlestick can fade others)
-  useEffect(() => {
-    setHoveredCandleIndex(tooltipData?.index ?? null);
-  }, [tooltipData?.index]);
+  const hoveredCandleIndex = tooltipData?.index ?? null;
 
   const isDefsComponent = (child: ReactElement): boolean => {
     const displayName =
@@ -245,7 +248,7 @@ const ChartCore = memo(function ChartCore({
 
   const contextValue = {
     data,
-    renderData: data,
+    renderData,
     xScale,
     yScale,
     width,
@@ -268,7 +271,6 @@ const ChartCore = memo(function ChartCore({
     clearSelection,
     bandWidth,
     hoveredCandleIndex,
-    setHoveredCandleIndex,
   };
 
   return (

--- a/packages/ui/src/charts/candlestick.tsx
+++ b/packages/ui/src/charts/candlestick.tsx
@@ -2,12 +2,16 @@
 
 import type { Transition } from "motion/react";
 import { motion } from "motion/react";
-import { useMemo } from "react";
+import { memo, useMemo } from "react";
 import { useChart } from "./chart-context";
 import { transitionWithDelay } from "./motion-utils";
 
 const DEFAULT_POSITIVE = "url(#candlestick-positive)";
 const DEFAULT_NEGATIVE = "url(#candlestick-negative)";
+
+const SOLID_POSITIVE = "var(--chart-1)";
+const SOLID_NEGATIVE = "var(--chart-5)";
+const WICK_WIDTH = 1.5;
 
 export interface CandlestickProps {
   /** Whether to animate the candlesticks. Default: true */
@@ -24,134 +28,232 @@ export interface CandlestickProps {
   insideStrokeWidth?: number;
   /** Opacity when another candle is hovered. Default: 0.3 */
   fadedOpacity?: number;
+  /** Dim non-hovered candles on hover. Default: true */
+  showHoverFade?: boolean;
 }
 
-const SOLID_POSITIVE = "var(--chart-1)";
-const SOLID_NEGATIVE = "var(--chart-5)";
-
-const WICK_WIDTH = 1.5;
+interface CandleGeometry {
+  time: number;
+  centerX: number;
+  bodyTop: number;
+  bodyHeight: number;
+  bodyLeft: number;
+  candleWidth: number;
+  wickTop: number;
+  wickHeight: number;
+  wickLeft: number;
+  bodySolidFill: string;
+  wickFill: string;
+  bodyPattern?: string;
+  insideStrokeWidth: number;
+}
 
 function getSolidColor(isPositive: boolean): string {
   return isPositive ? SOLID_POSITIVE : SOLID_NEGATIVE;
 }
 
-interface CandleShape {
-  bodyHeight: number;
-  bodyLeft: number;
-  bodyTop: number;
-  bodySolidFill: string;
-  wickFill: string;
-  wickHeight: number;
-  wickLeft: number;
-  wickTop: number;
-  centerX: number;
-  wickCenterY: number;
-  candleWidth: number;
-  bodyPattern: string | undefined;
-  hasPatternOverlay: boolean;
-  insideStrokeWidth: number;
-  enterTransition: Transition;
-  delay: number;
-  revealEpoch: number;
-  isFaded: boolean;
-  fadedOpacity: number;
+function computeGeometries(
+  renderData: Record<string, unknown>[],
+  xScale: (value: Date) => number | undefined,
+  yScale: (value: number) => number | undefined,
+  xAccessor: (d: Record<string, unknown>) => Date,
+  candleWidth: number,
+  positiveFill: string,
+  negativeFill: string,
+  bodyPatternPositive: string | undefined,
+  bodyPatternNegative: string | undefined,
+  insideStrokeWidth: number
+): CandleGeometry[] {
+  return renderData.map((d) => {
+    const date = xAccessor(d);
+    const open = d.open as number;
+    const high = d.high as number;
+    const low = d.low as number;
+    const close = d.close as number;
+    const centerX = xScale(date) ?? 0;
+    const yHigh = yScale(high) ?? 0;
+    const yLow = yScale(low) ?? 0;
+    const yOpen = yScale(open) ?? 0;
+    const yClose = yScale(close) ?? 0;
+    const bodyTop = Math.min(yOpen, yClose);
+    const bodyHeight = Math.abs(yClose - yOpen) || 1;
+    const bodyLeft = centerX - candleWidth / 2;
+    const wickTop = Math.min(yHigh, yLow);
+    const wickHeight = Math.abs(yLow - yHigh) || 1;
+    const isPositive = close >= open;
+    const fill = isPositive ? positiveFill : negativeFill;
+    const bodyPattern = isPositive ? bodyPatternPositive : bodyPatternNegative;
+    const hasPatternOverlay = Boolean(bodyPattern);
+    const bodySolidFill = hasPatternOverlay ? getSolidColor(isPositive) : fill;
+
+    return {
+      time: date.getTime(),
+      centerX,
+      bodyTop,
+      bodyHeight,
+      bodyLeft,
+      candleWidth,
+      wickTop,
+      wickHeight,
+      wickLeft: centerX - WICK_WIDTH / 2,
+      bodySolidFill,
+      wickFill: hasPatternOverlay ? bodySolidFill : fill,
+      bodyPattern: hasPatternOverlay ? bodyPattern : undefined,
+      insideStrokeWidth,
+    };
+  });
 }
 
-function CandleRect({
-  bodyHeight,
-  bodyLeft,
-  bodyTop,
-  bodySolidFill,
-  wickFill,
-  wickHeight,
-  wickLeft,
-  wickTop,
-  centerX,
-  wickCenterY,
-  candleWidth,
-  bodyPattern,
-  hasPatternOverlay,
-  insideStrokeWidth,
-  enterTransition,
-  delay,
-  revealEpoch,
-  isFaded,
-  fadedOpacity,
-}: CandleShape) {
-  const bodyOrigin = `${centerX}px ${bodyTop + bodyHeight / 2}px`;
-  const t = transitionWithDelay(enterTransition, delay);
+const CandlestickBody = memo(function CandlestickBody({
+  geometry,
+}: {
+  geometry: CandleGeometry;
+}) {
+  const {
+    wickLeft,
+    wickTop,
+    wickHeight,
+    wickFill,
+    bodyLeft,
+    bodyTop,
+    bodyHeight,
+    candleWidth,
+    bodySolidFill,
+    bodyPattern,
+    insideStrokeWidth,
+  } = geometry;
+
   return (
-    <g
-      opacity={isFaded ? fadedOpacity : 1}
-      style={{ transition: "opacity 0.15s ease-in-out" }}
-    >
-      <motion.g
-        animate={{ opacity: 1 }}
-        initial={{ opacity: 0 }}
-        key={`candle-enter-${centerX}-${revealEpoch}`}
-        style={{ transformOrigin: `${centerX}px ${wickCenterY}px` }}
-        transition={{ ...t, opacity: { duration: 0.15 } }}
-      >
-        <motion.rect
-          animate={{ scaleY: 1 }}
-          fill={wickFill}
-          height={wickHeight}
-          initial={{ scaleY: 0 }}
-          style={{ transformOrigin: `${centerX}px ${wickCenterY}px` }}
-          transition={t}
-          width={WICK_WIDTH}
-          x={wickLeft}
-          y={wickTop}
-        />
-        <motion.rect
-          animate={{ scaleY: 1 }}
-          fill={bodySolidFill}
+    <>
+      <rect
+        fill={wickFill}
+        height={wickHeight}
+        width={WICK_WIDTH}
+        x={wickLeft}
+        y={wickTop}
+      />
+      <rect
+        fill={bodySolidFill}
+        height={bodyHeight}
+        rx={1}
+        ry={1}
+        stroke={bodySolidFill}
+        strokeWidth={1}
+        width={candleWidth}
+        x={bodyLeft}
+        y={bodyTop}
+      />
+      {bodyPattern ? (
+        <rect
+          fill={bodyPattern}
           height={bodyHeight}
-          initial={{ scaleY: 0 }}
           rx={1}
           ry={1}
-          stroke={bodySolidFill}
-          strokeWidth={1}
-          style={{ transformOrigin: bodyOrigin }}
-          transition={t}
           width={candleWidth}
           x={bodyLeft}
           y={bodyTop}
         />
-        {hasPatternOverlay && bodyPattern && (
-          <motion.rect
-            animate={{ scaleY: 1 }}
-            fill={bodyPattern}
-            height={bodyHeight}
-            initial={{ scaleY: 0 }}
-            rx={1}
-            ry={1}
-            style={{ transformOrigin: bodyOrigin }}
-            transition={t}
-            width={candleWidth}
-            x={bodyLeft}
-            y={bodyTop}
-          />
-        )}
-        {insideStrokeWidth > 0 && (
-          <motion.rect
-            animate={{ scaleY: 1 }}
-            fill="none"
-            height={bodyHeight - insideStrokeWidth}
-            initial={{ scaleY: 0 }}
-            rx={1}
-            ry={1}
-            stroke={bodySolidFill}
-            strokeWidth={insideStrokeWidth}
-            style={{ transformOrigin: bodyOrigin }}
-            transition={t}
-            width={candleWidth - insideStrokeWidth}
-            x={bodyLeft + insideStrokeWidth / 2}
-            y={bodyTop + insideStrokeWidth / 2}
-          />
-        )}
-      </motion.g>
-    </g>
+      ) : null}
+      {insideStrokeWidth > 0 ? (
+        <rect
+          fill="none"
+          height={bodyHeight - insideStrokeWidth}
+          rx={1}
+          ry={1}
+          stroke={bodySolidFill}
+          strokeWidth={insideStrokeWidth}
+          width={candleWidth - insideStrokeWidth}
+          x={bodyLeft + insideStrokeWidth / 2}
+          y={bodyTop + insideStrokeWidth / 2}
+        />
+      ) : null}
+    </>
+  );
+});
+
+const CandlestickBodies = memo(function CandlestickBodies({
+  geometries,
+}: {
+  geometries: CandleGeometry[];
+}) {
+  return (
+    <>
+      {geometries.map((geometry) => (
+        <g key={geometry.time}>
+          <CandlestickBody geometry={geometry} />
+        </g>
+      ))}
+    </>
+  );
+});
+
+interface AnimatedCandleProps {
+  geometry: CandleGeometry;
+  delay: number;
+  enterTransition: Transition;
+  revealEpoch: number;
+}
+
+function AnimatedCandle({
+  geometry,
+  delay,
+  enterTransition,
+  revealEpoch,
+}: AnimatedCandleProps) {
+  const t = transitionWithDelay(enterTransition, delay);
+  const bodyOrigin = `${geometry.centerX}px ${geometry.bodyTop + geometry.bodyHeight / 2}px`;
+  const wickCenterY = geometry.wickTop + geometry.wickHeight / 2;
+
+  return (
+    <motion.g
+      animate={{ opacity: 1 }}
+      initial={{ opacity: 0 }}
+      key={`candle-enter-${geometry.time}-${revealEpoch}`}
+      style={{ transformOrigin: `${geometry.centerX}px ${wickCenterY}px` }}
+      transition={{ ...t, opacity: { duration: 0.15 } }}
+    >
+      <motion.rect
+        animate={{ scaleY: 1 }}
+        fill={geometry.wickFill}
+        height={geometry.wickHeight}
+        initial={{ scaleY: 0 }}
+        style={{ transformOrigin: `${geometry.centerX}px ${wickCenterY}px` }}
+        transition={t}
+        width={WICK_WIDTH}
+        x={geometry.wickLeft}
+        y={geometry.wickTop}
+      />
+      <motion.rect
+        animate={{ scaleY: 1 }}
+        fill={geometry.bodySolidFill}
+        height={geometry.bodyHeight}
+        initial={{ scaleY: 0 }}
+        rx={1}
+        ry={1}
+        stroke={geometry.bodySolidFill}
+        strokeWidth={1}
+        style={{ transformOrigin: bodyOrigin }}
+        transition={t}
+        width={geometry.candleWidth}
+        x={geometry.bodyLeft}
+        y={geometry.bodyTop}
+      />
+      {geometry.bodyPattern ? (
+        <motion.rect
+          animate={{ scaleY: 1 }}
+          fill={geometry.bodyPattern}
+          height={geometry.bodyHeight}
+          initial={{ scaleY: 0 }}
+          rx={1}
+          ry={1}
+          style={{ transformOrigin: bodyOrigin }}
+          transition={t}
+          width={geometry.candleWidth}
+          x={geometry.bodyLeft}
+          y={geometry.bodyTop}
+        />
+      ) : null}
+    </motion.g>
   );
 }
 
@@ -163,28 +265,95 @@ export function Candlestick({
   bodyPatternNegative,
   insideStrokeWidth = 0,
   fadedOpacity = 0.3,
+  showHoverFade = true,
 }: CandlestickProps) {
   const {
     data,
-    renderData,
     xScale,
     yScale,
     xAccessor,
     animationDuration,
     enterTransition,
     revealEpoch = 0,
+    isLoaded,
     bandWidth,
     columnWidth,
     hoveredCandleIndex,
   } = useChart();
 
   const candleWidth = Math.min(bandWidth ?? columnWidth * 0.8, columnWidth);
-  const staggerDelayMs = useMemo(() => {
-    if (renderData.length === 0) {
-      return 0;
+
+  const geometries = useMemo(
+    () =>
+      computeGeometries(
+        data,
+        xScale,
+        yScale,
+        xAccessor,
+        candleWidth,
+        positiveFill,
+        negativeFill,
+        bodyPatternPositive,
+        bodyPatternNegative,
+        insideStrokeWidth
+      ),
+    [
+      data,
+      xScale,
+      yScale,
+      xAccessor,
+      candleWidth,
+      positiveFill,
+      negativeFill,
+      bodyPatternPositive,
+      bodyPatternNegative,
+      insideStrokeWidth,
+    ]
+  );
+
+  const hoveredTime = useMemo(() => {
+    if (hoveredCandleIndex == null) {
+      return null;
     }
-    return (animationDuration * 0.6) / renderData.length;
-  }, [animationDuration, renderData.length]);
+    const point = data[hoveredCandleIndex];
+    return point ? xAccessor(point).getTime() : null;
+  }, [hoveredCandleIndex, data, xAccessor]);
+
+  const highlightGeometry = useMemo(() => {
+    if (hoveredCandleIndex == null) {
+      return null;
+    }
+    const point = data[hoveredCandleIndex];
+    if (!point) {
+      return null;
+    }
+    return (
+      computeGeometries(
+        [point],
+        xScale,
+        yScale,
+        xAccessor,
+        candleWidth,
+        positiveFill,
+        negativeFill,
+        bodyPatternPositive,
+        bodyPatternNegative,
+        insideStrokeWidth
+      )[0] ?? null
+    );
+  }, [
+    hoveredCandleIndex,
+    data,
+    xScale,
+    yScale,
+    xAccessor,
+    candleWidth,
+    positiveFill,
+    negativeFill,
+    bodyPatternPositive,
+    bodyPatternNegative,
+    insideStrokeWidth,
+  ]);
 
   const defaultEnter: Transition = {
     type: "spring",
@@ -192,72 +361,40 @@ export function Candlestick({
     bounce: 0.15,
   };
   const enter = enterTransition ?? defaultEnter;
+  const staggerDelayMs =
+    data.length > 0 ? (animationDuration * 0.6) / data.length : 0;
 
-  const hoveredPoint =
-    hoveredCandleIndex == null ? undefined : data[hoveredCandleIndex];
-  const hoveredTime = hoveredPoint
-    ? xAccessor(hoveredPoint as Record<string, unknown>).getTime()
-    : null;
+  if (animate && !isLoaded) {
+    return (
+      <g className="chart-candlesticks">
+        {geometries.map((geometry, index) => (
+          <AnimatedCandle
+            delay={(index * staggerDelayMs) / 1000}
+            enterTransition={enter}
+            geometry={geometry}
+            key={geometry.time}
+            revealEpoch={revealEpoch}
+          />
+        ))}
+      </g>
+    );
+  }
+
+  const dimBase = showHoverFade && hoveredTime !== null;
 
   return (
     <g className="chart-candlesticks">
-      {renderData.map((d, index) => {
-        const date = xAccessor(d);
-        const open = d.open as number;
-        const high = d.high as number;
-        const low = d.low as number;
-        const close = d.close as number;
-        const centerX = xScale(date) ?? 0;
-        const yHigh = yScale(high) ?? 0;
-        const yLow = yScale(low) ?? 0;
-        const yOpen = yScale(open) ?? 0;
-        const yClose = yScale(close) ?? 0;
-        const bodyTop = Math.min(yOpen, yClose);
-        const bodyHeight = Math.abs(yClose - yOpen) || 1;
-        const bodyLeft = centerX - candleWidth / 2;
-        const wickTop = Math.min(yHigh, yLow);
-        const wickHeight = Math.abs(yLow - yHigh) || 1;
-        const wickLeft = centerX - WICK_WIDTH / 2;
-        const wickCenterY = wickTop + wickHeight / 2;
-        const isPositive = close >= open;
-        const fill = isPositive ? positiveFill : negativeFill;
-        const bodyPattern = isPositive
-          ? bodyPatternPositive
-          : bodyPatternNegative;
-        const hasPatternOverlay = Boolean(bodyPattern);
-        const bodySolidFill = hasPatternOverlay
-          ? getSolidColor(isPositive)
-          : fill;
-        const wickFill = hasPatternOverlay ? bodySolidFill : fill;
-        const isFaded =
-          hoveredTime !== null && xAccessor(d).getTime() !== hoveredTime;
-        const delay = animate ? (index * staggerDelayMs) / 1000 : 0;
-
-        return (
-          <CandleRect
-            bodyHeight={bodyHeight}
-            bodyLeft={bodyLeft}
-            bodyPattern={bodyPattern}
-            bodySolidFill={bodySolidFill}
-            bodyTop={bodyTop}
-            candleWidth={candleWidth}
-            centerX={centerX}
-            delay={delay}
-            enterTransition={enter}
-            fadedOpacity={fadedOpacity}
-            hasPatternOverlay={hasPatternOverlay}
-            insideStrokeWidth={insideStrokeWidth}
-            isFaded={isFaded}
-            key={xAccessor(d).getTime()}
-            revealEpoch={revealEpoch}
-            wickCenterY={wickCenterY}
-            wickFill={wickFill}
-            wickHeight={wickHeight}
-            wickLeft={wickLeft}
-            wickTop={wickTop}
-          />
-        );
-      })}
+      <g
+        opacity={dimBase ? fadedOpacity : 1}
+        style={{ transition: "opacity 0.15s ease-in-out" }}
+      >
+        <CandlestickBodies geometries={geometries} />
+      </g>
+      {highlightGeometry ? (
+        <g>
+          <CandlestickBody geometry={highlightGeometry} />
+        </g>
+      ) : null}
     </g>
   );
 }

--- a/packages/ui/src/charts/candlestick.tsx
+++ b/packages/ui/src/charts/candlestick.tsx
@@ -81,72 +81,77 @@ function CandleRect({
   const bodyOrigin = `${centerX}px ${bodyTop + bodyHeight / 2}px`;
   const t = transitionWithDelay(enterTransition, delay);
   return (
-    <motion.g
-      animate={{ opacity: isFaded ? fadedOpacity : 1 }}
-      initial={{ opacity: 0 }}
-      key={`candle-g-${centerX}-${revealEpoch}`}
-      style={{ transformOrigin: `${centerX}px ${wickCenterY}px` }}
-      transition={{ ...t, opacity: { duration: 0.15 } }}
+    <g
+      opacity={isFaded ? fadedOpacity : 1}
+      style={{ transition: "opacity 0.15s ease-in-out" }}
     >
-      <motion.rect
-        animate={{ scaleY: 1 }}
-        fill={wickFill}
-        height={wickHeight}
-        initial={{ scaleY: 0 }}
+      <motion.g
+        animate={{ opacity: 1 }}
+        initial={{ opacity: 0 }}
+        key={`candle-enter-${centerX}-${revealEpoch}`}
         style={{ transformOrigin: `${centerX}px ${wickCenterY}px` }}
-        transition={t}
-        width={WICK_WIDTH}
-        x={wickLeft}
-        y={wickTop}
-      />
-      <motion.rect
-        animate={{ scaleY: 1 }}
-        fill={bodySolidFill}
-        height={bodyHeight}
-        initial={{ scaleY: 0 }}
-        rx={1}
-        ry={1}
-        stroke={bodySolidFill}
-        strokeWidth={1}
-        style={{ transformOrigin: bodyOrigin }}
-        transition={t}
-        width={candleWidth}
-        x={bodyLeft}
-        y={bodyTop}
-      />
-      {hasPatternOverlay && bodyPattern && (
+        transition={{ ...t, opacity: { duration: 0.15 } }}
+      >
         <motion.rect
           animate={{ scaleY: 1 }}
-          fill={bodyPattern}
+          fill={wickFill}
+          height={wickHeight}
+          initial={{ scaleY: 0 }}
+          style={{ transformOrigin: `${centerX}px ${wickCenterY}px` }}
+          transition={t}
+          width={WICK_WIDTH}
+          x={wickLeft}
+          y={wickTop}
+        />
+        <motion.rect
+          animate={{ scaleY: 1 }}
+          fill={bodySolidFill}
           height={bodyHeight}
           initial={{ scaleY: 0 }}
           rx={1}
           ry={1}
+          stroke={bodySolidFill}
+          strokeWidth={1}
           style={{ transformOrigin: bodyOrigin }}
           transition={t}
           width={candleWidth}
           x={bodyLeft}
           y={bodyTop}
         />
-      )}
-      {insideStrokeWidth > 0 && (
-        <motion.rect
-          animate={{ scaleY: 1 }}
-          fill="none"
-          height={bodyHeight - insideStrokeWidth}
-          initial={{ scaleY: 0 }}
-          rx={1}
-          ry={1}
-          stroke={bodySolidFill}
-          strokeWidth={insideStrokeWidth}
-          style={{ transformOrigin: bodyOrigin }}
-          transition={t}
-          width={candleWidth - insideStrokeWidth}
-          x={bodyLeft + insideStrokeWidth / 2}
-          y={bodyTop + insideStrokeWidth / 2}
-        />
-      )}
-    </motion.g>
+        {hasPatternOverlay && bodyPattern && (
+          <motion.rect
+            animate={{ scaleY: 1 }}
+            fill={bodyPattern}
+            height={bodyHeight}
+            initial={{ scaleY: 0 }}
+            rx={1}
+            ry={1}
+            style={{ transformOrigin: bodyOrigin }}
+            transition={t}
+            width={candleWidth}
+            x={bodyLeft}
+            y={bodyTop}
+          />
+        )}
+        {insideStrokeWidth > 0 && (
+          <motion.rect
+            animate={{ scaleY: 1 }}
+            fill="none"
+            height={bodyHeight - insideStrokeWidth}
+            initial={{ scaleY: 0 }}
+            rx={1}
+            ry={1}
+            stroke={bodySolidFill}
+            strokeWidth={insideStrokeWidth}
+            style={{ transformOrigin: bodyOrigin }}
+            transition={t}
+            width={candleWidth - insideStrokeWidth}
+            x={bodyLeft + insideStrokeWidth / 2}
+            y={bodyTop + insideStrokeWidth / 2}
+          />
+        )}
+      </motion.g>
+    </g>
   );
 }
 
@@ -161,6 +166,7 @@ export function Candlestick({
 }: CandlestickProps) {
   const {
     data,
+    renderData,
     xScale,
     yScale,
     xAccessor,
@@ -174,11 +180,11 @@ export function Candlestick({
 
   const candleWidth = Math.min(bandWidth ?? columnWidth * 0.8, columnWidth);
   const staggerDelayMs = useMemo(() => {
-    if (data.length === 0) {
+    if (renderData.length === 0) {
       return 0;
     }
-    return (animationDuration * 0.6) / data.length;
-  }, [animationDuration, data.length]);
+    return (animationDuration * 0.6) / renderData.length;
+  }, [animationDuration, renderData.length]);
 
   const defaultEnter: Transition = {
     type: "spring",
@@ -187,9 +193,15 @@ export function Candlestick({
   };
   const enter = enterTransition ?? defaultEnter;
 
+  const hoveredPoint =
+    hoveredCandleIndex == null ? undefined : data[hoveredCandleIndex];
+  const hoveredTime = hoveredPoint
+    ? xAccessor(hoveredPoint as Record<string, unknown>).getTime()
+    : null;
+
   return (
     <g className="chart-candlesticks">
-      {data.map((d, index) => {
+      {renderData.map((d, index) => {
         const date = xAccessor(d);
         const open = d.open as number;
         const high = d.high as number;
@@ -218,7 +230,7 @@ export function Candlestick({
           : fill;
         const wickFill = hasPatternOverlay ? bodySolidFill : fill;
         const isFaded =
-          hoveredCandleIndex !== null && hoveredCandleIndex !== index;
+          hoveredTime !== null && xAccessor(d).getTime() !== hoveredTime;
         const delay = animate ? (index * staggerDelayMs) / 1000 : 0;
 
         return (

--- a/packages/ui/src/charts/chart-context.tsx
+++ b/packages/ui/src/charts/chart-context.tsx
@@ -81,6 +81,8 @@ export interface LineConfig {
 export interface ChartContextValue {
   // Data
   data: Record<string, unknown>[];
+  /** Decimated subset for SVG path rendering; equals `data` when no decimation is needed. */
+  renderData: Record<string, unknown>[];
 
   // Scales
   xScale: ScaleTime<number, number>;

--- a/packages/ui/src/charts/decimate-time-series.ts
+++ b/packages/ui/src/charts/decimate-time-series.ts
@@ -89,3 +89,52 @@ export function decimateTimeSeries<T extends Record<string, unknown>>(
 export function maxRenderPointsForWidth(innerWidth: number): number {
   return Math.max(64, Math.ceil(innerWidth * 1.5));
 }
+
+/** Bucket OHLC rows into fewer candles while preserving high/low extremes. */
+export function decimateOhlcData<T extends Record<string, unknown>>(
+  data: T[],
+  maxPoints: number
+): T[] {
+  const len = data.length;
+  if (maxPoints >= len || maxPoints < 2) {
+    return data;
+  }
+
+  const bucketSize = len / maxPoints;
+  const sampled: T[] = [];
+
+  for (let i = 0; i < maxPoints; i++) {
+    const start = Math.floor(i * bucketSize);
+    const end = Math.min(len, Math.floor((i + 1) * bucketSize));
+    if (start >= end) {
+      continue;
+    }
+
+    const bucket = data.slice(start, end);
+    const first = bucket[0] as T;
+    const last = bucket.at(-1) as T;
+
+    let high = Number.NEGATIVE_INFINITY;
+    let low = Number.POSITIVE_INFINITY;
+    for (const row of bucket) {
+      const rowHigh = row.high;
+      const rowLow = row.low;
+      if (typeof rowHigh === "number" && rowHigh > high) {
+        high = rowHigh;
+      }
+      if (typeof rowLow === "number" && rowLow < low) {
+        low = rowLow;
+      }
+    }
+
+    sampled.push({
+      ...last,
+      open: first.open,
+      high: Number.isFinite(high) ? high : last.high,
+      low: Number.isFinite(low) ? low : last.low,
+      close: last.close,
+    } as T);
+  }
+
+  return sampled;
+}

--- a/packages/ui/src/charts/decimate-time-series.ts
+++ b/packages/ui/src/charts/decimate-time-series.ts
@@ -1,0 +1,91 @@
+/**
+ * Largest-Triangle-Three-Buckets downsampling for time-series SVG paths.
+ * Keeps first/last points and picks visually significant points per bucket.
+ */
+export function decimateTimeSeries<T extends Record<string, unknown>>(
+  data: T[],
+  maxPoints: number,
+  valueKeys: string[] = []
+): T[] {
+  const len = data.length;
+  if (maxPoints >= len || maxPoints < 3) {
+    return data;
+  }
+
+  const getY = (point: T, index: number): number => {
+    if (valueKeys.length === 0) {
+      for (const val of Object.values(point)) {
+        if (typeof val === "number") {
+          return val;
+        }
+      }
+      return index;
+    }
+
+    let sum = 0;
+    let count = 0;
+    for (const key of valueKeys) {
+      const val = point[key];
+      if (typeof val === "number") {
+        sum += val;
+        count++;
+      }
+    }
+    return count > 0 ? sum / count : index;
+  };
+
+  const sampled: T[] = [data[0] as T];
+  const bucketSize = (len - 2) / (maxPoints - 2);
+  let previousIndex = 0;
+
+  for (let i = 0; i < maxPoints - 2; i++) {
+    const rangeStart = Math.floor((i + 1) * bucketSize) + 1;
+    const rangeEnd = Math.min(Math.floor((i + 2) * bucketSize) + 1, len - 1);
+
+    const nextRangeStart = Math.floor((i + 2) * bucketSize) + 1;
+    const nextRangeEnd = Math.min(Math.floor((i + 3) * bucketSize) + 1, len);
+    const nextCount = Math.max(0, nextRangeEnd - nextRangeStart);
+
+    let avgX = len - 1;
+    let avgY = getY(data[len - 1] as T, len - 1);
+    if (nextCount > 0) {
+      avgX = 0;
+      avgY = 0;
+      for (let j = nextRangeStart; j < nextRangeEnd; j++) {
+        avgX += j;
+        avgY += getY(data[j] as T, j);
+      }
+      avgX /= nextCount;
+      avgY /= nextCount;
+    }
+
+    const pointA = data[previousIndex] as T;
+    const ax = previousIndex;
+    const ay = getY(pointA, previousIndex);
+
+    let maxArea = -1;
+    let maxIndex = rangeStart;
+
+    for (let j = rangeStart; j < rangeEnd; j++) {
+      const area =
+        Math.abs(
+          (ax - avgX) * (getY(data[j] as T, j) - ay) - (ax - j) * (avgY - ay)
+        ) * 0.5;
+      if (area > maxArea) {
+        maxArea = area;
+        maxIndex = j;
+      }
+    }
+
+    sampled.push(data[maxIndex] as T);
+    previousIndex = maxIndex;
+  }
+
+  sampled.push(data[len - 1] as T);
+  return sampled;
+}
+
+/** ~1.5 points per pixel — enough for crisp curves without over-drawing. */
+export function maxRenderPointsForWidth(innerWidth: number): number {
+  return Math.max(64, Math.ceil(innerWidth * 1.5));
+}

--- a/packages/ui/src/charts/line.tsx
+++ b/packages/ui/src/charts/line.tsx
@@ -64,6 +64,7 @@ export function Line({
 }: LineProps) {
   const {
     data,
+    renderData,
     xScale,
     yScale,
     innerHeight,
@@ -77,7 +78,7 @@ export function Line({
   } = useChart();
 
   const pathRef = useRef<SVGPathElement>(null);
-  const pathMetricsKey = `${data.length}:${innerWidth}:${dashFromIndex}:${animate}`;
+  const pathMetricsKey = `${renderData.length}:${innerWidth}:${dashFromIndex}:${animate}`;
   const { pathLength, pathD } = usePathStrokeMetrics(pathRef, pathMetricsKey);
 
   const reactId = useId();
@@ -112,7 +113,7 @@ export function Line({
         </defs>
       ) : null}
 
-      {animate && data.length > 1 ? (
+      {animate && renderData.length > 1 ? (
         <defs>
           <ChartRevealClip
             clipPathId={`grow-clip-${dataKey}`}
@@ -126,7 +127,9 @@ export function Line({
 
       <g
         clipPath={
-          animate && data.length > 1 ? `url(#grow-clip-${dataKey})` : undefined
+          animate && renderData.length > 1
+            ? `url(#grow-clip-${dataKey})`
+            : undefined
         }
       >
         <motion.g
@@ -136,7 +139,7 @@ export function Line({
         >
           <LinePath
             curve={curve}
-            data={data}
+            data={renderData}
             innerRef={pathRef}
             stroke={hasDashTail ? "transparent" : lineStroke}
             strokeLinecap="round"

--- a/packages/ui/src/charts/live-line-chart.tsx
+++ b/packages/ui/src/charts/live-line-chart.tsx
@@ -68,6 +68,8 @@ export interface LiveLineChartProps {
 
 const LERP_SPEED = 0.08;
 const DEFAULT_MARGIN: Margin = { top: 24, right: 16, bottom: 32, left: 16 };
+/** React commit interval for the live animation loop (~30fps). */
+const LIVE_FRAME_COMMIT_MS = 32;
 
 interface AnimFrame {
   now: number;
@@ -206,6 +208,73 @@ function extractLiveLineConfigs(children: ReactNode): LineConfig[] {
 // Inner chart
 // ---------------------------------------------------------------------------
 
+function liveTooltipKey(
+  tooltip: TooltipData | null,
+  dataKey: string
+): string | null {
+  if (!tooltip) {
+    return null;
+  }
+  return `${Math.round(tooltip.x)}:${Math.round(tooltip.yPositions[dataKey] ?? 0)}`;
+}
+
+function resolveLiveTooltip(
+  cursorX: number | null,
+  innerWidth: number,
+  innerHeight: number,
+  frame: AnimFrame,
+  leadingMs: number,
+  windowMs: number,
+  xTickUnitMs: number,
+  data: LiveLinePoint[],
+  dataKey: string
+): TooltipData | null {
+  if (cursorX === null || innerWidth <= 0 || innerHeight <= 0) {
+    return null;
+  }
+
+  const domainEndMs = frame.now + leadingMs;
+  const xScaleNext = scaleTime({
+    domain: [new Date(domainEndMs - windowMs), new Date(domainEndMs)],
+    range: [0, innerWidth],
+  });
+  const yScaleNext = scaleLinear({
+    domain: [frame.yMin, frame.yMax],
+    range: [innerHeight, 0],
+    nice: true,
+  });
+  const timeMs = xScaleNext.invert(cursorX).getTime();
+  const timeSec = timeMs / 1000;
+  const visible = data.filter((p) => p.time >= (domainEndMs - windowMs) / 1000);
+  visible.push({ time: frame.now / 1000, value: frame.displayValue });
+  visible.push({
+    time: (frame.now + xTickUnitMs) / 1000,
+    value: frame.displayValue,
+  });
+  const val = interpolateAtTime(visible, timeSec);
+  if (val === null) {
+    return null;
+  }
+
+  return {
+    point: { date: new Date(timeMs), [dataKey]: val },
+    index: 0,
+    x: cursorX,
+    yPositions: { [dataKey]: yScaleNext(val) ?? 0 },
+  };
+}
+
+function shouldCommitLiveUpdates(
+  now: number,
+  lastFrameCommit: number,
+  tooltipKey: string | null,
+  lastTooltipKey: string | null
+): { commitFrame: boolean; commitTooltip: boolean } {
+  const commitFrame = now - lastFrameCommit >= LIVE_FRAME_COMMIT_MS;
+  const commitTooltip = tooltipKey !== lastTooltipKey;
+  return { commitFrame, commitTooltip };
+}
+
 interface InnerProps {
   data: LiveLinePoint[];
   value: number;
@@ -293,6 +362,8 @@ const LiveLineChartCore = memo(function LiveLineChartCore({
   // ---- rAF loop: update frame and tooltip in one place to avoid effect→setState loops ----
   const cursorXRef = useRef<number | null>(null);
   const [tooltipData, setTooltipData] = useState<TooltipData | null>(null);
+  const lastFrameCommitRef = useRef(0);
+  const lastTooltipKeyRef = useRef<string | null>(null);
 
   useEffect(() => {
     let raf: number;
@@ -306,49 +377,47 @@ const LiveLineChartCore = memo(function LiveLineChartCore({
       );
       animRef.current = next;
 
-      const domainEndMsNext = next.now + leadingMs;
-      const cursorX = cursorXRef.current;
-      let nextTooltip: TooltipData | null = null;
-      if (cursorX !== null && innerWidth > 0 && innerHeight > 0) {
-        const xScaleNext = scaleTime({
-          domain: [
-            new Date(domainEndMsNext - windowMs),
-            new Date(domainEndMsNext),
-          ],
-          range: [0, innerWidth],
-        });
-        const yScaleNext = scaleLinear({
-          domain: [next.yMin, next.yMax],
-          range: [innerHeight, 0],
-          nice: true,
-        });
-        const timeMs = xScaleNext.invert(cursorX).getTime();
-        const timeSec = timeMs / 1000;
-        const currentData = dataRef.current;
-        const visible = currentData.filter(
-          (p) => p.time >= (domainEndMsNext - windowMs) / 1000
-        );
-        visible.push({ time: next.now / 1000, value: next.displayValue });
-        visible.push({
-          time: (next.now + xTickUnitMs) / 1000,
-          value: next.displayValue,
-        });
-        const val = interpolateAtTime(visible, timeSec);
-        const key = dataKeyRef.current;
-        if (val !== null) {
-          nextTooltip = {
-            point: { date: new Date(timeMs), [key]: val },
-            index: 0,
-            x: cursorX,
-            yPositions: { [key]: yScaleNext(val) ?? 0 },
-          };
-        }
+      const nextTooltip = resolveLiveTooltip(
+        cursorXRef.current,
+        innerWidth,
+        innerHeight,
+        next,
+        leadingMs,
+        windowMs,
+        xTickUnitMs,
+        dataRef.current,
+        dataKeyRef.current
+      );
+      const now = performance.now();
+      const tooltipKey = liveTooltipKey(nextTooltip, dataKeyRef.current);
+      const { commitFrame, commitTooltip } = shouldCommitLiveUpdates(
+        now,
+        lastFrameCommitRef.current,
+        tooltipKey,
+        lastTooltipKeyRef.current
+      );
+
+      if (!(commitFrame || commitTooltip)) {
+        raf = requestAnimationFrame(tick);
+        return;
+      }
+
+      if (commitFrame) {
+        lastFrameCommitRef.current = now;
+      }
+      if (commitTooltip) {
+        lastTooltipKeyRef.current = tooltipKey;
       }
 
       startTransition(() => {
-        setTooltipData(nextTooltip);
-        setFrame(next);
+        if (commitFrame) {
+          setFrame(next);
+        }
+        if (commitTooltip) {
+          setTooltipData(nextTooltip);
+        }
       });
+
       raf = requestAnimationFrame(tick);
     };
     raf = requestAnimationFrame(tick);
@@ -443,6 +512,7 @@ const LiveLineChartCore = memo(function LiveLineChartCore({
 
   const handleMouseLeave = useCallback(() => {
     cursorXRef.current = null;
+    lastTooltipKeyRef.current = null;
     setTooltipData(null);
   }, []);
 

--- a/packages/ui/src/charts/live-line-chart.tsx
+++ b/packages/ui/src/charts/live-line-chart.tsx
@@ -462,6 +462,7 @@ const LiveLineChartCore = memo(function LiveLineChartCore({
   const contextValue = useMemo(
     () => ({
       data: contextData,
+      renderData: contextData,
       xScale,
       yScale,
       width,

--- a/packages/ui/src/charts/scatter-chart-shell.tsx
+++ b/packages/ui/src/charts/scatter-chart-shell.tsx
@@ -183,6 +183,7 @@ export function ScatterChartInner({
 
   const contextValue: ChartContextValue = {
     data,
+    renderData: data,
     xScale: xScale as ChartContextValue["xScale"],
     yScale: yScale as ChartContextValue["yScale"],
     width,

--- a/packages/ui/src/charts/series-markers.tsx
+++ b/packages/ui/src/charts/series-markers.tsx
@@ -1,15 +1,13 @@
 "use client";
 
 import { useCallback, useMemo } from "react";
-import {
-  clipRevealTransition,
-  DEFAULT_CHART_ENTER_TRANSITION,
-} from "./animation";
+import { clipRevealTransition } from "./animation";
 import { defaultScatterColors, useChart } from "./chart-context";
 import {
   getSeriesMarkerVisualExtent,
   SeriesPointMarker,
   type SeriesPointMarkerStyle,
+  StaticSeriesPointMarker,
 } from "./series-point-marker";
 
 export interface SeriesMarkersProps extends SeriesPointMarkerStyle {
@@ -78,7 +76,6 @@ export function SeriesMarkers({
   const revealDurationSec =
     clipRevealTransition(enterTransition).duration ?? animationDuration / 1000;
   const enterDuration = 0.5;
-  const hoverEase = DEFAULT_CHART_ENTER_TRANSITION.ease;
   const isRevealing = animate && !isLoaded;
 
   const getY = useCallback(
@@ -120,35 +117,70 @@ export function SeriesMarkers({
     ]
   );
 
+  const markerStyle = {
+    fill: resolvedFill,
+    stroke: resolvedStroke,
+    strokeWidth,
+    ringGap,
+    outlineWidth,
+    outlineColor,
+    radius,
+  };
+
+  if (isRevealing) {
+    return (
+      <g>
+        {points.map((point) => (
+          <SeriesPointMarker
+            cx={point.cx}
+            cy={point.cy}
+            dataKey={dataKey}
+            enterBlur={enterBlur}
+            enterDuration={enterDuration}
+            index={point.index}
+            key={`${dataKey}-${point.index}`}
+            revealDelay={point.revealDelay}
+            revealEpoch={revealEpoch ?? 0}
+            {...markerStyle}
+          />
+        ))}
+      </g>
+    );
+  }
+
+  const dimBase = fadeOnHover && isHovering;
+  const activePoint = dimBase
+    ? points.find((point) => point.index === activeIndex)
+    : null;
+  const activeScale = showActiveHighlight ? 1.35 : 1;
+
   return (
     <g>
-      {points.map((point) => (
-        <SeriesPointMarker
-          cx={point.cx}
-          cy={point.cy}
-          dataKey={dataKey}
-          enterBlur={enterBlur}
-          enterDuration={enterDuration}
-          fadeOnHover={fadeOnHover}
-          fill={resolvedFill}
-          hoverEase={hoverEase}
-          inactiveBlur={inactiveBlur}
-          inactiveOpacity={inactiveOpacity}
-          index={point.index}
-          isActive={activeIndex === point.index}
-          isHovering={isHovering}
-          key={`${dataKey}-${point.index}`}
-          outlineColor={outlineColor}
-          outlineWidth={outlineWidth}
-          radius={radius}
-          revealDelay={point.revealDelay}
-          revealEpoch={revealEpoch ?? 0}
-          ringGap={ringGap}
-          showActiveHighlight={showActiveHighlight}
-          stroke={resolvedStroke}
-          strokeWidth={strokeWidth}
+      <g
+        opacity={dimBase ? inactiveOpacity : 1}
+        style={{
+          transition: "opacity 0.15s ease-in-out, filter 0.15s ease-in-out",
+          filter:
+            dimBase && inactiveBlur > 0 ? `blur(${inactiveBlur}px)` : "none",
+        }}
+      >
+        {points.map((point) => (
+          <StaticSeriesPointMarker
+            cx={point.cx}
+            cy={point.cy}
+            key={`${dataKey}-${point.index}`}
+            {...markerStyle}
+          />
+        ))}
+      </g>
+      {activePoint ? (
+        <StaticSeriesPointMarker
+          cx={activePoint.cx}
+          cy={activePoint.cy}
+          scale={activeScale}
+          {...markerStyle}
         />
-      ))}
+      ) : null}
     </g>
   );
 }

--- a/packages/ui/src/charts/series-point-marker.tsx
+++ b/packages/ui/src/charts/series-point-marker.tsx
@@ -2,6 +2,7 @@
 
 import type { Variants } from "motion/react";
 import { motion } from "motion/react";
+import { memo } from "react";
 import { DEFAULT_CHART_ENTER_TRANSITION } from "./animation";
 
 export interface SeriesPointMarkerStyle {
@@ -23,7 +24,10 @@ export interface SeriesPointMarkerStyle {
   fadeOnHover?: boolean;
   /** Opacity for non-hovered points when `fadeOnHover` is true. Default: 0.5 */
   inactiveOpacity?: number;
-  /** Blur in px for non-hovered points when `fadeOnHover` is true. Default: 2 */
+  /**
+   * Blur in px for non-hovered points when `fadeOnHover` is true.
+   * Applied once on the dimmed layer (not per dot) for performance. Default: 2
+   */
   inactiveBlur?: number;
   /** Initial blur in px during enter animation. Default: 2 */
   enterBlur?: number;
@@ -31,29 +35,106 @@ export interface SeriesPointMarkerStyle {
   showActiveHighlight?: boolean;
 }
 
+interface MarkerCirclesProps {
+  fill?: string;
+  stroke?: string;
+  strokeWidth: number;
+  ringGap: number;
+  outlineWidth: number;
+  outlineColor?: string;
+  radius: number;
+}
+
+function MarkerCircles({
+  fill,
+  stroke,
+  strokeWidth,
+  ringGap,
+  outlineWidth,
+  outlineColor,
+  radius,
+}: MarkerCirclesProps) {
+  const resolvedStroke = stroke ?? fill ?? "currentColor";
+  const resolvedOutlineColor = outlineColor ?? resolvedStroke;
+  const ringOuter = strokeWidth > 0 ? radius + ringGap + strokeWidth : radius;
+  const outlineRadius = outlineWidth > 0 ? ringOuter + outlineWidth / 2 : 0;
+
+  return (
+    <>
+      {outlineWidth > 0 ? (
+        <circle
+          cx={0}
+          cy={0}
+          fill="none"
+          r={outlineRadius}
+          stroke={resolvedOutlineColor}
+          strokeWidth={outlineWidth}
+        />
+      ) : null}
+      <circle cx={0} cy={0} fill={fill} r={radius} />
+      {strokeWidth > 0 ? (
+        <circle
+          cx={0}
+          cy={0}
+          fill="none"
+          r={radius + ringGap + strokeWidth / 2}
+          stroke={resolvedStroke}
+          strokeWidth={strokeWidth}
+        />
+      ) : null}
+    </>
+  );
+}
+
+export interface StaticSeriesPointMarkerProps extends SeriesPointMarkerStyle {
+  cx: number;
+  cy: number;
+  scale?: number;
+}
+
+export const StaticSeriesPointMarker = memo(function StaticSeriesPointMarker({
+  cx,
+  cy,
+  scale = 1,
+  fill,
+  stroke,
+  strokeWidth = 2,
+  ringGap = 2,
+  outlineWidth = 0,
+  outlineColor,
+  radius = 5,
+}: StaticSeriesPointMarkerProps) {
+  return (
+    <g transform={`translate(${cx}, ${cy}) scale(${scale})`}>
+      <MarkerCircles
+        fill={fill}
+        outlineColor={outlineColor}
+        outlineWidth={outlineWidth}
+        radius={radius}
+        ringGap={ringGap}
+        stroke={stroke}
+        strokeWidth={strokeWidth}
+      />
+    </g>
+  );
+});
+
 export interface SeriesPointMarkerProps extends SeriesPointMarkerStyle {
   dataKey: string;
   index: number;
   cx: number;
   cy: number;
-  isActive: boolean;
-  isHovering: boolean;
   revealDelay: number;
   revealEpoch: number;
   enterDuration: number;
-  hoverEase: typeof DEFAULT_CHART_ENTER_TRANSITION.ease;
 }
 
+/** Motion enter marker — used only while the chart reveal is running. */
 export function SeriesPointMarker({
   dataKey,
   index,
   cx,
   cy,
-  isActive,
-  isHovering,
-  fadeOnHover = true,
-  inactiveOpacity = 0.5,
-  inactiveBlur = 2,
   enterBlur = 2,
   revealDelay,
   revealEpoch,
@@ -65,19 +146,7 @@ export function SeriesPointMarker({
   outlineWidth = 0,
   outlineColor,
   radius = 5,
-  showActiveHighlight = true,
-  hoverEase,
 }: SeriesPointMarkerProps) {
-  const resolvedStroke = stroke ?? fill ?? "currentColor";
-  const resolvedOutlineColor = outlineColor ?? resolvedStroke;
-
-  const animateState = (() => {
-    if (isHovering && fadeOnHover) {
-      return isActive ? "active" : "dimmed";
-    }
-    return "visible";
-  })();
-
   const variants: Variants = {
     hidden: {
       opacity: 0,
@@ -94,52 +163,25 @@ export function SeriesPointMarker({
         ease: DEFAULT_CHART_ENTER_TRANSITION.ease,
       },
     },
-    dimmed: {
-      opacity: inactiveOpacity,
-      filter: `blur(${inactiveBlur}px)`,
-      scale: 1,
-      transition: { duration: 0.4, ease: hoverEase },
-    },
-    active: {
-      opacity: 1,
-      filter: "blur(0px)",
-      scale: showActiveHighlight ? 1.35 : 1,
-      transition: { duration: 0.4, ease: hoverEase },
-    },
   };
-
-  const ringOuter = strokeWidth > 0 ? radius + ringGap + strokeWidth : radius;
-  const outlineRadius = outlineWidth > 0 ? ringOuter + outlineWidth / 2 : 0;
 
   return (
     <g transform={`translate(${cx}, ${cy})`}>
       <motion.g
-        animate={animateState}
+        animate="visible"
         initial="hidden"
         key={`${dataKey}-${index}-${revealEpoch}`}
         variants={variants}
       >
-        {outlineWidth > 0 ? (
-          <circle
-            cx={0}
-            cy={0}
-            fill="none"
-            r={outlineRadius}
-            stroke={resolvedOutlineColor}
-            strokeWidth={outlineWidth}
-          />
-        ) : null}
-        <circle cx={0} cy={0} fill={fill} r={radius} />
-        {strokeWidth > 0 ? (
-          <circle
-            cx={0}
-            cy={0}
-            fill="none"
-            r={radius + ringGap + strokeWidth / 2}
-            stroke={resolvedStroke}
-            strokeWidth={strokeWidth}
-          />
-        ) : null}
+        <MarkerCircles
+          fill={fill}
+          outlineColor={outlineColor}
+          outlineWidth={outlineWidth}
+          radius={radius}
+          ringGap={ringGap}
+          stroke={stroke}
+          strokeWidth={strokeWidth}
+        />
       </motion.g>
     </g>
   );

--- a/packages/ui/src/charts/time-series-chart-shell.tsx
+++ b/packages/ui/src/charts/time-series-chart-shell.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { scaleLinear, scaleTime } from "@visx/scale";
-import { bisector } from "d3-array";
+import { bisector, extent } from "d3-array";
 import type { Transition } from "motion/react";
 import {
   Children,
@@ -18,6 +18,10 @@ import { DEFAULT_ANIMATION_EASING } from "./animation";
 import { ChartProvider, type LineConfig, type Margin } from "./chart-context";
 import { isGradientDefComponent, isPatternDefComponent } from "./chart-defs";
 import { shortDateFmt } from "./chart-formatters";
+import {
+  decimateTimeSeries,
+  maxRenderPointsForWidth,
+} from "./decimate-time-series";
 import { useChartInteraction } from "./use-chart-interaction";
 
 /** Markers render after the interaction overlay so they stay clickable. */
@@ -120,15 +124,24 @@ const TimeSeriesChartCore = memo(function TimeSeriesChartCore({
   );
 
   const xScale = useMemo(() => {
-    const dates = data.map((d) => xAccessor(d));
-    const minTime = Math.min(...dates.map((d) => d.getTime()));
-    const maxTime = Math.max(...dates.map((d) => d.getTime()));
+    const timeExtent = extent(data, (d) => xAccessor(d).getTime());
+    const minTime = timeExtent[0] ?? 0;
+    const maxTime = timeExtent[1] ?? minTime;
 
     return scaleTime({
       range: [0, innerWidth],
       domain: [minTime, maxTime],
     });
   }, [innerWidth, data, xAccessor]);
+
+  const renderData = useMemo(() => {
+    const valueKeys = lines.map((line) => line.dataKey);
+    return decimateTimeSeries(
+      data,
+      maxRenderPointsForWidth(innerWidth),
+      valueKeys
+    );
+  }, [data, innerWidth, lines]);
 
   const columnWidth = useMemo(() => {
     if (data.length < 2) {
@@ -142,9 +155,10 @@ const TimeSeriesChartCore = memo(function TimeSeriesChartCore({
     if (yScaleDomainMax != null && yScaleDomainMax > 0) {
       maxValue = yScaleDomainMax;
     } else {
-      for (const line of lines) {
-        for (const d of data) {
-          const value = d[line.dataKey];
+      const dataKeys = lines.map((line) => line.dataKey);
+      for (const d of data) {
+        for (const key of dataKeys) {
+          const value = d[key];
           if (typeof value === "number" && value > maxValue) {
             maxValue = value;
           }
@@ -221,6 +235,7 @@ const TimeSeriesChartCore = memo(function TimeSeriesChartCore({
 
   const contextValue = {
     data,
+    renderData,
     xScale,
     yScale,
     width,

--- a/packages/ui/src/charts/tooltip/chart-tooltip.tsx
+++ b/packages/ui/src/charts/tooltip/chart-tooltip.tsx
@@ -69,6 +69,7 @@ const ChartTooltipInner = memo(function ChartTooltipInner({
   } = useChart();
 
   const isHorizontal = orientation === "horizontal";
+  const discreteInteraction = dateLabels.length > 60;
 
   const visible = tooltipData !== null;
   const x = tooltipData?.x ?? 0;
@@ -81,10 +82,12 @@ const ChartTooltipInner = memo(function ChartTooltipInner({
     : 0;
   const yWithMargin = firstLineY + margin.top;
 
-  // Animated crosshair position
+  // Animated crosshair position (springs are skipped for large discrete datasets)
   const animatedX = useSpring(xWithMargin, crosshairSpringConfig);
 
-  animatedX.set(xWithMargin);
+  if (!discreteInteraction) {
+    animatedX.set(xWithMargin);
+  }
 
   // Generate rows from lines
   const tooltipRows = useMemo(() => {
@@ -145,6 +148,7 @@ const ChartTooltipInner = memo(function ChartTooltipInner({
         >
           <g transform={`translate(${margin.left},${margin.top})`}>
             <TooltipIndicator
+              animate={!discreteInteraction}
               colorEdge={indicatorColor}
               colorMid={indicatorColor}
               columnWidth={columnWidth}
@@ -209,7 +213,7 @@ const ChartTooltipInner = memo(function ChartTooltipInner({
         <motion.div
           className="pointer-events-none absolute z-50"
           style={{
-            left: animatedX,
+            left: discreteInteraction ? xWithMargin : animatedX,
             transform: "translateX(-50%)",
             bottom: 4,
           }}

--- a/packages/ui/src/charts/tooltip/date-ticker.tsx
+++ b/packages/ui/src/charts/tooltip/date-ticker.tsx
@@ -4,12 +4,29 @@ import { motion, useSpring } from "motion/react";
 import { memo, useMemo, useRef } from "react";
 
 const TICKER_ITEM_HEIGHT = 24;
+/** Full scroll stacks are skipped above this count — single label + instant updates. */
+const COMPACT_TICKER_THRESHOLD = 60;
 
 export interface DateTickerProps {
   currentIndex: number;
   labels: string[];
   visible: boolean;
 }
+
+const DateTickerCompact = memo(function DateTickerCompact({
+  currentIndex,
+  labels,
+}: Omit<DateTickerProps, "visible">) {
+  const label = labels[currentIndex] ?? labels[0] ?? "";
+
+  return (
+    <div className="overflow-hidden rounded-full bg-zinc-900 px-4 py-1 text-white shadow-lg dark:bg-zinc-100 dark:text-zinc-900">
+      <div className="flex h-6 items-center justify-center">
+        <span className="whitespace-nowrap font-medium text-sm">{label}</span>
+      </div>
+    </div>
+  );
+});
 
 const DateTickerInner = memo(function DateTickerInner({
   currentIndex,
@@ -119,6 +136,10 @@ const DateTickerInner = memo(function DateTickerInner({
 export function DateTicker({ currentIndex, labels, visible }: DateTickerProps) {
   if (!visible || labels.length === 0) {
     return null;
+  }
+
+  if (labels.length > COMPACT_TICKER_THRESHOLD) {
+    return <DateTickerCompact currentIndex={currentIndex} labels={labels} />;
   }
 
   return <DateTickerInner currentIndex={currentIndex} labels={labels} />;

--- a/packages/ui/src/charts/tooltip/tooltip-indicator.tsx
+++ b/packages/ui/src/charts/tooltip/tooltip-indicator.tsx
@@ -38,6 +38,8 @@ export interface TooltipIndicatorProps {
   colorMid?: string;
   /** Whether to fade to transparent at 0% and 100% */
   fadeEdges?: boolean;
+  /** Animate position with a spring. Default: true */
+  animate?: boolean;
   /** Unique ID for the gradient */
   gradientId?: string;
 }
@@ -70,6 +72,7 @@ export function TooltipIndicator({
   colorEdge = chartCssVars.crosshair,
   colorMid = chartCssVars.crosshair,
   fadeEdges = true,
+  animate = true,
   gradientId = "tooltip-indicator-gradient",
 }: TooltipIndicatorProps) {
   const pixelWidth =
@@ -77,9 +80,12 @@ export function TooltipIndicator({
       ? span * columnWidth
       : resolveWidth(width);
 
-  const animatedX = useSpring(x - pixelWidth / 2, crosshairSpringConfig);
+  const rectX = x - pixelWidth / 2;
+  const animatedX = useSpring(rectX, crosshairSpringConfig);
 
-  animatedX.set(x - pixelWidth / 2);
+  if (animate) {
+    animatedX.set(rectX);
+  }
 
   if (!visible) {
     return null;
@@ -104,13 +110,23 @@ export function TooltipIndicator({
           />
         </linearGradient>
       </defs>
-      <motion.rect
-        fill={`url(#${gradientId})`}
-        height={height}
-        width={pixelWidth}
-        x={animatedX}
-        y={0}
-      />
+      {animate ? (
+        <motion.rect
+          fill={`url(#${gradientId})`}
+          height={height}
+          width={pixelWidth}
+          x={animatedX}
+          y={0}
+        />
+      ) : (
+        <rect
+          fill={`url(#${gradientId})`}
+          height={height}
+          width={pixelWidth}
+          x={rectX}
+          y={0}
+        />
+      )}
     </g>
   );
 }

--- a/packages/ui/src/charts/use-chart-interaction.ts
+++ b/packages/ui/src/charts/use-chart-interaction.ts
@@ -2,8 +2,9 @@
 
 import { localPoint } from "@visx/event";
 import type { scaleLinear, scaleTime } from "@visx/scale";
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useRef, useState } from "react";
 import type { LineConfig, Margin, TooltipData } from "./chart-context";
+import { useScheduledTooltip } from "./use-scheduled-tooltip";
 
 type ScaleTime = ReturnType<typeof scaleTime<number>>;
 type ScaleLinear = ReturnType<typeof scaleLinear<number>>;
@@ -58,50 +59,17 @@ export function useChartInteraction({
   bisectDate,
   canInteract,
 }: UseChartInteractionParams): ChartInteractionResult {
-  const [tooltipData, setTooltipData] = useState<TooltipData | null>(null);
   const [selection, setSelection] = useState<ChartSelection | null>(null);
+  const {
+    tooltipData,
+    setTooltipData,
+    scheduleTooltip,
+    clearTooltip,
+    resetTooltipDedupe,
+  } = useScheduledTooltip<TooltipData>();
 
   const isDraggingRef = useRef(false);
   const dragStartXRef = useRef<number>(0);
-  const lastTooltipIndexRef = useRef<number | null>(null);
-  const pendingTooltipRef = useRef<TooltipData | null>(null);
-  const tooltipRafRef = useRef<number | null>(null);
-
-  useEffect(() => {
-    return () => {
-      if (tooltipRafRef.current !== null) {
-        cancelAnimationFrame(tooltipRafRef.current);
-      }
-    };
-  }, []);
-
-  const commitTooltip = useCallback((tooltip: TooltipData) => {
-    if (tooltip.index === lastTooltipIndexRef.current) {
-      return;
-    }
-    lastTooltipIndexRef.current = tooltip.index;
-    setTooltipData(tooltip);
-  }, []);
-
-  const scheduleTooltip = useCallback(
-    (tooltip: TooltipData) => {
-      pendingTooltipRef.current = tooltip;
-      if (tooltip.index === lastTooltipIndexRef.current) {
-        return;
-      }
-      if (tooltipRafRef.current !== null) {
-        return;
-      }
-      tooltipRafRef.current = requestAnimationFrame(() => {
-        tooltipRafRef.current = null;
-        const next = pendingTooltipRef.current;
-        if (next) {
-          commitTooltip(next);
-        }
-      });
-    },
-    [commitTooltip]
-  );
 
   const resolveTooltipFromX = useCallback(
     (pixelX: number): TooltipData | null => {
@@ -193,8 +161,6 @@ export function useChartInteraction({
     [margin.left]
   );
 
-  // --- Mouse handlers ---
-
   const handleMouseMove = useCallback(
     (event: React.MouseEvent<SVGGElement>) => {
       const chartX = getChartX(event);
@@ -224,18 +190,12 @@ export function useChartInteraction({
   );
 
   const handleMouseLeave = useCallback(() => {
-    if (tooltipRafRef.current !== null) {
-      cancelAnimationFrame(tooltipRafRef.current);
-      tooltipRafRef.current = null;
-    }
-    pendingTooltipRef.current = null;
-    lastTooltipIndexRef.current = null;
-    setTooltipData(null);
+    clearTooltip();
     if (isDraggingRef.current) {
       isDraggingRef.current = false;
     }
     setSelection(null);
-  }, []);
+  }, [clearTooltip]);
 
   const handleMouseDown = useCallback(
     (event: React.MouseEvent<SVGGElement>) => {
@@ -245,10 +205,10 @@ export function useChartInteraction({
       }
       isDraggingRef.current = true;
       dragStartXRef.current = chartX;
-      setTooltipData(null);
+      clearTooltip();
       setSelection(null);
     },
-    [getChartX]
+    [getChartX, clearTooltip]
   );
 
   const handleMouseUp = useCallback(() => {
@@ -257,8 +217,6 @@ export function useChartInteraction({
     }
     setSelection(null);
   }, []);
-
-  // --- Touch handlers ---
 
   const handleTouchStart = useCallback(
     (event: React.TouchEvent<SVGGElement>) => {
@@ -274,8 +232,8 @@ export function useChartInteraction({
         }
       } else if (event.touches.length === 2) {
         event.preventDefault();
-        lastTooltipIndexRef.current = null;
-        setTooltipData(null);
+        resetTooltipDedupe();
+        clearTooltip();
         const x0 = getChartX(event, 0);
         const x1 = getChartX(event, 1);
         if (x0 === null || x1 === null) {
@@ -292,7 +250,14 @@ export function useChartInteraction({
         });
       }
     },
-    [getChartX, resolveTooltipFromX, resolveIndexFromX, scheduleTooltip]
+    [
+      getChartX,
+      resolveTooltipFromX,
+      resolveIndexFromX,
+      scheduleTooltip,
+      resetTooltipDedupe,
+      clearTooltip,
+    ]
   );
 
   const handleTouchMove = useCallback(
@@ -329,15 +294,9 @@ export function useChartInteraction({
   );
 
   const handleTouchEnd = useCallback(() => {
-    if (tooltipRafRef.current !== null) {
-      cancelAnimationFrame(tooltipRafRef.current);
-      tooltipRafRef.current = null;
-    }
-    pendingTooltipRef.current = null;
-    lastTooltipIndexRef.current = null;
-    setTooltipData(null);
+    clearTooltip();
     setSelection(null);
-  }, []);
+  }, [clearTooltip]);
 
   const clearSelection = useCallback(() => {
     setSelection(null);

--- a/packages/ui/src/charts/use-chart-interaction.ts
+++ b/packages/ui/src/charts/use-chart-interaction.ts
@@ -2,7 +2,7 @@
 
 import { localPoint } from "@visx/event";
 import type { scaleLinear, scaleTime } from "@visx/scale";
-import { useCallback, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import type { LineConfig, Margin, TooltipData } from "./chart-context";
 
 type ScaleTime = ReturnType<typeof scaleTime<number>>;
@@ -63,6 +63,45 @@ export function useChartInteraction({
 
   const isDraggingRef = useRef(false);
   const dragStartXRef = useRef<number>(0);
+  const lastTooltipIndexRef = useRef<number | null>(null);
+  const pendingTooltipRef = useRef<TooltipData | null>(null);
+  const tooltipRafRef = useRef<number | null>(null);
+
+  useEffect(() => {
+    return () => {
+      if (tooltipRafRef.current !== null) {
+        cancelAnimationFrame(tooltipRafRef.current);
+      }
+    };
+  }, []);
+
+  const commitTooltip = useCallback((tooltip: TooltipData) => {
+    if (tooltip.index === lastTooltipIndexRef.current) {
+      return;
+    }
+    lastTooltipIndexRef.current = tooltip.index;
+    setTooltipData(tooltip);
+  }, []);
+
+  const scheduleTooltip = useCallback(
+    (tooltip: TooltipData) => {
+      pendingTooltipRef.current = tooltip;
+      if (tooltip.index === lastTooltipIndexRef.current) {
+        return;
+      }
+      if (tooltipRafRef.current !== null) {
+        return;
+      }
+      tooltipRafRef.current = requestAnimationFrame(() => {
+        tooltipRafRef.current = null;
+        const next = pendingTooltipRef.current;
+        if (next) {
+          commitTooltip(next);
+        }
+      });
+    },
+    [commitTooltip]
+  );
 
   const resolveTooltipFromX = useCallback(
     (pixelX: number): TooltipData | null => {
@@ -178,13 +217,19 @@ export function useChartInteraction({
 
       const tooltip = resolveTooltipFromX(chartX);
       if (tooltip) {
-        setTooltipData(tooltip);
+        scheduleTooltip(tooltip);
       }
     },
-    [getChartX, resolveTooltipFromX, resolveIndexFromX]
+    [getChartX, resolveTooltipFromX, resolveIndexFromX, scheduleTooltip]
   );
 
   const handleMouseLeave = useCallback(() => {
+    if (tooltipRafRef.current !== null) {
+      cancelAnimationFrame(tooltipRafRef.current);
+      tooltipRafRef.current = null;
+    }
+    pendingTooltipRef.current = null;
+    lastTooltipIndexRef.current = null;
     setTooltipData(null);
     if (isDraggingRef.current) {
       isDraggingRef.current = false;
@@ -225,10 +270,11 @@ export function useChartInteraction({
         }
         const tooltip = resolveTooltipFromX(chartX);
         if (tooltip) {
-          setTooltipData(tooltip);
+          scheduleTooltip(tooltip);
         }
       } else if (event.touches.length === 2) {
         event.preventDefault();
+        lastTooltipIndexRef.current = null;
         setTooltipData(null);
         const x0 = getChartX(event, 0);
         const x1 = getChartX(event, 1);
@@ -246,7 +292,7 @@ export function useChartInteraction({
         });
       }
     },
-    [getChartX, resolveTooltipFromX, resolveIndexFromX]
+    [getChartX, resolveTooltipFromX, resolveIndexFromX, scheduleTooltip]
   );
 
   const handleTouchMove = useCallback(
@@ -259,7 +305,7 @@ export function useChartInteraction({
         }
         const tooltip = resolveTooltipFromX(chartX);
         if (tooltip) {
-          setTooltipData(tooltip);
+          scheduleTooltip(tooltip);
         }
       } else if (event.touches.length === 2) {
         event.preventDefault();
@@ -279,10 +325,16 @@ export function useChartInteraction({
         });
       }
     },
-    [getChartX, resolveTooltipFromX, resolveIndexFromX]
+    [getChartX, resolveTooltipFromX, resolveIndexFromX, scheduleTooltip]
   );
 
   const handleTouchEnd = useCallback(() => {
+    if (tooltipRafRef.current !== null) {
+      cancelAnimationFrame(tooltipRafRef.current);
+      tooltipRafRef.current = null;
+    }
+    pendingTooltipRef.current = null;
+    lastTooltipIndexRef.current = null;
     setTooltipData(null);
     setSelection(null);
   }, []);

--- a/packages/ui/src/charts/use-scatter-chart-interaction.ts
+++ b/packages/ui/src/charts/use-scatter-chart-interaction.ts
@@ -5,6 +5,7 @@ import { useCallback, useRef, useState } from "react";
 import type { LineConfig, Margin, TooltipData } from "./chart-context";
 import { localPointFromSvg } from "./scatter-svg";
 import type { ChartSelection } from "./use-chart-interaction";
+import { useScheduledTooltip } from "./use-scheduled-tooltip";
 
 type XScale = ScaleTime<number, number>;
 type YScale = ScaleLinear<number, number>;
@@ -51,8 +52,14 @@ export function useScatterChartInteraction({
   bisectDate,
   canInteract,
 }: UseScatterChartInteractionParams): ScatterChartInteractionResult {
-  const [tooltipData, setTooltipData] = useState<TooltipData | null>(null);
   const [selection, setSelection] = useState<ChartSelection | null>(null);
+  const {
+    tooltipData,
+    setTooltipData,
+    scheduleTooltip,
+    clearTooltip,
+    resetTooltipDedupe,
+  } = useScheduledTooltip<TooltipData>();
 
   const isDraggingRef = useRef(false);
   const dragStartXRef = useRef<number>(0);
@@ -170,19 +177,19 @@ export function useScatterChartInteraction({
 
       const tooltip = resolveTooltipFromX(chartX);
       if (tooltip) {
-        setTooltipData(tooltip);
+        scheduleTooltip(tooltip);
       }
     },
-    [getChartX, resolveTooltipFromX, resolveIndexFromX]
+    [getChartX, resolveTooltipFromX, resolveIndexFromX, scheduleTooltip]
   );
 
   const handleMouseLeave = useCallback(() => {
-    setTooltipData(null);
+    clearTooltip();
     if (isDraggingRef.current) {
       isDraggingRef.current = false;
     }
     setSelection(null);
-  }, []);
+  }, [clearTooltip]);
 
   const handleMouseDown = useCallback(
     (event: React.MouseEvent<SVGGElement>) => {
@@ -192,10 +199,10 @@ export function useScatterChartInteraction({
       }
       isDraggingRef.current = true;
       dragStartXRef.current = chartX;
-      setTooltipData(null);
+      clearTooltip();
       setSelection(null);
     },
-    [getChartX]
+    [getChartX, clearTooltip]
   );
 
   const handleMouseUp = useCallback(() => {
@@ -215,11 +222,12 @@ export function useScatterChartInteraction({
         }
         const tooltip = resolveTooltipFromX(chartX);
         if (tooltip) {
-          setTooltipData(tooltip);
+          scheduleTooltip(tooltip);
         }
       } else if (event.touches.length === 2) {
         event.preventDefault();
-        setTooltipData(null);
+        resetTooltipDedupe();
+        clearTooltip();
         const x0 = getChartX(event, 0);
         const x1 = getChartX(event, 1);
         if (x0 === null || x1 === null) {
@@ -236,7 +244,14 @@ export function useScatterChartInteraction({
         });
       }
     },
-    [getChartX, resolveTooltipFromX, resolveIndexFromX]
+    [
+      getChartX,
+      resolveTooltipFromX,
+      resolveIndexFromX,
+      scheduleTooltip,
+      resetTooltipDedupe,
+      clearTooltip,
+    ]
   );
 
   const handleTouchMove = useCallback(
@@ -249,7 +264,7 @@ export function useScatterChartInteraction({
         }
         const tooltip = resolveTooltipFromX(chartX);
         if (tooltip) {
-          setTooltipData(tooltip);
+          scheduleTooltip(tooltip);
         }
       } else if (event.touches.length === 2) {
         event.preventDefault();
@@ -269,13 +284,13 @@ export function useScatterChartInteraction({
         });
       }
     },
-    [getChartX, resolveTooltipFromX, resolveIndexFromX]
+    [getChartX, resolveTooltipFromX, resolveIndexFromX, scheduleTooltip]
   );
 
   const handleTouchEnd = useCallback(() => {
-    setTooltipData(null);
+    clearTooltip();
     setSelection(null);
-  }, []);
+  }, [clearTooltip]);
 
   const clearSelection = useCallback(() => {
     setSelection(null);

--- a/packages/ui/src/charts/use-scheduled-tooltip.ts
+++ b/packages/ui/src/charts/use-scheduled-tooltip.ts
@@ -1,0 +1,93 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+
+export interface ScheduledTooltipControls<T> {
+  tooltipData: T | null;
+  setTooltipData: React.Dispatch<React.SetStateAction<T | null>>;
+  scheduleTooltip: (tooltip: T, dedupeKey?: string) => void;
+  clearTooltip: () => void;
+  resetTooltipDedupe: () => void;
+}
+
+function defaultDedupeKey<T>(tooltip: T): string {
+  if (
+    typeof tooltip === "object" &&
+    tooltip !== null &&
+    "index" in tooltip &&
+    typeof (tooltip as { index: unknown }).index === "number"
+  ) {
+    return String((tooltip as { index: number }).index);
+  }
+  return JSON.stringify(tooltip);
+}
+
+export function useScheduledTooltip<T>(): ScheduledTooltipControls<T> {
+  const [tooltipData, setTooltipData] = useState<T | null>(null);
+  const lastKeyRef = useRef<string | null>(null);
+  const pendingRef = useRef<T | null>(null);
+  const rafRef = useRef<number | null>(null);
+  const pendingKeyRef = useRef<string | null>(null);
+
+  useEffect(() => {
+    return () => {
+      if (rafRef.current !== null) {
+        cancelAnimationFrame(rafRef.current);
+      }
+    };
+  }, []);
+
+  const commitTooltip = useCallback((tooltip: T, dedupeKey: string) => {
+    if (dedupeKey === lastKeyRef.current) {
+      return;
+    }
+    lastKeyRef.current = dedupeKey;
+    setTooltipData(tooltip);
+  }, []);
+
+  const scheduleTooltip = useCallback(
+    (tooltip: T, dedupeKey?: string) => {
+      const key = dedupeKey ?? defaultDedupeKey(tooltip);
+      pendingRef.current = tooltip;
+      pendingKeyRef.current = key;
+      if (key === lastKeyRef.current) {
+        return;
+      }
+      if (rafRef.current !== null) {
+        return;
+      }
+      rafRef.current = requestAnimationFrame(() => {
+        rafRef.current = null;
+        const next = pendingRef.current;
+        const nextKey = pendingKeyRef.current;
+        if (next && nextKey) {
+          commitTooltip(next, nextKey);
+        }
+      });
+    },
+    [commitTooltip]
+  );
+
+  const clearTooltip = useCallback(() => {
+    if (rafRef.current !== null) {
+      cancelAnimationFrame(rafRef.current);
+      rafRef.current = null;
+    }
+    pendingRef.current = null;
+    pendingKeyRef.current = null;
+    lastKeyRef.current = null;
+    setTooltipData(null);
+  }, []);
+
+  const resetTooltipDedupe = useCallback(() => {
+    lastKeyRef.current = null;
+  }, []);
+
+  return {
+    tooltipData,
+    setTooltipData,
+    scheduleTooltip,
+    clearTooltip,
+    resetTooltipDedupe,
+  };
+}


### PR DESCRIPTION
## Summary

- LTTB path decimation for line/area (and OHLC bucket aggregation for candlestick) so SVG rendering scales with chart width while tooltips and scales keep the full dataset
- RAF-batched tooltip updates with index dedup across cartesian interactions; live-line React commits throttled to ~30fps
- Candlestick + scatter: keep enter animations (stagger / blur reveal), then switch to static SVG after load with group-layer hover (opacity dim + highlight; scatter uses one blur filter per series instead of per-dot motion)
- Large datasets: compact date ticker and instant crosshair snap (>60 labels) to avoid scroll-stack and spring overhead during scrubbing

Follow-up to #90.

## Test plan

- [x] `pnpm lint` passes at repo root
- [x] `pnpm check-types` passes
- [x] `pnpm build` succeeds
- [x] `packages/ui` chart unit tests pass (30)
- [x] CI lint + test jobs green
- [ ] Candlestick: enter stagger + hover fade at 6mo daily data (~60 FPS)
- [ ] Scatter: 3-series enter blur + group blur/opacity hover at 6mo daily data
- [ ] Line/area/bar: hover scrub still smooth on docs demos