### PR TITLE
feat(studio): procedural cartesian data with configurable series + points

### DIFF
--- a/apps/web/lib/studio/__tests__/codegen.test.ts
+++ b/apps/web/lib/studio/__tests__/codegen.test.ts
@@ -49,16 +49,24 @@ describe("generateStudioCode", () => {
     assert.match(code, STROKE_WIDTH_3_RE);
   });
 
-  it("bar horizontal stacked includes orientation and primary key", () => {
+  it("bar horizontal uses categorical browser dataset", () => {
     const state = defaultStudioState({
       chart: "bar-chart",
       barOrientation: "horizontal",
-      barSeriesMode: "stacked",
     });
     const { code } = generateStudioCode("bar-chart", state);
     assert.match(code, ORIENTATION_HORIZONTAL_RE);
-    assert.match(code, STACKED_RE);
     assert.match(code, DATA_KEY_USERS_RE);
+  });
+
+  it("bar vertical stacked emits stacked prop with multi-series", () => {
+    const state = defaultStudioState({
+      chart: "bar-chart",
+      barSeriesMode: "stacked",
+      dataSeries: 3,
+    });
+    const { code } = generateStudioCode("bar-chart", state);
+    assert.match(code, STACKED_RE);
   });
 
   it("gauge uses dynamic label and angles", () => {
@@ -75,9 +83,9 @@ describe("generateStudioCode", () => {
 });
 
 describe("barCodegen", () => {
-  it("grouped vertical adds mobile series", () => {
+  it("grouped vertical adds mobile series when dataSeries > 1", () => {
     const { code } = barCodegen(
-      defaultStudioState({ barSeriesMode: "grouped" })
+      defaultStudioState({ barSeriesMode: "grouped", dataSeries: 2 })
     );
     assert.match(code, DATA_KEY_MOBILE_RE);
   });

--- a/apps/web/lib/studio/codegen-helpers.ts
+++ b/apps/web/lib/studio/codegen-helpers.ts
@@ -1,18 +1,17 @@
 import { motionSliceFromState } from "./chart-animation";
 import { curveImportName } from "./curves";
 import {
-  areaData,
-  barData,
   barHorizontalData,
-  barStackedData,
   candlestickOhlcData,
-  composedDemoData,
+  clampStudioPointCount,
+  clampStudioSeriesCount,
   funnelData,
-  lineHeroData,
   liveLineSampleData,
   radarDataDual,
   radarMetrics5,
   ringData,
+  STUDIO_SERIES_KEYS,
+  type StudioCartesianXAxis,
   sankeySimple,
   scatterStudioData,
 } from "./demo-data";
@@ -24,24 +23,91 @@ import { patternCodegenBlock } from "./patterns";
 import { seriesStrokePropsCodegen } from "./series-stroke-props";
 import type { StudioUrlState } from "./studio-parsers";
 
+// Only 5 chart-N vars exist; series 6–10 cycle back through chart-1…chart-5.
+const SERIES_COLOR_BY_INDEX = [
+  "var(--chart-1)",
+  "var(--chart-2)",
+  "var(--chart-3)",
+  "var(--chart-4)",
+  "var(--chart-5)",
+  "var(--chart-1)",
+  "var(--chart-2)",
+  "var(--chart-3)",
+  "var(--chart-4)",
+  "var(--chart-5)",
+];
+
+function seriesKeysForState(state: StudioUrlState): string[] {
+  const count = clampStudioSeriesCount(state.dataSeries);
+  return STUDIO_SERIES_KEYS.slice(0, count);
+}
+
+/** Procedural `Array.from(...)` chart data snippet — matches `generateStudioCartesianData`. */
+export function studioCartesianDataSnippet(
+  state: StudioUrlState,
+  xAxis: StudioCartesianXAxis,
+  keysOverride?: readonly string[]
+): string {
+  const keys = keysOverride ?? seriesKeysForState(state);
+  const points = clampStudioPointCount(state.dataPoints);
+  const xLine =
+    xAxis === "date"
+      ? "  date: new Date(2024, 0, i + 1),"
+      : '  month: ["Jan","Feb","Mar","Apr","May","Jun","Jul","Aug","Sep","Oct","Nov","Dec"][i % 12],';
+  // Four layered waves at geometrically-spaced periods (~30, ~10.7, ~3.8, ~1.9) for lively, non-repeating output.
+  const seriesLines = keys
+    .map(
+      (key, s) =>
+        `  ${key}: Math.max(10, Math.floor(${180 + s * 18} + Math.sin((i + ${s * 17}) / 4.77) * ${38 + s * 3} + Math.cos((i + ${s * 7}) / 1.7) * 24 + Math.sin((i + ${s * 3}) / 0.61) * 14 + Math.cos((i + ${s * 11}) / 0.31) * 8)),`
+    )
+    .join("\n");
+  return `const chartData = Array.from({ length: ${points} }, (_, i) => ({
+${xLine}
+${seriesLines}
+}));`;
+}
+
 export function cartesianCodegen(
   chartType: "AreaChart" | "LineChart",
-  state: StudioUrlState,
-  dataKey: string
+  state: StudioUrlState
 ) {
   const curveName = curveImportName(state.curve);
   const fill = "url(#studio-pattern-fill)";
   const anim = `\n  ${cssRevealAnimationCodegen(state.animationDuration, motionSliceFromState(state))}`;
 
   const seriesProps = seriesStrokePropsCodegen(state);
+  const keys = seriesKeysForState(state);
 
   let child = "";
   if (chartType === "LineChart") {
-    child = `\n  <Line dataKey="${dataKey}" curve={${curveName}} strokeWidth={${state.strokeWidth}} fadeEdges={${state.fadeEdges}} showHighlight={${state.showHighlight}}${seriesProps} />`;
+    child = keys
+      .map((key, idx) => {
+        const strokeAttr =
+          idx === 0 ? "" : ` stroke="${SERIES_COLOR_BY_INDEX[idx]}"`;
+        return `\n  <Line dataKey="${key}"${strokeAttr} curve={${curveName}} strokeWidth={${state.strokeWidth}} fadeEdges={${state.fadeEdges}} showHighlight={${state.showHighlight}}${seriesProps} />`;
+      })
+      .join("");
   } else if (state.pattern === "none") {
-    child = `\n  <Area dataKey="${dataKey}" curve={${curveName}} fillOpacity={${state.fillOpacity}} strokeWidth={${state.strokeWidth}} fadeEdges={${state.fadeEdges}} gradientToOpacity={${state.gradientToOpacity}} showLine={${state.showLine}} showHighlight={${state.showHighlight}}${seriesProps} />`;
+    child = keys
+      .map((key, idx) => {
+        const fillAttr =
+          idx === 0 ? "" : ` fill="${SERIES_COLOR_BY_INDEX[idx]}"`;
+        return `\n  <Area dataKey="${key}"${fillAttr} curve={${curveName}} fillOpacity={${state.fillOpacity}} strokeWidth={${state.strokeWidth}} fadeEdges={${state.fadeEdges}} gradientToOpacity={${state.gradientToOpacity}} showLine={${state.showLine}} showHighlight={${state.showHighlight}}${seriesProps} />`;
+      })
+      .join("");
   } else {
-    child = `\n  ${patternCodegenBlock(state.pattern)}\n  <PatternArea dataKey="${dataKey}" fill="${fill}" curve={${curveName}} />\n  <Area dataKey="${dataKey}" fillOpacity={0} curve={${curveName}} strokeWidth={${state.strokeWidth}} fadeEdges={${state.fadeEdges}} gradientToOpacity={${state.gradientToOpacity}} showLine={${state.showLine}} showHighlight={${state.showHighlight}}${seriesProps} />`;
+    // Pattern fill applies only to the primary series; secondaries fall back to solid chart-N color.
+    const [primaryKey, ...rest] = keys;
+    const primary = primaryKey
+      ? `\n  ${patternCodegenBlock(state.pattern)}\n  <PatternArea dataKey="${primaryKey}" fill="${fill}" curve={${curveName}} />\n  <Area dataKey="${primaryKey}" fillOpacity={0} curve={${curveName}} strokeWidth={${state.strokeWidth}} fadeEdges={${state.fadeEdges}} gradientToOpacity={${state.gradientToOpacity}} showLine={${state.showLine}} showHighlight={${state.showHighlight}}${seriesProps} />`
+      : "";
+    const others = rest
+      .map(
+        (key, idx) =>
+          `\n  <Area dataKey="${key}" fill="${SERIES_COLOR_BY_INDEX[idx + 1]}" curve={${curveName}} fillOpacity={${state.fillOpacity}} strokeWidth={${state.strokeWidth}} fadeEdges={${state.fadeEdges}} gradientToOpacity={${state.gradientToOpacity}} showLine={${state.showLine}} showHighlight={${state.showHighlight}}${seriesProps} />`
+      )
+      .join("");
+    child = `${primary}${others}`;
   }
 
   let extraImports = "";
@@ -99,20 +165,24 @@ export function gaugeCodegen(state: StudioUrlState) {
 
 export function barCodegen(state: StudioUrlState) {
   const horizontal = state.barOrientation === "horizontal";
-  const stacked = state.barSeriesMode === "stacked";
-  const multi = state.barSeriesMode !== "single";
-  const xKey = horizontal ? "browser" : "month";
-  const primaryKey = horizontal ? "users" : "desktop";
-  const fill =
+  const seriesCount = clampStudioSeriesCount(state.dataSeries);
+  // "single" mode is treated as grouped when dataSeries > 1.
+  const stacked = seriesCount > 1 && state.barSeriesMode === "stacked";
+  const primaryFill =
     state.pattern === "none" ? "var(--chart-1)" : "url(#studio-pattern-fill)";
 
   let dataSnippet: string;
+  let xKey: string;
+  let keys: string[];
   if (horizontal) {
+    // Horizontal bar keeps the categorical browser dataset.
     dataSnippet = `const chartData = ${JSON.stringify(barHorizontalData, null, 2)};`;
-  } else if (multi) {
-    dataSnippet = `const chartData = ${JSON.stringify(barStackedData, null, 2)};`;
+    xKey = "browser";
+    keys = ["users"];
   } else {
-    dataSnippet = `const chartData = ${JSON.stringify(barData, null, 2)};`;
+    keys = STUDIO_SERIES_KEYS.slice(0, seriesCount);
+    dataSnippet = studioCartesianDataSnippet(state, "month", keys);
+    xKey = "month";
   }
 
   const chartProps = [
@@ -137,17 +207,18 @@ export function barCodegen(state: StudioUrlState) {
   const patternBlock =
     state.pattern === "none" ? "" : `\n  ${patternCodegenBlock(state.pattern)}`;
 
-  const secondBar =
-    multi && !horizontal
-      ? `\n  <Bar dataKey="mobile" fill="var(--chart-3)" lineCap="${state.barLineCap}" fadedOpacity={${state.barFadedOpacity}} groupGap={${state.groupGap}}${stacked ? " stackGap={3}" : ""} />`
-      : "";
+  const bars = keys
+    .map((key, idx) => {
+      const fill = idx === 0 ? primaryFill : SERIES_COLOR_BY_INDEX[idx];
+      return `\n  <Bar dataKey="${key}" lineCap="${state.barLineCap}" fill="${fill}" fadedOpacity={${state.barFadedOpacity}} groupGap={${state.groupGap}}${stacked ? " stackGap={3}" : ""} />`;
+    })
+    .join("");
 
   return {
     code: `import { BarChart, Bar, BarXAxis, Grid, ChartTooltip${state.pattern === "none" ? "" : ", PatternLines"} } from "@bklitui/ui/charts";
 
 <BarChart ${chartProps}>
-  <Grid ${gridProps} />${patternBlock}
-  <Bar dataKey="${primaryKey}" lineCap="${state.barLineCap}" fill="${fill}" fadedOpacity={${state.barFadedOpacity}} groupGap={${state.groupGap}}${stacked ? " stackGap={3}" : ""} />${secondBar}
+  <Grid ${gridProps} />${patternBlock}${bars}
   <BarXAxis />
   <ChartTooltip showCrosshair={false} />
 </BarChart>`,
@@ -160,6 +231,19 @@ export function composedCodegen(state: StudioUrlState) {
   const barPattern =
     state.pattern === "none" ? "" : `\n  ${patternCodegenBlock(state.pattern)}`;
   const seriesProps = seriesStrokePropsCodegen(state);
+  const keys = seriesKeysForState(state);
+  const [barKey, ...secondaryKeys] = keys;
+
+  const barLine = barKey
+    ? `\n  <SeriesBar dataKey="${barKey}" radius={${state.composedBarRadius}} ${state.pattern === "none" ? 'fill="var(--chart-1)"' : 'fill="url(#studio-pattern-fill)"'} />`
+    : "";
+
+  const overlays = secondaryKeys
+    .map((key, idx) => {
+      const color = SERIES_COLOR_BY_INDEX[idx + 1];
+      return `\n  <Area dataKey="${key}" curve={${curveName}} fillOpacity={${state.fillOpacity}} fadeEdges={${state.fadeEdges}} fill="${color}"${seriesProps} />\n  <Line dataKey="${key}" curve={${curveName}} strokeWidth={${state.strokeWidth}} fadeEdges={${state.fadeEdges}} stroke="${color}"${seriesProps} />`;
+    })
+    .join("");
 
   return {
     code: `import { ComposedChart, SeriesBar, Area, Line, Grid, XAxis, ChartTooltip${state.pattern === "none" ? "" : ", PatternLines"} } from "@bklitui/ui/charts";
@@ -167,14 +251,11 @@ import { ${curveName} } from "@visx/curve";
 
 <ComposedChart data={chartData}
   ${cssRevealAnimationCodegen(state.animationDuration, motionSliceFromState(state))}>
-  <Grid horizontal />${barPattern}
-  <SeriesBar dataKey="revenue" radius={${state.composedBarRadius}} ${state.pattern === "none" ? 'fill="var(--chart-1)"' : 'fill="url(#studio-pattern-fill)"'} />
-  <Area dataKey="runRate" curve={${curveName}} fillOpacity={${state.fillOpacity}} fadeEdges={${state.fadeEdges}} fill="var(--chart-4)"${seriesProps} />
-  <Line dataKey="runRate" curve={${curveName}} strokeWidth={${state.strokeWidth}} fadeEdges={${state.fadeEdges}} stroke="var(--chart-2)"${seriesProps} />
+  <Grid horizontal />${barPattern}${barLine}${overlays}
   <XAxis />
   <ChartTooltip />
 </ComposedChart>`,
-    data: `const chartData = ${JSON.stringify(composedDemoData, null, 2)};`,
+    data: studioCartesianDataSnippet(state, "date"),
   };
 }
 
@@ -325,12 +406,12 @@ export function scatterChartDataSnippet() {
   return `const chartData = ${JSON.stringify(scatterStudioData.slice(0, 12), null, 2)};`;
 }
 
-export function lineChartDataSnippet() {
-  return `const chartData = ${JSON.stringify(lineHeroData, null, 2)};`;
+export function lineChartDataSnippet(state: StudioUrlState) {
+  return studioCartesianDataSnippet(state, "date");
 }
 
-export function areaChartDataSnippet() {
-  return `const chartData = ${JSON.stringify(areaData, null, 2)};`;
+export function areaChartDataSnippet(state: StudioUrlState) {
+  return studioCartesianDataSnippet(state, "date");
 }
 
 export function gaugeDataSnippet(state: StudioUrlState) {

--- a/apps/web/lib/studio/demo-data.ts
+++ b/apps/web/lib/studio/demo-data.ts
@@ -195,3 +195,122 @@ export const liveLineSampleData = Array.from({ length: 24 }, (_, i) => ({
   time: Date.now() - (23 - i) * 1000,
   value: Math.floor(40 + Math.sin(i / 3) * 18 + ((i * 5) % 11)),
 }));
+
+/**
+ * Series keys + matching chart-N CSS vars used by procedural generators.
+ * Only 5 chart-N vars exist, so series 6–10 cycle back through chart-1…chart-5.
+ */
+export const STUDIO_SERIES_KEYS = [
+  "desktop",
+  "mobile",
+  "tablet",
+  "watch",
+  "tv",
+  "console",
+  "vr",
+  "kiosk",
+  "ereader",
+  "wearable",
+] as const;
+export const STUDIO_SERIES_COLORS = [
+  "var(--chart-1)",
+  "var(--chart-2)",
+  "var(--chart-3)",
+  "var(--chart-4)",
+  "var(--chart-5)",
+  "var(--chart-1)",
+  "var(--chart-2)",
+  "var(--chart-3)",
+  "var(--chart-4)",
+  "var(--chart-5)",
+] as const;
+const MONTH_LABELS = [
+  "Jan",
+  "Feb",
+  "Mar",
+  "Apr",
+  "May",
+  "Jun",
+  "Jul",
+  "Aug",
+  "Sep",
+  "Oct",
+  "Nov",
+  "Dec",
+] as const;
+export const STUDIO_MAX_DATA_SERIES = STUDIO_SERIES_KEYS.length;
+
+/** Clamp the user-supplied series count to the supported range. */
+export function clampStudioSeriesCount(n: number): number {
+  if (!Number.isFinite(n) || n < 1) {
+    return 1;
+  }
+  return Math.min(STUDIO_MAX_DATA_SERIES, Math.floor(n));
+}
+
+/** Clamp the user-supplied point count to the supported range. */
+export function clampStudioPointCount(n: number): number {
+  if (!Number.isFinite(n) || n < 2) {
+    return 2;
+  }
+  return Math.min(365, Math.floor(n));
+}
+
+/**
+ * Deterministic, non-repeating series value — four sine/cosine waves at
+ * geometrically-spaced periods (~30, ~10.7, ~3.8, ~1.9) so the signal looks
+ * lively at every zoom (12 → 365 pts) without ever cycling exactly.
+ * Keep in sync with the inline formula emitted by `studioCartesianDataSnippet`.
+ */
+function studioSeriesValue(index: number, seriesIndex: number): number {
+  const arc =
+    Math.sin((index + seriesIndex * 17) / 4.77) * (38 + seriesIndex * 3);
+  const swell = Math.cos((index + seriesIndex * 7) / 1.7) * 24;
+  const ripple = Math.sin((index + seriesIndex * 3) / 0.61) * 14;
+  const jitter = Math.cos((index + seriesIndex * 11) / 0.31) * 8;
+  const base = 180 + seriesIndex * 18;
+  return Math.max(10, Math.floor(base + arc + swell + ripple + jitter));
+}
+
+export type StudioCartesianXAxis = "date" | "month";
+
+interface StudioCartesianDatum {
+  date?: Date;
+  month?: string;
+  [seriesKey: string]: Date | string | number | undefined;
+}
+
+/** Generate cartesian rows with N series + M points, x-axis is `date` or `month`. */
+export function generateStudioCartesianData({
+  seriesCount,
+  pointCount,
+  xAxis,
+}: {
+  seriesCount: number;
+  pointCount: number;
+  xAxis: StudioCartesianXAxis;
+}): StudioCartesianDatum[] {
+  const series = clampStudioSeriesCount(seriesCount);
+  const points = clampStudioPointCount(pointCount);
+  const baseYear = 2024;
+  return Array.from({ length: points }, (_, i) => {
+    const row: StudioCartesianDatum = {};
+    if (xAxis === "date") {
+      row.date = new Date(baseYear, 0, i + 1);
+    } else {
+      const monthIdx = i % MONTH_LABELS.length;
+      const yearOffset = Math.floor(i / MONTH_LABELS.length);
+      row.month =
+        yearOffset > 0
+          ? `${MONTH_LABELS[monthIdx]} ${(baseYear + yearOffset) % 100}`
+          : MONTH_LABELS[monthIdx];
+    }
+    for (let s = 0; s < series; s++) {
+      const key = STUDIO_SERIES_KEYS[s];
+      if (key) {
+        row[key] = studioSeriesValue(i, s);
+      }
+    }
+    return row;
+  });
+}

--- a/apps/web/lib/studio/registry-control-groups.ts
+++ b/apps/web/lib/studio/registry-control-groups.ts
@@ -1,6 +1,7 @@
 import {
   controlGroup,
   curveControl,
+  dataGroup,
   designGroup,
   lineGroup,
   patternControl,
@@ -123,6 +124,7 @@ export const seriesDashTailControlGroup = controlGroup("Dash tail", [
 ]);
 
 export const areaChartControlGroups: StudioControlGroup[] = [
+  dataGroup(),
   designGroup([
     patternControl(),
     {
@@ -164,6 +166,7 @@ export const areaChartControlGroups: StudioControlGroup[] = [
 ];
 
 export const lineChartControlGroups: StudioControlGroup[] = [
+  dataGroup(),
   lineGroup([
     curveControl(),
     {
@@ -182,13 +185,13 @@ export const lineChartControlGroups: StudioControlGroup[] = [
 ];
 
 export const barChartControlGroups: StudioControlGroup[] = [
+  dataGroup(),
   controlGroup("Series", [
     {
       type: "select",
       key: "barSeriesMode",
-      label: "Series",
+      label: "Series mode",
       options: [
-        { value: "single", label: "Single" },
         { value: "grouped", label: "Grouped" },
         { value: "stacked", label: "Stacked" },
       ],
@@ -234,6 +237,7 @@ export const barChartControlGroups: StudioControlGroup[] = [
 ];
 
 export const composedChartControlGroups: StudioControlGroup[] = [
+  dataGroup(),
   designGroup([
     patternControl(),
     {

--- a/apps/web/lib/studio/registry.tsx
+++ b/apps/web/lib/studio/registry.tsx
@@ -66,16 +66,15 @@ import {
 } from "./codegen-helpers";
 import { resolveCurve } from "./curves";
 import {
-  areaData,
-  barData,
   barHorizontalData,
-  barStackedData,
   candlestickOhlcData,
-  composedDemoData,
-  lineHeroData,
+  clampStudioSeriesCount,
+  generateStudioCartesianData,
   pieData,
   radarDataDual,
   radarMetrics5,
+  STUDIO_SERIES_COLORS,
+  STUDIO_SERIES_KEYS,
   sankeySimple,
   scatterStudioData,
 } from "./demo-data";
@@ -123,31 +122,54 @@ const areaConfig: StudioChartConfig = {
   render: (state, ctx) => {
     const curve = resolveCurve(state.curve);
     const fill = ctx.patternFill ?? undefined;
-    const seriesStroke = seriesStrokePropsFromState(state, areaData.length);
+    const seriesCount = clampStudioSeriesCount(state.dataSeries);
+    const data = generateStudioCartesianData({
+      seriesCount,
+      pointCount: state.dataPoints,
+      xAxis: "date",
+    });
+    const seriesStroke = seriesStrokePropsFromState(state, data.length);
     return (
       <StudioCartesianFill>
         <AreaChart
           {...getStudioCssRevealPropsForPreview(state, ctx)}
           className="size-full"
-          data={areaData}
+          data={data}
           key={studioPreviewChartKey(ctx)}
         >
           <Grid horizontal />
           {ctx.patternDefs}
-          {fill ? (
-            <PatternArea curve={curve} dataKey="desktop" fill={fill} />
-          ) : null}
-          <Area
-            curve={curve}
-            dataKey="desktop"
-            fadeEdges={fill ? false : state.fadeEdges}
-            fillOpacity={fill ? 0 : state.fillOpacity}
-            gradientToOpacity={state.gradientToOpacity}
-            showHighlight={state.showHighlight}
-            showLine={state.showLine}
-            strokeWidth={state.strokeWidth}
-            {...seriesStroke}
-          />
+          {STUDIO_SERIES_KEYS.slice(0, seriesCount).flatMap((key, idx) => {
+            // AreaChart picks up series via `Children.forEach` — wrapping in <Fragment> hides children, so flatten.
+            const isPrimary = idx === 0;
+            const patternThisSeries = isPrimary ? fill : undefined;
+            const nodes = [
+              <Area
+                curve={curve}
+                dataKey={key}
+                fadeEdges={patternThisSeries ? false : state.fadeEdges}
+                fill={isPrimary ? undefined : STUDIO_SERIES_COLORS[idx]}
+                fillOpacity={patternThisSeries ? 0 : state.fillOpacity}
+                gradientToOpacity={state.gradientToOpacity}
+                key={`area-${key}`}
+                showHighlight={state.showHighlight}
+                showLine={state.showLine}
+                strokeWidth={state.strokeWidth}
+                {...seriesStroke}
+              />,
+            ];
+            if (patternThisSeries) {
+              nodes.unshift(
+                <PatternArea
+                  curve={curve}
+                  dataKey={key}
+                  fill={patternThisSeries}
+                  key={`pattern-${key}`}
+                />
+              );
+            }
+            return nodes;
+          })}
           <XAxis />
           <ChartTooltip />
         </AreaChart>
@@ -155,8 +177,8 @@ const areaConfig: StudioChartConfig = {
     );
   },
   generateCode: (state) => ({
-    code: cartesianCodegen("AreaChart", state, "desktop"),
-    data: areaChartDataSnippet(),
+    code: cartesianCodegen("AreaChart", state),
+    data: areaChartDataSnippet(state),
   }),
 };
 
@@ -167,31 +189,44 @@ const lineConfig: StudioChartConfig = {
   motionPanel: true,
   controls: [],
   controlGroups: lineChartControlGroups,
-  render: (state, ctx) => (
-    <StudioCartesianFill>
-      <LineChart
-        {...getStudioCssRevealPropsForPreview(state, ctx)}
-        className="size-full"
-        data={lineHeroData}
-        key={studioPreviewChartKey(ctx)}
-      >
-        <Grid horizontal />
-        <Line
-          curve={resolveCurve(state.curve)}
-          dataKey="desktop"
-          fadeEdges={state.fadeEdges}
-          showHighlight={state.showHighlight}
-          strokeWidth={state.strokeWidth}
-          {...seriesStrokePropsFromState(state, lineHeroData.length)}
-        />
-        <XAxis />
-        <ChartTooltip />
-      </LineChart>
-    </StudioCartesianFill>
-  ),
+  render: (state, ctx) => {
+    const seriesCount = clampStudioSeriesCount(state.dataSeries);
+    const data = generateStudioCartesianData({
+      seriesCount,
+      pointCount: state.dataPoints,
+      xAxis: "date",
+    });
+    const seriesStroke = seriesStrokePropsFromState(state, data.length);
+    return (
+      <StudioCartesianFill>
+        <LineChart
+          {...getStudioCssRevealPropsForPreview(state, ctx)}
+          className="size-full"
+          data={data}
+          key={studioPreviewChartKey(ctx)}
+        >
+          <Grid horizontal />
+          {STUDIO_SERIES_KEYS.slice(0, seriesCount).map((key, idx) => (
+            <Line
+              curve={resolveCurve(state.curve)}
+              dataKey={key}
+              fadeEdges={state.fadeEdges}
+              key={key}
+              showHighlight={state.showHighlight}
+              stroke={idx === 0 ? undefined : STUDIO_SERIES_COLORS[idx]}
+              strokeWidth={state.strokeWidth}
+              {...seriesStroke}
+            />
+          ))}
+          <XAxis />
+          <ChartTooltip />
+        </LineChart>
+      </StudioCartesianFill>
+    );
+  },
   generateCode: (state) => ({
-    code: cartesianCodegen("LineChart", state, "desktop"),
-    data: lineChartDataSnippet(),
+    code: cartesianCodegen("LineChart", state),
+    data: lineChartDataSnippet(state),
   }),
 };
 
@@ -247,21 +282,29 @@ const barConfig: StudioChartConfig = {
   controlGroups: barChartControlGroups,
   render: (state, ctx) => {
     const horizontal = state.barOrientation === "horizontal";
-    const stacked = state.barSeriesMode === "stacked";
-    const multi = state.barSeriesMode !== "single";
-    type BarStudioDatum =
-      | (typeof barData)[number]
-      | (typeof barHorizontalData)[number]
-      | (typeof barStackedData)[number];
-    let chartData: BarStudioDatum[] = barData;
-    if (horizontal) {
-      chartData = barHorizontalData;
-    } else if (multi) {
-      chartData = barStackedData;
-    }
-    const xKey = horizontal ? "browser" : "month";
-    const fill = ctx.patternFill ?? "var(--chart-1)";
+    const seriesCount = clampStudioSeriesCount(state.dataSeries);
+    // barSeriesMode "single" is treated as grouped when dataSeries > 1.
+    const stacked = seriesCount > 1 && state.barSeriesMode === "stacked";
     const lineCap = state.barLineCap;
+    const primaryFill = ctx.patternFill ?? "var(--chart-1)";
+
+    let chartData: Record<string, unknown>[];
+    let xKey: string;
+    let seriesKeys: readonly string[];
+    if (horizontal) {
+      // Horizontal bar keeps its categorical browser dataset for readability.
+      chartData = barHorizontalData as unknown as Record<string, unknown>[];
+      xKey = "browser";
+      seriesKeys = ["users"];
+    } else {
+      chartData = generateStudioCartesianData({
+        seriesCount,
+        pointCount: state.dataPoints,
+        xAxis: "month",
+      }) as unknown as Record<string, unknown>[];
+      xKey = "month";
+      seriesKeys = STUDIO_SERIES_KEYS.slice(0, seriesCount);
+    }
 
     return (
       <StudioCartesianFill>
@@ -284,24 +327,17 @@ const barConfig: StudioChartConfig = {
             vertical={horizontal}
           />
           {ctx.patternDefs}
-          <Bar
-            dataKey={horizontal ? "users" : "desktop"}
-            fadedOpacity={state.barFadedOpacity}
-            fill={fill}
-            groupGap={state.groupGap}
-            lineCap={lineCap}
-            stackGap={stacked ? 3 : 0}
-          />
-          {multi && !horizontal ? (
+          {seriesKeys.map((key, idx) => (
             <Bar
-              dataKey="mobile"
+              dataKey={key}
               fadedOpacity={state.barFadedOpacity}
-              fill="var(--chart-3)"
+              fill={idx === 0 ? primaryFill : STUDIO_SERIES_COLORS[idx]}
               groupGap={state.groupGap}
+              key={key}
               lineCap={lineCap}
               stackGap={stacked ? 3 : 0}
             />
-          ) : null}
+          ))}
           <BarXAxis />
           <ChartTooltip showCrosshair={false} />
         </BarChart>
@@ -321,41 +357,58 @@ const composedConfig: StudioChartConfig = {
   controlGroups: composedChartControlGroups,
   render: (state, ctx) => {
     const curve = resolveCurve(state.curve);
-    const seriesStroke = seriesStrokePropsFromState(
-      state,
-      composedDemoData.length
-    );
+    const seriesCount = clampStudioSeriesCount(state.dataSeries);
+    const data = generateStudioCartesianData({
+      seriesCount,
+      pointCount: state.dataPoints,
+      xAxis: "date",
+    });
+    const seriesStroke = seriesStrokePropsFromState(state, data.length);
+    const barKey = STUDIO_SERIES_KEYS[0];
     return (
       <StudioCartesianFill>
         <ComposedChart
           {...getStudioCssRevealPropsForPreview(state, ctx)}
           className="size-full"
-          data={composedDemoData}
+          data={data}
           key={studioPreviewChartKey(ctx)}
         >
           <Grid horizontal />
           {ctx.patternDefs}
-          <SeriesBar
-            dataKey="revenue"
-            fill={ctx.patternFill ?? "var(--chart-1)"}
-            radius={state.composedBarRadius}
-          />
-          <Area
-            curve={curve}
-            dataKey="runRate"
-            fadeEdges={state.fadeEdges}
-            fill="var(--chart-4)"
-            fillOpacity={state.fillOpacity}
-            {...seriesStroke}
-          />
-          <Line
-            curve={curve}
-            dataKey="runRate"
-            fadeEdges={state.fadeEdges}
-            stroke="var(--chart-2)"
-            strokeWidth={state.strokeWidth}
-            {...seriesStroke}
-          />
+          {barKey ? (
+            <SeriesBar
+              dataKey={barKey}
+              fill={ctx.patternFill ?? "var(--chart-1)"}
+              radius={state.composedBarRadius}
+            />
+          ) : null}
+          {STUDIO_SERIES_KEYS.slice(1, seriesCount).flatMap(
+            (key, secondaryIdx) => {
+              // ComposedChart picks up series via `Children.forEach` — keep Area+Line as flat siblings, not inside a Fragment.
+              const colorIdx = secondaryIdx + 1;
+              const color = STUDIO_SERIES_COLORS[colorIdx];
+              return [
+                <Area
+                  curve={curve}
+                  dataKey={key}
+                  fadeEdges={state.fadeEdges}
+                  fill={color}
+                  fillOpacity={state.fillOpacity}
+                  key={`area-${key}`}
+                  {...seriesStroke}
+                />,
+                <Line
+                  curve={curve}
+                  dataKey={key}
+                  fadeEdges={state.fadeEdges}
+                  key={`line-${key}`}
+                  stroke={color}
+                  strokeWidth={state.strokeWidth}
+                  {...seriesStroke}
+                />,
+              ];
+            }
+          )}
           <XAxis />
           <ChartTooltip />
         </ComposedChart>

--- a/apps/web/lib/studio/sidebar-control-templates.ts
+++ b/apps/web/lib/studio/sidebar-control-templates.ts
@@ -30,3 +30,28 @@ export const patternControl = (): StudioControl => ({
   key: "pattern",
   label: "Pattern",
 });
+
+/**
+ * "Data" group with series + point count sliders.
+ *
+ * @param maxSeries - Cap series count (default 10, matches `STUDIO_SERIES_KEYS`).
+ */
+export const dataGroup = (maxSeries = 10): StudioControlGroup =>
+  controlGroup("Data", [
+    {
+      type: "number",
+      key: "dataSeries",
+      label: "Series",
+      min: 1,
+      max: maxSeries,
+      step: 1,
+    },
+    {
+      type: "number",
+      key: "dataPoints",
+      label: "Points",
+      min: 3,
+      max: 365,
+      step: 1,
+    },
+  ]);

--- a/apps/web/lib/studio/studio-parsers.ts
+++ b/apps/web/lib/studio/studio-parsers.ts
@@ -76,11 +76,9 @@ export const studioSearchParams = {
   barWidth: parseAsInteger.withDefault(0),
   groupGap: parseAsInteger.withDefault(4),
   barFadedOpacity: parseAsFloat.withDefault(0.3),
-  barSeriesMode: parseAsStringLiteral([
-    "single",
-    "grouped",
-    "stacked",
-  ]).withDefault("single"),
+  barSeriesMode: parseAsStringLiteral(["grouped", "stacked"]).withDefault(
+    "grouped"
+  ),
   barLineCap: parseAsStringLiteral(["round", "butt"]).withDefault("round"),
   barOrientation: parseAsStringLiteral(["vertical", "horizontal"]).withDefault(
     "vertical"
@@ -138,6 +136,8 @@ export const studioSearchParams = {
   seriesDashTail: parseAsBoolean.withDefault(false),
   seriesDashFromIndex: parseAsInteger.withDefault(4),
   seriesDashArray: parseAsString.withDefault("6,4"),
+  dataSeries: parseAsInteger.withDefault(1),
+  dataPoints: parseAsInteger.withDefault(12),
 };
 
 export interface StudioUrlState {
@@ -190,7 +190,7 @@ export interface StudioUrlState {
   barWidth: number;
   groupGap: number;
   barFadedOpacity: number;
-  barSeriesMode: "single" | "grouped" | "stacked";
+  barSeriesMode: "grouped" | "stacked";
   barLineCap: "round" | "butt";
   barOrientation: "vertical" | "horizontal";
   ringGap: number;
@@ -241,6 +241,8 @@ export interface StudioUrlState {
   seriesDashTail: boolean;
   seriesDashFromIndex: number;
   seriesDashArray: string;
+  dataSeries: number;
+  dataPoints: number;
 }
 
 export function defaultsForChart(): Partial<
@@ -305,7 +307,7 @@ export function defaultStudioState(
     barWidth: 0,
     groupGap: 4,
     barFadedOpacity: 0.3,
-    barSeriesMode: "single",
+    barSeriesMode: "grouped",
     barLineCap: "round",
     barOrientation: "vertical",
     ringGap: 6,
@@ -356,6 +358,8 @@ export function defaultStudioState(
     seriesDashTail: false,
     seriesDashFromIndex: 4,
     seriesDashArray: "6,4",
+    dataSeries: 1,
+    dataPoints: 12,
     ...overrides,
   };
 }


### PR DESCRIPTION
## Summary
Adds a configurable data generator + matching codegen for the chart studio so users can sweep series count (1–10) and point count (2–365) without leaving the studio.

- `generateStudioCartesianData({ seriesCount, pointCount, xAxis })` — deterministic per-key values from four layered sine/cosine waves at geometrically-spaced periods (~30, ~10.7, ~3.8, ~1.9) so the signal stays lively at every zoom without exact repetition.
- `studioCartesianDataSnippet(...)` emits the same formula inline so generated code matches the studio preview.
- Series keys cycle `desktop`, `mobile`, `tablet`, `watch`, `tv`, `console`, `vr`, `kiosk`, `ereader`, `wearable`; colors cycle `--chart-1` .. `--chart-5`.
- `dataSeries` / `dataPoints` URL state + sidebar controls + parsers + registry control groups updated to drive the new shape.

## Files
- `apps/web/lib/studio/demo-data.ts` — generator + clampers + series constants
- `apps/web/lib/studio/codegen-helpers.ts` — `studioCartesianDataSnippet` + threading of `seriesCount` through cartesian codegen
- `apps/web/lib/studio/registry.tsx`, `registry-control-groups.ts`, `sidebar-control-templates.ts`, `studio-parsers.ts` — wire up the new controls
- `apps/web/lib/studio/__tests__/codegen.test.ts` — updated snapshots

## Test plan
- [ ] `pnpm --filter @bklitui/web test -- studio`
- [ ] Open the studio, change "Series" 1→10 and "Points" 12→365 — preview + emitted code stay in sync
- [ ] Toggle x-axis between `date` and `month` — generator emits the matching shape

🤖 Generated with [Claude Code](https://claude.com/claude-code)