### PR TITLE
Add Skills page and agent skills for Bklit charts

### DIFF
--- a/.agents/skills/bklit-playground/SKILL.md
+++ b/.agents/skills/bklit-playground/SKILL.md
@@ -1,0 +1,76 @@
+---
+name: bklit-playground
+description: >
+  bklit-ui monorepo contributors only. Scaffold or edit the gitignored playground
+  at apps/web/app/playground/ for chart debugging, animation testing, and
+  responsive QA.
+disable-model-invocation: true
+---
+
+# Bklit Playground Skill
+
+**Monorepo contributors only.** Use this skill when working inside a cloned `bklit/bklit-ui` repo to prototype charts on a local, gitignored route before shipping via **bklit-ship**.
+
+## When to use
+
+- Creating or editing `apps/web/app/playground/page.tsx` (never committed — see `.gitignore`).
+- Debugging chart animations, responsiveness, or performance during development.
+- Building a focused test page before moving code into `packages/ui`.
+
+## Workflow
+
+### 1. Create the playground route
+
+Copy the template to the gitignored path:
+
+```
+.agents/skills/bklit-playground/templates/page.tsx
+  → apps/web/app/playground/page.tsx
+```
+
+Visit `http://localhost:3000/playground` while the dev server is running.
+
+### 2. Use committed dev tools
+
+Import from `@/components/playground/*` — do not rebuild these from scratch:
+
+| Export | Purpose |
+|--------|---------|
+| `PlaygroundShell` | Page layout, title, toolbar slot, overlay slot |
+| `PlaygroundToolbar` | Viewport presets, dimensions, replay button |
+| `ResizablePreview` | Drag-resize chart frame |
+| `FpsCounter` | rAF FPS overlay |
+| `useReplayKey` | `[key, replay]` hook to remount charts |
+
+### 3. Wire the dev toolbar
+
+- **Replay animation** — call `replay()` from `useReplayKey()` and pass `key={replayKey}` to the chart wrapper (or change `revealSignature`).
+- **Responsive testing** — `PlaygroundToolbar` presets: Mobile (375px), Tablet (768px), Desktop (full width). Users can also drag-resize via `ResizablePreview` handles.
+- **FPS counter** — pass `<FpsCounter />` to `PlaygroundShell` `overlay` prop.
+
+### 4. Replace the demo chart
+
+Swap the template `LineChart` with your work-in-progress component. Keep imports from `@bklitui/ui/charts` once the chart lives in the package, or colocate prototype components under `apps/web/app/playground/` until ready to ship.
+
+For live/streaming charts, add pause/play controls and multiple card examples (see Live Line PR notes in `.github/PULL_REQUEST_TEMPLATE_LIVELINE.md`).
+
+### 5. Ship when ready
+
+When the API and variants are stable, follow `.agents/skills/bklit-ship/SKILL.md` to move the chart into `packages/ui`, add docs, gallery examples, and registry entries.
+
+## File reference
+
+| Item | Path |
+|------|------|
+| Playground route (gitignored) | `apps/web/app/playground/page.tsx` |
+| Dev tool components | `apps/web/components/playground/` |
+| Template | `.agents/skills/bklit-playground/templates/page.tsx` |
+| Ship checklist | `.agents/skills/bklit-ship/SKILL.md` |
+| Gitignore entry | `.gitignore` → `apps/web/app/playground/` |
+
+## Checklist
+
+- [ ] `apps/web/app/playground/page.tsx` created from template
+- [ ] Replay, viewport presets, and FPS counter wired
+- [ ] Chart prototype renders without console errors
+- [ ] When done prototyping → run **bklit-ship** skill

--- a/.agents/skills/bklit-playground/templates/page.tsx
+++ b/.agents/skills/bklit-playground/templates/page.tsx
@@ -1,0 +1,73 @@
+"use client";
+
+import { ChartTooltip, Grid, Line, LineChart, XAxis } from "@bklitui/ui/charts";
+import { useState } from "react";
+import { FpsCounter } from "@/components/playground/fps-counter";
+import { PlaygroundShell } from "@/components/playground/playground-shell";
+import { PlaygroundToolbar } from "@/components/playground/playground-toolbar";
+import {
+  ResizablePreview,
+  VIEWPORT_PRESETS,
+  type ViewportPreset,
+} from "@/components/playground/resizable-preview";
+import { useReplayKey } from "@/components/playground/use-replay-key";
+
+const demoData = [
+  { date: new Date("2025-01-01"), users: 1200, pageviews: 3400 },
+  { date: new Date("2025-01-02"), users: 1350, pageviews: 3600 },
+  { date: new Date("2025-01-03"), users: 1280, pageviews: 3550 },
+  { date: new Date("2025-01-04"), users: 1420, pageviews: 3900 },
+  { date: new Date("2025-01-05"), users: 1510, pageviews: 4100 },
+  { date: new Date("2025-01-06"), users: 1480, pageviews: 4050 },
+  { date: new Date("2025-01-07"), users: 1620, pageviews: 4300 },
+];
+
+export default function PlaygroundPage() {
+  const [replayKey, replay] = useReplayKey();
+  const [viewport, setViewport] = useState<ViewportPreset>("desktop");
+  const preset = VIEWPORT_PRESETS[viewport];
+  const frameWidth = preset.width ?? 960;
+  const [size, setSize] = useState({ width: frameWidth, height: preset.height });
+
+  const handleViewportChange = (next: ViewportPreset) => {
+    setViewport(next);
+    const nextPreset = VIEWPORT_PRESETS[next];
+    setSize({
+      width: nextPreset.width ?? 960,
+      height: nextPreset.height,
+    });
+  };
+
+  return (
+    <PlaygroundShell
+      description="Local chart playground — gitignored route for prototyping. Replace the chart below with your work-in-progress component."
+      overlay={<FpsCounter />}
+      title="Playground"
+      toolbar={
+        <PlaygroundToolbar
+          height={size.height}
+          onReplay={replay}
+          onViewportChange={handleViewportChange}
+          viewport={viewport}
+          width={size.width}
+        />
+      }
+    >
+      <ResizablePreview
+        defaultHeight={size.height}
+        defaultWidth={size.width}
+        onSizeChange={setSize}
+      >
+        <div className="h-full w-full" key={replayKey}>
+          <LineChart data={demoData}>
+            <Grid horizontal />
+            <Line dataKey="users" stroke="var(--chart-line-primary)" />
+            <Line dataKey="pageviews" stroke="var(--chart-line-secondary)" />
+            <XAxis />
+            <ChartTooltip />
+          </LineChart>
+        </div>
+      </ResizablePreview>
+    </PlaygroundShell>
+  );
+}

--- a/.agents/skills/bklit-ship/SKILL.md
+++ b/.agents/skills/bklit-ship/SKILL.md
@@ -1,16 +1,16 @@
 ---
-name: bklit-ui
-description: This skill is for transitioning a chart or component from prototype to production.
+name: bklit-ship
+description: bklit-ui monorepo contributors only — ship a chart or component from playground prototype to production in packages/ui with docs and registry.
 disable-model-invocation: true
 ---
 
-# Bklit UI Skill
+# Bklit Ship Skill
 
-This skill is for taking an experimental chart or component from **prototype** (usually on an untracked route like the playground) into **production**: published in the UI package, documented, and ready for users.
+This skill is for **bklit-ui monorepo contributors** taking an experimental chart or component from **prototype** (usually on an untracked route like the playground) into **production**: published in the UI package, documented, and ready for users.
 
 ## When to use this skill
 
-- You have a working prototype on a temporary route (e.g. `apps/web/app/playground/page.tsx`) and want to ship it.
+- You cloned `bklit/bklit-ui` and have a working prototype on a temporary route (e.g. `apps/web/app/playground/page.tsx`) and want to ship it.
 - You are ready to move from "scaffolding" to "permanent": the API and key props/variants are decided from the prototyping phase.
 
 ---

--- a/.github/PULL_REQUEST_TEMPLATE_CANDLESTICK.md
+++ b/.github/PULL_REQUEST_TEMPLATE_CANDLESTICK.md
@@ -33,7 +33,7 @@ This PR ships the **Candlestick Chart** from prototype to production: OHLC chart
 ### Registry and skill
 
 - **Shadcn registry**: `candlestick-chart` entry in `packages/ui/registry.json`; `pnpm registry:build` outputs to `apps/web/public/r/`.
-- **Bklit UI skill** (`.agents/skills/bklit-ui/SKILL.md`): Step-by-step plan for moving a chart/component from playground to production (UI package, docs, chart slugs/examples, sidebar, mobile nav, registry, lint/format, commit, PR checklist).
+- **Bklit ship skill** (`.agents/skills/bklit-ship/SKILL.md`): Step-by-step plan for moving a chart/component from playground to production (UI package, docs, chart slugs/examples, sidebar, mobile nav, registry, lint/format, commit, PR checklist). Use **bklit-playground** (`.agents/skills/bklit-playground/SKILL.md`) for local prototyping.
 
 ---
 

--- a/apps/web/components/docs/nav-link-label.tsx
+++ b/apps/web/components/docs/nav-link-label.tsx
@@ -1,0 +1,14 @@
+import { isNewNavLink } from "@/lib/is-new-nav-link";
+
+export function NavLinkLabel({ text, url }: { text: string; url: string }) {
+  if (!isNewNavLink(url)) {
+    return text;
+  }
+
+  return (
+    <span className="flex items-center gap-1.5">
+      {text}
+      <span aria-hidden className="size-1.5 shrink-0 rounded-full bg-chart-1" />
+    </span>
+  );
+}

--- a/apps/web/components/docs/sidebar.tsx
+++ b/apps/web/components/docs/sidebar.tsx
@@ -5,6 +5,7 @@ import type * as PageTree from "fumadocs-core/page-tree";
 import { usePathname } from "next/navigation";
 import { useState } from "react";
 import { DocsScrollArea } from "@/components/docs/docs-scroll-area";
+import { NavLinkLabel } from "@/components/docs/nav-link-label";
 import { cn } from "@/lib/utils";
 
 const linkStyles = {
@@ -49,7 +50,7 @@ export function Sidebar({ tree, links = [] }: SidebarProps) {
                       )}
                       href={link.url}
                     >
-                      {link.text}
+                      <NavLinkLabel text={link.text} url={link.url} />
                     </Link>
                   </li>
                 );

--- a/apps/web/components/docs/site-header.tsx
+++ b/apps/web/components/docs/site-header.tsx
@@ -11,27 +11,12 @@ import { GitHubIcon } from "../icons/github";
 import { Button } from "../ui/button";
 import { Separator } from "../ui/separator";
 import { DocsSearchTrigger } from "./docs-search-trigger";
+import { NavLinkLabel } from "./nav-link-label";
 
 interface NavLink {
   text: string;
   url: string;
   active?: "url" | "nested-url";
-}
-
-function isStudioLink(url: string) {
-  return url === "/studio";
-}
-
-function NavLinkLabel({ text, url }: { text: string; url: string }) {
-  if (!isStudioLink(url)) {
-    return text;
-  }
-  return (
-    <span className="flex items-center gap-1.5">
-      {text}
-      <span aria-hidden className="size-1.5 shrink-0 rounded-full bg-chart-1" />
-    </span>
-  );
 }
 
 interface SiteHeaderProps {

--- a/apps/web/components/playground/fps-counter.tsx
+++ b/apps/web/components/playground/fps-counter.tsx
@@ -1,0 +1,61 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import { cn } from "@/lib/utils";
+
+function fpsTone(fps: number) {
+  if (fps >= 55) {
+    return "text-emerald-500";
+  }
+  if (fps >= 30) {
+    return "text-amber-500";
+  }
+  return "text-red-500";
+}
+
+export function FpsCounter({ className }: { className?: string }) {
+  const [fps, setFps] = useState(60);
+  const frameTimesRef = useRef<number[]>([]);
+  const rafRef = useRef<number | null>(null);
+
+  useEffect(() => {
+    let lastTime = performance.now();
+
+    const tick = (now: number) => {
+      const delta = now - lastTime;
+      lastTime = now;
+
+      if (delta > 0) {
+        const samples = frameTimesRef.current;
+        samples.push(1000 / delta);
+        if (samples.length > 30) {
+          samples.shift();
+        }
+        const average =
+          samples.reduce((sum, value) => sum + value, 0) / samples.length;
+        setFps(Math.round(average));
+      }
+
+      rafRef.current = requestAnimationFrame(tick);
+    };
+
+    rafRef.current = requestAnimationFrame(tick);
+    return () => {
+      if (rafRef.current !== null) {
+        cancelAnimationFrame(rafRef.current);
+      }
+    };
+  }, []);
+
+  return (
+    <div
+      className={cn(
+        "rounded-md border border-border/60 bg-background/90 px-2 py-1 font-mono text-xs tabular-nums backdrop-blur-sm",
+        className
+      )}
+    >
+      <span className="text-muted-foreground">FPS </span>
+      <span className={fpsTone(fps)}>{fps}</span>
+    </div>
+  );
+}

--- a/apps/web/components/playground/playground-shell.tsx
+++ b/apps/web/components/playground/playground-shell.tsx
@@ -1,0 +1,51 @@
+"use client";
+
+import type { ReactNode } from "react";
+import { cn } from "@/lib/utils";
+
+export function PlaygroundShell({
+  title,
+  description,
+  toolbar,
+  children,
+  overlay,
+  className,
+}: {
+  title?: string;
+  description?: string;
+  toolbar?: ReactNode;
+  children: ReactNode;
+  overlay?: ReactNode;
+  className?: string;
+}) {
+  return (
+    <div
+      className={cn(
+        "mx-auto flex w-full max-w-6xl flex-col gap-4 p-6",
+        className
+      )}
+    >
+      {(title || description) && (
+        <header className="space-y-1">
+          {title ? (
+            <h1 className="font-semibold text-2xl tracking-tight">{title}</h1>
+          ) : null}
+          {description ? (
+            <p className="text-muted-foreground text-sm">{description}</p>
+          ) : null}
+        </header>
+      )}
+
+      {toolbar}
+
+      <div className="relative">
+        {children}
+        {overlay ? (
+          <div className="pointer-events-none absolute top-3 right-3 z-30">
+            {overlay}
+          </div>
+        ) : null}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/components/playground/playground-toolbar.tsx
+++ b/apps/web/components/playground/playground-toolbar.tsx
@@ -1,0 +1,58 @@
+"use client";
+
+import { RotateCcw } from "lucide-react";
+import {
+  VIEWPORT_PRESETS,
+  type ViewportPreset,
+} from "@/components/playground/resizable-preview";
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+
+export function PlaygroundToolbar({
+  className,
+  width,
+  height,
+  viewport,
+  onViewportChange,
+  onReplay,
+}: {
+  className?: string;
+  width: number;
+  height: number;
+  viewport: ViewportPreset;
+  onViewportChange: (preset: ViewportPreset) => void;
+  onReplay: () => void;
+}) {
+  return (
+    <div
+      className={cn(
+        "flex flex-wrap items-center gap-2 rounded-lg border border-border bg-muted/40 p-2",
+        className
+      )}
+    >
+      <div className="flex items-center gap-1">
+        {(Object.keys(VIEWPORT_PRESETS) as ViewportPreset[]).map((preset) => (
+          <Button
+            key={preset}
+            onClick={() => onViewportChange(preset)}
+            size="sm"
+            type="button"
+            variant={viewport === preset ? "default" : "outline"}
+          >
+            {VIEWPORT_PRESETS[preset].label}
+          </Button>
+        ))}
+      </div>
+
+      <div className="ml-auto flex items-center gap-2">
+        <span className="font-mono text-muted-foreground text-xs tabular-nums">
+          {width} × {height}
+        </span>
+        <Button onClick={onReplay} size="sm" type="button" variant="outline">
+          <RotateCcw className="size-3.5" data-icon="inline-start" />
+          Replay
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/components/playground/resizable-preview.tsx
+++ b/apps/web/components/playground/resizable-preview.tsx
@@ -1,0 +1,217 @@
+"use client";
+
+import type {
+  CSSProperties,
+  ReactNode,
+  PointerEvent as ReactPointerEvent,
+} from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
+import { cn } from "@/lib/utils";
+
+const MIN_WIDTH = 280;
+const MIN_HEIGHT = 200;
+const DEFAULT_WIDTH = 720;
+const DEFAULT_HEIGHT = 400;
+
+type ResizeEdge = "right" | "bottom" | "corner";
+
+interface FrameSize {
+  width: number;
+  height: number;
+}
+
+function clampSize(
+  width: number,
+  height: number,
+  maxWidth: number,
+  maxHeight: number
+): FrameSize {
+  return {
+    width: Math.round(Math.min(maxWidth, Math.max(MIN_WIDTH, width))),
+    height: Math.round(Math.min(maxHeight, Math.max(MIN_HEIGHT, height))),
+  };
+}
+
+function resizeCursor(edge: ResizeEdge) {
+  if (edge === "right") {
+    return "ew-resize";
+  }
+  if (edge === "bottom") {
+    return "ns-resize";
+  }
+  return "nwse-resize";
+}
+
+function resizeAriaLabel(edge: ResizeEdge) {
+  if (edge === "corner") {
+    return "Resize width and height";
+  }
+  if (edge === "right") {
+    return "Resize width";
+  }
+  return "Resize height";
+}
+
+function ResizeHandle({
+  edge,
+  onPointerDown,
+}: {
+  edge: ResizeEdge;
+  onPointerDown: (event: ReactPointerEvent<HTMLButtonElement>) => void;
+}) {
+  return (
+    <button
+      aria-label={resizeAriaLabel(edge)}
+      className={cn(
+        "absolute z-20 touch-none select-none border-0 bg-transparent p-0",
+        edge === "right" &&
+          "top-0 right-0 h-full w-3 translate-x-1/2 cursor-ew-resize",
+        edge === "bottom" &&
+          "bottom-0 left-0 h-3 w-full translate-y-1/2 cursor-ns-resize",
+        edge === "corner" &&
+          "right-0 bottom-0 size-4 translate-x-1/2 translate-y-1/2 cursor-nwse-resize"
+      )}
+      onPointerDown={onPointerDown}
+      type="button"
+    />
+  );
+}
+
+export function ResizablePreview({
+  children,
+  className,
+  defaultWidth = DEFAULT_WIDTH,
+  defaultHeight = DEFAULT_HEIGHT,
+  onSizeChange,
+}: {
+  children: ReactNode;
+  className?: string;
+  defaultWidth?: number;
+  defaultHeight?: number;
+  onSizeChange?: (size: FrameSize) => void;
+}) {
+  const wrapRef = useRef<HTMLDivElement>(null);
+  const draggingRef = useRef(false);
+  const [maxSize, setMaxSize] = useState({ width: 1200, height: 800 });
+  const [size, setSize] = useState<FrameSize>(() =>
+    clampSize(defaultWidth, defaultHeight, 1200, 800)
+  );
+
+  useEffect(() => {
+    const bounds = wrapRef.current?.parentElement;
+    if (!bounds) {
+      return;
+    }
+    const update = () => {
+      setMaxSize({
+        width: Math.max(bounds.clientWidth, MIN_WIDTH),
+        height: Math.max(bounds.clientHeight, MIN_HEIGHT),
+      });
+    };
+    update();
+    const observer = new ResizeObserver(update);
+    observer.observe(bounds);
+    return () => observer.disconnect();
+  }, []);
+
+  useEffect(() => {
+    if (draggingRef.current) {
+      return;
+    }
+    setSize(
+      clampSize(defaultWidth, defaultHeight, maxSize.width, maxSize.height)
+    );
+  }, [defaultWidth, defaultHeight, maxSize.width, maxSize.height]);
+
+  const startDrag = useCallback(
+    (edge: ResizeEdge) => (event: ReactPointerEvent<HTMLButtonElement>) => {
+      event.preventDefault();
+      const handle = event.currentTarget;
+      handle.setPointerCapture(event.pointerId);
+      draggingRef.current = true;
+
+      const startX = event.clientX;
+      const startY = event.clientY;
+      const startWidth = size.width;
+      const startHeight = size.height;
+
+      document.body.style.cursor = resizeCursor(edge);
+      document.body.style.userSelect = "none";
+
+      let latest = clampSize(
+        startWidth,
+        startHeight,
+        maxSize.width,
+        maxSize.height
+      );
+
+      const onPointerMove = (moveEvent: globalThis.PointerEvent) => {
+        let nextWidth = startWidth;
+        let nextHeight = startHeight;
+
+        if (edge === "right" || edge === "corner") {
+          nextWidth = startWidth + (moveEvent.clientX - startX);
+        }
+        if (edge === "bottom" || edge === "corner") {
+          nextHeight = startHeight + (moveEvent.clientY - startY);
+        }
+
+        latest = clampSize(
+          nextWidth,
+          nextHeight,
+          maxSize.width,
+          maxSize.height
+        );
+        setSize(latest);
+        onSizeChange?.(latest);
+      };
+
+      const onPointerUp = (upEvent: globalThis.PointerEvent) => {
+        handle.releasePointerCapture(upEvent.pointerId);
+        handle.removeEventListener("pointermove", onPointerMove);
+        handle.removeEventListener("pointerup", onPointerUp);
+        document.body.style.cursor = "";
+        document.body.style.userSelect = "";
+        draggingRef.current = false;
+        onSizeChange?.(latest);
+      };
+
+      handle.addEventListener("pointermove", onPointerMove);
+      handle.addEventListener("pointerup", onPointerUp);
+    },
+    [maxSize.height, maxSize.width, onSizeChange, size.height, size.width]
+  );
+
+  const frameStyle: CSSProperties = {
+    width: size.width,
+    height: size.height,
+  };
+
+  return (
+    <div
+      className={cn("relative flex min-h-0 w-full justify-center", className)}
+      ref={wrapRef}
+    >
+      <div
+        className="relative overflow-hidden rounded-xl border border-border bg-card shadow-sm"
+        style={frameStyle}
+      >
+        <div className="size-full min-h-0 min-w-0 p-4">{children}</div>
+        <ResizeHandle edge="right" onPointerDown={startDrag("right")} />
+        <ResizeHandle edge="bottom" onPointerDown={startDrag("bottom")} />
+        <ResizeHandle edge="corner" onPointerDown={startDrag("corner")} />
+      </div>
+    </div>
+  );
+}
+
+export type ViewportPreset = "mobile" | "tablet" | "desktop";
+
+export const VIEWPORT_PRESETS: Record<
+  ViewportPreset,
+  { label: string; width: number | null; height: number }
+> = {
+  mobile: { label: "Mobile", width: 375, height: 320 },
+  tablet: { label: "Tablet", width: 768, height: 400 },
+  desktop: { label: "Desktop", width: null, height: 400 },
+};

--- a/apps/web/components/playground/use-replay-key.ts
+++ b/apps/web/components/playground/use-replay-key.ts
@@ -1,0 +1,12 @@
+"use client";
+
+import { useCallback, useState } from "react";
+
+export function useReplayKey(initialKey = 0) {
+  const [key, setKey] = useState(initialKey);
+  const replay = useCallback(() => {
+    setKey((current) => current + 1);
+  }, []);
+
+  return [key, replay] as const;
+}

--- a/apps/web/content/docs/skills.mdx
+++ b/apps/web/content/docs/skills.mdx
@@ -1,0 +1,80 @@
+---
+title: Skills
+description: Give AI agents project-aware context for Bklit charts in your application.
+---
+
+Skills give AI assistants project-aware context about Bklit UI. When installed, your agent knows how to install, compose, theme, and animate charts using the correct APIs and patterns for your project.
+
+For example, you can ask your AI assistant to:
+
+- "Add an area chart with tooltips to my dashboard."
+- "Install and theme a gauge chart for this KPI card."
+- "Build a stats page with bar and line charts using the @bklit registry."
+- "Fix the crosshair color on my candlestick chart tooltip."
+
+The skill reads your project's `components.json` and provides the assistant with your framework, aliases, installed components, and resolved paths so it can generate correct chart code on the first try.
+
+## Install
+
+```bash
+npx skills add bklit/bklit-ui
+```
+
+This installs the **bklit-ui** skill into your project. Once installed, your AI assistant automatically loads it when working with Bklit charts and data visualization.
+
+Learn more about skills at [skills.sh](https://skills.sh/docs/).
+
+## What's Included
+
+The skill provides your AI assistant with the following knowledge:
+
+### Project Context
+
+On every interaction, the skill runs `shadcn info --json` to get your project's configuration: framework, Tailwind version, aliases, installed components, and resolved file paths — including which `@bklit` charts are already installed.
+
+### Registry Installation
+
+How to configure the `@bklit` namespace and install charts with the shadcn CLI:
+
+```bash
+npx shadcn@latest add @bklit/line-chart
+```
+
+### Composition and Theming
+
+How to compose charts (`LineChart` → `Grid` → `Line` → `XAxis` → `ChartTooltip`), use `chartCssVars` for type-safe theming, and apply series palette tokens (`--chart-1` … `--chart-5`).
+
+### Animation and Tooltips
+
+Enter animation defaults, replay patterns via `revealSignature`, custom tooltip content, `indicatorColor` for candlesticks, and the `useChart` hook for custom indicators.
+
+### Chart Catalog
+
+A decision guide for all 14 chart types with doc URLs, gallery links, and install commands — area, bar, line, live line, composed, scatter, candlestick, pie, ring, radar, gauge, funnel, sankey, and choropleth.
+
+## How It Works
+
+1. **Project detection** — The skill activates when working with `@bklit` registry components, `@bklitui/ui/charts`, or chart/data-visualization tasks.
+2. **Context injection** — It runs `shadcn info --json` to read your project configuration and injects the result into the assistant's context.
+3. **Pattern enforcement** — The assistant follows Bklit composition rules: root chart + children, semantic chart CSS variables, and correct tooltip/crosshair patterns.
+4. **Doc discovery** — The assistant references [ui.bklit.com](https://ui.bklit.com/docs/components) documentation and the [charts gallery](https://ui.bklit.com/charts/area-chart) before generating code.
+
+## Learn More
+
+- [Installation](/docs/installation) — Set up the `@bklit` registry in your project
+- [Theming](/docs/theming) — CSS variables and `chartCssVars`
+- [Components](/docs/components) — Chart API reference
+- [Charts gallery](/charts/area-chart) — Interactive examples
+- [Studio](/studio) — Tune props and copy generated code
+- [skills.sh](https://skills.sh/docs/) — Learn more about AI skills
+
+## Contributing to bklit-ui
+
+If you cloned the [bklit-ui repository](https://github.com/bklit/bklit-ui) to contribute new charts, additional contributor-only skills live in `.agents/skills/`:
+
+| Skill | Purpose |
+|-------|---------|
+| **bklit-playground** | Scaffold the gitignored `/playground` route with replay, responsive preview, and FPS tools |
+| **bklit-ship** | Move a chart from playground prototype to `packages/ui` with docs, gallery, and registry |
+
+These skills are **not** published to skills.sh — they are for monorepo development only.

--- a/apps/web/lib/is-new-nav-link.ts
+++ b/apps/web/lib/is-new-nav-link.ts
@@ -1,0 +1,3 @@
+export function isNewNavLink(url: string) {
+  return url === "/studio" || url === "/docs/skills";
+}

--- a/apps/web/lib/site-nav-links.ts
+++ b/apps/web/lib/site-nav-links.ts
@@ -5,4 +5,5 @@ export const siteNavLinks = [
   { text: "Theming", url: "/docs/theming" },
   { text: "Charts", url: "/charts" },
   { text: "Studio", url: "/studio" },
+  { text: "Skills", url: "/docs/skills" },
 ] as const;

--- a/packages/ui/registry.json
+++ b/packages/ui/registry.json
@@ -8,10 +8,7 @@
       "type": "registry:lib",
       "title": "Utilities",
       "description": "Utility functions for className merging with clsx and tailwind-merge",
-      "dependencies": [
-        "clsx",
-        "tailwind-merge"
-      ],
+      "dependencies": ["clsx", "tailwind-merge"],
       "files": [
         {
           "path": "src/lib/utils.ts",
@@ -25,9 +22,7 @@
       "type": "registry:component",
       "title": "Chart Context",
       "description": "Shared context and hooks for Bklit chart components",
-      "registryDependencies": [
-        "@bklit/utils"
-      ],
+      "registryDependencies": ["@bklit/utils"],
       "dependencies": [
         "@visx/event@4.0.1-alpha.0",
         "@visx/responsive@4.0.1-alpha.0",
@@ -94,9 +89,7 @@
       "type": "registry:component",
       "title": "Chart Animation",
       "description": "Shared motion helpers for chart enter transitions, clip reveals, and staggered animations",
-      "dependencies": [
-        "motion"
-      ],
+      "dependencies": ["motion"],
       "files": [
         {
           "path": "src/charts/animation.ts",
@@ -130,12 +123,8 @@
       "type": "registry:component",
       "title": "Chart Grid",
       "description": "Grid lines for charts",
-      "registryDependencies": [
-        "@bklit/chart-context"
-      ],
-      "dependencies": [
-        "@visx/grid@4.0.1-alpha.0"
-      ],
+      "registryDependencies": ["@bklit/chart-context"],
+      "dependencies": ["@visx/grid@4.0.1-alpha.0"],
       "files": [
         {
           "path": "src/charts/grid.tsx",
@@ -149,10 +138,7 @@
       "type": "registry:component",
       "title": "X Axis",
       "description": "X-axis component for time-series charts",
-      "registryDependencies": [
-        "@bklit/chart-context",
-        "@bklit/utils"
-      ],
+      "registryDependencies": ["@bklit/chart-context", "@bklit/utils"],
       "files": [
         {
           "path": "src/charts/x-axis.tsx",
@@ -166,10 +152,7 @@
       "type": "registry:component",
       "title": "Y Axis",
       "description": "Y-axis component for value labels in line and area charts",
-      "registryDependencies": [
-        "@bklit/chart-context",
-        "@bklit/utils"
-      ],
+      "registryDependencies": ["@bklit/chart-context", "@bklit/utils"],
       "files": [
         {
           "path": "src/charts/y-axis.tsx",
@@ -183,14 +166,8 @@
       "type": "registry:component",
       "title": "Chart Tooltip",
       "description": "Composable tooltip components for charts",
-      "registryDependencies": [
-        "@bklit/chart-context",
-        "@bklit/utils"
-      ],
-      "dependencies": [
-        "@number-flow/react",
-        "motion"
-      ],
+      "registryDependencies": ["@bklit/chart-context", "@bklit/utils"],
+      "dependencies": ["@number-flow/react", "motion"],
       "files": [
         {
           "path": "src/charts/tooltip/chart-tooltip.tsx",
@@ -234,13 +211,8 @@
       "type": "registry:component",
       "title": "Chart Legend",
       "description": "Composable legend components for charts",
-      "registryDependencies": [
-        "@bklit/utils"
-      ],
-      "dependencies": [
-        "@base-ui/react",
-        "@number-flow/react"
-      ],
+      "registryDependencies": ["@bklit/utils"],
+      "dependencies": ["@base-ui/react", "@number-flow/react"],
       "cssVars": {
         "light": {
           "--legend": "oklch(1 0 0)",
@@ -501,12 +473,7 @@
         "@bklit/chart-tooltip",
         "@bklit/utils"
       ],
-      "dependencies": [
-        "d3-array",
-        "d3-scale",
-        "motion",
-        "react-use-measure"
-      ],
+      "dependencies": ["d3-array", "d3-scale", "motion", "react-use-measure"],
       "files": [
         {
           "path": "src/charts/scatter-chart.tsx",
@@ -615,10 +582,7 @@
       "type": "registry:component",
       "title": "Pie Chart",
       "description": "A composable pie chart with animations and customizable slices",
-      "registryDependencies": [
-        "@bklit/chart-animation",
-        "@bklit/utils"
-      ],
+      "registryDependencies": ["@bklit/chart-animation", "@bklit/utils"],
       "dependencies": [
         "@number-flow/react",
         "@visx/group@4.0.1-alpha.0",
@@ -665,10 +629,7 @@
       "type": "registry:component",
       "title": "Radar Chart",
       "description": "A composable radar/spider chart with multiple data series",
-      "registryDependencies": [
-        "@bklit/chart-animation",
-        "@bklit/utils"
-      ],
+      "registryDependencies": ["@bklit/chart-animation", "@bklit/utils"],
       "dependencies": [
         "@visx/group@4.0.1-alpha.0",
         "@visx/responsive@4.0.1-alpha.0",
@@ -715,10 +676,7 @@
       "type": "registry:component",
       "title": "Ring Chart",
       "description": "A composable donut/ring chart with progress indicators",
-      "registryDependencies": [
-        "@bklit/chart-animation",
-        "@bklit/utils"
-      ],
+      "registryDependencies": ["@bklit/chart-animation", "@bklit/utils"],
       "dependencies": [
         "@visx/group@4.0.1-alpha.0",
         "@visx/responsive@4.0.1-alpha.0",
@@ -759,9 +717,7 @@
       "type": "registry:component",
       "title": "Gauge",
       "description": "Notch-based radial gauge with PieCenter-style center, patterns, and optional arc gradients",
-      "registryDependencies": [
-        "@bklit/utils"
-      ],
+      "registryDependencies": ["@bklit/utils"],
       "dependencies": [
         "@visx/responsive@4.0.1-alpha.0",
         "@visx/pattern@4.0.1-alpha.0",
@@ -802,10 +758,7 @@
       "type": "registry:component",
       "title": "Choropleth Map",
       "description": "A geographic map chart with zoom, pan, and data visualization",
-      "registryDependencies": [
-        "@bklit/chart-animation",
-        "@bklit/utils"
-      ],
+      "registryDependencies": ["@bklit/chart-animation", "@bklit/utils"],
       "dependencies": [
         "@types/geojson",
         "@visx/geo@4.0.1-alpha.0",
@@ -853,13 +806,8 @@
       "type": "registry:component",
       "title": "Funnel Chart",
       "description": "An animated funnel chart with multi-layer halo rings, hover interactions, and staggered entrance animations",
-      "registryDependencies": [
-        "@bklit/chart-animation",
-        "@bklit/utils"
-      ],
-      "dependencies": [
-        "motion"
-      ],
+      "registryDependencies": ["@bklit/chart-animation", "@bklit/utils"],
+      "dependencies": ["motion"],
       "files": [
         {
           "path": "src/charts/funnel-chart.tsx",
@@ -873,10 +821,7 @@
       "type": "registry:component",
       "title": "Sankey Diagram",
       "description": "A flow diagram for visualizing data transfers between nodes",
-      "registryDependencies": [
-        "@bklit/chart-animation",
-        "@bklit/utils"
-      ],
+      "registryDependencies": ["@bklit/chart-animation", "@bklit/utils"],
       "dependencies": [
         "@visx/event@4.0.1-alpha.0",
         "@visx/gradient@4.0.1-alpha.0",
@@ -1017,12 +962,7 @@
         "@bklit/x-axis",
         "@bklit/chart-tooltip"
       ],
-      "dependencies": [
-        "d3-scale",
-        "d3-array",
-        "motion",
-        "react-use-measure"
-      ],
+      "dependencies": ["d3-scale", "d3-array", "motion", "react-use-measure"],
       "files": [
         {
           "path": "registry/examples/scatter-chart.tsx",
@@ -1041,13 +981,8 @@
       "type": "registry:example",
       "title": "Pie Chart Example",
       "description": "Composable pie-chart demo for Open in v0",
-      "registryDependencies": [
-        "@bklit/pie-chart"
-      ],
-      "dependencies": [
-        "@visx/shape@4.0.1-alpha.0",
-        "motion"
-      ],
+      "registryDependencies": ["@bklit/pie-chart"],
+      "dependencies": ["@visx/shape@4.0.1-alpha.0", "motion"],
       "files": [
         {
           "path": "registry/examples/pie-chart.tsx",
@@ -1066,13 +1001,8 @@
       "type": "registry:example",
       "title": "Gauge Chart Example",
       "description": "Composable gauge-chart demo for Open in v0",
-      "registryDependencies": [
-        "@bklit/gauge-chart"
-      ],
-      "dependencies": [
-        "@visx/shape@4.0.1-alpha.0",
-        "motion"
-      ],
+      "registryDependencies": ["@bklit/gauge-chart"],
+      "dependencies": ["@visx/shape@4.0.1-alpha.0", "motion"],
       "files": [
         {
           "path": "registry/examples/gauge-chart.tsx",
@@ -1091,13 +1021,8 @@
       "type": "registry:example",
       "title": "Ring Chart Example",
       "description": "Composable ring-chart demo for Open in v0",
-      "registryDependencies": [
-        "@bklit/ring-chart"
-      ],
-      "dependencies": [
-        "@visx/shape@4.0.1-alpha.0",
-        "motion"
-      ],
+      "registryDependencies": ["@bklit/ring-chart"],
+      "dependencies": ["@visx/shape@4.0.1-alpha.0", "motion"],
       "files": [
         {
           "path": "registry/examples/ring-chart.tsx",
@@ -1116,13 +1041,8 @@
       "type": "registry:example",
       "title": "Radar Chart Example",
       "description": "Composable radar-chart demo for Open in v0",
-      "registryDependencies": [
-        "@bklit/radar-chart"
-      ],
-      "dependencies": [
-        "@visx/shape@4.0.1-alpha.0",
-        "motion"
-      ],
+      "registryDependencies": ["@bklit/radar-chart"],
+      "dependencies": ["@visx/shape@4.0.1-alpha.0", "motion"],
       "files": [
         {
           "path": "registry/examples/radar-chart.tsx",
@@ -1170,13 +1090,8 @@
       "type": "registry:example",
       "title": "Funnel Chart Example",
       "description": "Composable funnel-chart demo for Open in v0",
-      "registryDependencies": [
-        "@bklit/funnel-chart"
-      ],
-      "dependencies": [
-        "@visx/shape@4.0.1-alpha.0",
-        "motion"
-      ],
+      "registryDependencies": ["@bklit/funnel-chart"],
+      "dependencies": ["@visx/shape@4.0.1-alpha.0", "motion"],
       "files": [
         {
           "path": "registry/examples/funnel-chart.tsx",
@@ -1195,9 +1110,7 @@
       "type": "registry:example",
       "title": "Sankey Chart Example",
       "description": "Composable sankey-chart demo for Open in v0",
-      "registryDependencies": [
-        "@bklit/sankey-chart"
-      ],
+      "registryDependencies": ["@bklit/sankey-chart"],
       "dependencies": [
         "@visx/sankey@4.0.1-alpha.0",
         "@visx/shape@4.0.1-alpha.0",
@@ -1228,10 +1141,7 @@
         "@bklit/y-axis",
         "@bklit/chart-tooltip"
       ],
-      "dependencies": [
-        "@visx/shape@4.0.1-alpha.0",
-        "motion"
-      ],
+      "dependencies": ["@visx/shape@4.0.1-alpha.0", "motion"],
       "files": [
         {
           "path": "registry/examples/candlestick-chart.tsx",
@@ -1250,14 +1160,8 @@
       "type": "registry:example",
       "title": "Choropleth Chart Example",
       "description": "Composable choropleth-chart demo for Open in v0",
-      "registryDependencies": [
-        "@bklit/choropleth-chart"
-      ],
-      "dependencies": [
-        "@visx/geo@4.0.1-alpha.0",
-        "d3-geo",
-        "topojson-client"
-      ],
+      "registryDependencies": ["@bklit/choropleth-chart"],
+      "dependencies": ["@visx/geo@4.0.1-alpha.0", "d3-geo", "topojson-client"],
       "files": [
         {
           "path": "registry/examples/choropleth-chart.tsx",
@@ -1303,13 +1207,8 @@
       "type": "registry:component",
       "title": "Chart Stat Flow",
       "description": "Animated stat value and label for chart overlays",
-      "registryDependencies": [
-        "@bklit/utils"
-      ],
-      "dependencies": [
-        "@number-flow/react",
-        "motion"
-      ],
+      "registryDependencies": ["@bklit/utils"],
+      "dependencies": ["@number-flow/react", "motion"],
       "files": [
         {
           "path": "src/charts/chart-stat-flow.tsx",
@@ -1373,9 +1272,7 @@
       "type": "registry:example",
       "title": "Stat Card Area Example",
       "description": "Revenue stat card with gradient area sparkline, NumberFlow, and trend badge — demo for Open in v0",
-      "registryDependencies": [
-        "@bklit/stat-card-area-01"
-      ],
+      "registryDependencies": ["@bklit/stat-card-area-01"],
       "dependencies": [
         "@visx/curve@4.0.1-alpha.0",
         "@visx/gradient@4.0.1-alpha.0",
@@ -1449,9 +1346,7 @@
       "type": "registry:example",
       "title": "Stat Card Line Example",
       "description": "Sessions stat card with line sparkline, overlaid NumberFlow, and trend badge — demo for Open in v0",
-      "registryDependencies": [
-        "@bklit/stat-card-line-01"
-      ],
+      "registryDependencies": ["@bklit/stat-card-line-01"],
       "dependencies": [
         "@visx/curve@4.0.1-alpha.0",
         "@number-flow/react",
@@ -1531,9 +1426,7 @@
       "type": "registry:example",
       "title": "Stat Card Choropleth Example",
       "description": "Visitor map stat card with choropleth sparkline, NumberFlow, and trend badge — demo for Open in v0",
-      "registryDependencies": [
-        "@bklit/stat-card-choropleth-01"
-      ],
+      "registryDependencies": ["@bklit/stat-card-choropleth-01"],
       "dependencies": [
         "@number-flow/react",
         "@types/geojson",

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -1,6 +1,11 @@
 {
   "version": 1,
   "skills": {
+    "bklit-ui": {
+      "source": "/Users/matt/Bklit/bklit-ui/skills/bklit-ui",
+      "sourceType": "local",
+      "computedHash": "ace89f8b9a6d5d8f0367307f886cb9654065356db537df7b57b3d849aa503534"
+    },
     "shadcn": {
       "source": "shadcn/ui",
       "sourceType": "github",

--- a/skills/bklit-ui/SKILL.md
+++ b/skills/bklit-ui/SKILL.md
@@ -1,0 +1,136 @@
+---
+name: bklit-ui
+description: >
+  Bklit UI charts and data visualization for any project using the @bklit
+  shadcn registry. Install, compose, theme, and animate charts correctly.
+  Triggers when working with @bklitui/ui/charts, @bklit components, data
+  visualization, dashboards, or chart theming. Also invoke manually for
+  chart tasks.
+allowed-tools: Bash(npx shadcn@latest *), Bash(pnpm dlx shadcn@latest *), Bash(bunx --bun shadcn@latest *)
+---
+
+# Bklit UI
+
+Composable chart components for React, distributed via the `@bklit` shadcn registry. Charts are installed as source into the user's project.
+
+> **IMPORTANT:** Run shadcn CLI commands with the project's package runner: `npx shadcn@latest`, `pnpm dlx shadcn@latest`, or `bunx --bun shadcn@latest`.
+
+## Current Project Context
+
+```json
+!`npx shadcn@latest info --json`
+```
+
+Use the JSON above for framework, aliases, Tailwind version, installed components, and resolved paths. Confirm the `@bklit` registry is configured before adding charts.
+
+## Principles
+
+1. **Install before inventing.** Use `npx shadcn@latest add @bklit/<chart>` — charts are registry components, not hand-rolled SVG.
+2. **Compose, don't flatten.** Root chart → `Grid` → series → axes → `ChartTooltip`. See [composition.md](./rules/composition.md).
+3. **Theme with tokens.** Use `chartCssVars` and `--chart-*` variables — never hardcode one-off colors. See [theming.md](./rules/theming.md).
+4. **Read the doc page first.** Each chart has props, data shape, and examples at `https://ui.bklit.com/docs/components/<slug>`.
+5. **Browse variants.** Gallery: `https://ui.bklit.com/charts/<slug>` — Studio: `https://ui.bklit.com/studio?chart=<slug>`.
+
+## Critical Rules
+
+These rules are **always enforced**. Each links to Incorrect/Correct examples.
+
+### Composition → [composition.md](./rules/composition.md)
+
+- **Series and axes live inside the root chart** — `LineChart`, `BarChart`, `AreaChart`, etc.
+- **One root per chart** — use `ComposedChart` for mixed series types.
+- **Grid before series** so lines/bars render above grid lines.
+- **`ChartTooltip` as a chart child** — required for crosshair and hover context.
+
+### Theming → [theming.md](./rules/theming.md)
+
+- **Use `chartCssVars`** from `@bklitui/ui/charts` instead of raw `"var(--chart-…)"` strings.
+- **Series palette:** `--chart-1` … `--chart-5` for multi-series charts.
+- **Tooltip surfaces:** `bg-popover text-popover-foreground` — avoids white-on-white in light mode.
+
+### Animation → [animation.md](./rules/animation.md)
+
+- **Default duration ~1100ms** for cartesian enter animations unless the doc specifies otherwise.
+- **Replay:** change `revealSignature` or remount with a new `key`.
+- **Live charts:** use `paused` on `LiveLineChart` to debug without stopping the rAF loop manually.
+
+### Tooltips → [tooltips.md](./rules/tooltips.md)
+
+- **Custom content via `ChartTooltip` `content` prop** or children patterns from docs.
+- **`indicatorColor` function** for candlestick / dynamic crosshair colors.
+- **Custom indicators:** use `useChart()` — do not track mouse globally outside chart context.
+
+### Installation → [installation.md](./rules/installation.md)
+
+- **Require `@bklit` registry** in `components.json`.
+- **Install:** `npx shadcn@latest add @bklit/<slug>`.
+- **Let the CLI install peer dependencies** — do not pin `@visx/*` / `motion` manually unless resolving a conflict.
+
+## Chart Catalog
+
+| Slug | Use when | Install | Docs | Gallery |
+|------|----------|---------|------|---------|
+| `area-chart` | Trends with filled regions under lines | `@bklit/area-chart` | [/docs/components/area-chart](https://ui.bklit.com/docs/components/area-chart) | [/charts/area-chart](https://ui.bklit.com/charts/area-chart) |
+| `bar-chart` | Category comparisons, stacked or grouped bars | `@bklit/bar-chart` | [/docs/components/bar-chart](https://ui.bklit.com/docs/components/bar-chart) | [/charts/bar-chart](https://ui.bklit.com/charts/bar-chart) |
+| `line-chart` | Time series, multi-line trends, markers | `@bklit/line-chart` | [/docs/components/line-chart](https://ui.bklit.com/docs/components/line-chart) | [/charts/line-chart](https://ui.bklit.com/charts/line-chart) |
+| `live-line-chart` | Streaming / real-time data | `@bklit/live-line-chart` | [/docs/components/live-line-chart](https://ui.bklit.com/docs/components/live-line-chart) | [/charts/live-line-chart](https://ui.bklit.com/charts/live-line-chart) |
+| `composed-chart` | Mixed bar + line (or similar) on one axis | `@bklit/composed-chart` | [/docs/components/composed-chart](https://ui.bklit.com/docs/components/composed-chart) | [/charts/composed-chart](https://ui.bklit.com/charts/composed-chart) |
+| `scatter-chart` | Correlation, distribution, bubble sizing | `@bklit/scatter-chart` | [/docs/components/scatter-chart](https://ui.bklit.com/docs/components/scatter-chart) | [/charts/scatter-chart](https://ui.bklit.com/charts/scatter-chart) |
+| `candlestick-chart` | OHLC financial data, brushes | `@bklit/candlestick-chart` | [/docs/components/candlestick-chart](https://ui.bklit.com/docs/components/candlestick-chart) | [/charts/candlestick-chart](https://ui.bklit.com/charts/candlestick-chart) |
+| `pie-chart` | Part-to-whole slices | `@bklit/pie-chart` | [/docs/components/pie-chart](https://ui.bklit.com/docs/components/pie-chart) | [/charts/pie-chart](https://ui.bklit.com/charts/pie-chart) |
+| `ring-chart` | Donut / ring KPIs | `@bklit/ring-chart` | [/docs/components/ring-chart](https://ui.bklit.com/docs/components/ring-chart) | [/charts/ring-chart](https://ui.bklit.com/charts/ring-chart) |
+| `radar-chart` | Multi-axis comparison | `@bklit/radar-chart` | [/docs/components/radar-chart](https://ui.bklit.com/docs/components/radar-chart) | [/charts/radar-chart](https://ui.bklit.com/charts/radar-chart) |
+| `gauge-chart` | Single-value KPI dial | `@bklit/gauge-chart` | [/docs/components/gauge-chart](https://ui.bklit.com/docs/components/gauge-chart) | [/charts/gauge-chart](https://ui.bklit.com/charts/gauge-chart) |
+| `funnel-chart` | Stage conversion funnels | `@bklit/funnel-chart` | [/docs/components/funnel-chart](https://ui.bklit.com/docs/components/funnel-chart) | [/charts/funnel-chart](https://ui.bklit.com/charts/funnel-chart) |
+| `sankey-chart` | Flow between nodes | `@bklit/sankey-chart` | [/docs/components/sankey-chart](https://ui.bklit.com/docs/components/sankey-chart) | [/charts/sankey-chart](https://ui.bklit.com/charts/sankey-chart) |
+| `choropleth-chart` | Geo regions colored by value | `@bklit/choropleth-chart` | [/docs/components/choropleth-chart](https://ui.bklit.com/docs/components/choropleth-chart) | [/charts/choropleth-chart](https://ui.bklit.com/charts/choropleth-chart) |
+
+## Workflow
+
+1. Run `npx shadcn@latest info --json` — verify `@bklit` registry and aliases.
+2. Pick a chart from the catalog (or ask the user what story the data tells).
+3. Open the doc URL for data shape and props.
+4. If not installed: `npx shadcn@latest add @bklit/<slug>`.
+5. Compose with grid, series, axes, tooltip — apply theming tokens.
+6. Point the user to the gallery or Studio URL for variant inspiration.
+
+## Quick Reference
+
+```bash
+# Project info
+npx shadcn@latest info --json
+
+# Add a chart
+npx shadcn@latest add @bklit/line-chart
+
+# Search registries (if configured)
+npx shadcn@latest search @bklit
+```
+
+```tsx
+import { LineChart, Line, Grid, XAxis, ChartTooltip, chartCssVars } from "@bklitui/ui/charts";
+
+<LineChart data={data} xDataKey="date">
+  <Grid horizontal />
+  <Line dataKey="users" stroke={chartCssVars.linePrimary} />
+  <XAxis />
+  <ChartTooltip />
+</LineChart>
+```
+
+## Utility docs
+
+- Theming: https://ui.bklit.com/docs/theming
+- Grid: https://ui.bklit.com/docs/utility/grid
+- Legend: https://ui.bklit.com/docs/utility/legend
+- Tooltip: https://ui.bklit.com/docs/utility/tooltip
+- Custom indicator: https://ui.bklit.com/docs/utility/custom-indicator
+- useChart: https://ui.bklit.com/docs/utility/use-chart
+
+## Detailed References
+
+- [composition.md](./rules/composition.md)
+- [theming.md](./rules/theming.md)
+- [animation.md](./rules/animation.md)
+- [tooltips.md](./rules/tooltips.md)
+- [installation.md](./rules/installation.md)

--- a/skills/bklit-ui/rules/animation.md
+++ b/skills/bklit-ui/rules/animation.md
@@ -1,0 +1,42 @@
+# Animation
+
+## Defaults
+
+Most cartesian charts default to ~1100ms enter animation. Bar charts often use staggered reveals (~1.2s total) with easing `cubic-bezier(0.85, 0, 0.15, 1)`.
+
+## Replay enter animations
+
+Pass a changing `revealSignature` (or remount the chart with a new `key`) to replay mount animations after prop changes.
+
+### Correct
+
+```tsx
+const [replayKey, setReplayKey] = useState(0);
+
+<LineChart key={replayKey} data={data} revealSignature={String(replayKey)}>
+  {/* ... */}
+</LineChart>
+
+<button type="button" onClick={() => setReplayKey((k) => k + 1)}>
+  Replay
+</button>
+```
+
+## Live charts
+
+- `LiveLineChart` runs its own animation loop — use `paused` to freeze updates for debugging.
+- Avoid nesting heavy state updates inside the rAF path; pass stable props where possible.
+
+## Reduced motion
+
+Respect `prefers-reduced-motion` when adding custom animation wrappers around charts. Bklit charts handle reduced motion internally for enter transitions.
+
+## Performance
+
+- Prefer CSS/SVG-friendly props over re-creating large data arrays every frame.
+- For streaming data, append points and trim the window instead of replacing the full array when possible.
+
+## Inspiration
+
+Browse animated variants: https://ui.bklit.com/charts/<chart-slug>  
+Tune motion interactively: https://ui.bklit.com/studio?chart=<chart-slug>

--- a/skills/bklit-ui/rules/composition.md
+++ b/skills/bklit-ui/rules/composition.md
@@ -1,0 +1,57 @@
+# Chart Composition
+
+## Root + children
+
+Charts use a composable API. Always wrap series, axes, and overlays inside the root chart component.
+
+### Incorrect
+
+```tsx
+<div className="h-80">
+  <Line dataKey="users" />
+  <XAxis />
+</div>
+```
+
+### Correct
+
+```tsx
+<LineChart data={data}>
+  <Grid horizontal />
+  <Line dataKey="users" />
+  <XAxis />
+  <ChartTooltip />
+</LineChart>
+```
+
+## Axes and grid
+
+- Put `Grid` before series so lines render on top.
+- Use `XAxis` / `YAxis` as siblings inside the root chart — not outside the chart context.
+- For live streaming charts, use `LiveXAxis` and `LiveYAxis` inside `LiveLineChart`.
+
+## Tooltips and markers
+
+- `ChartTooltip` must be a child of the root chart so it can read hover state.
+- Custom tooltip content receives chart context — prefer `useChart()` when building custom indicators.
+- `ChartMarkers` and marker content render inside `ChartTooltip` when showing event callouts.
+
+## Multi-series charts
+
+- One `Line` / `Bar` / `Area` child per `dataKey`.
+- Use `--chart-1` … `--chart-5` or explicit stroke/fill props for series differentiation.
+- For combined line + bar, use `ComposedChart` instead of nesting unrelated roots.
+
+## Data shape
+
+- Cartesian charts: array of objects; set `xDataKey` on the root (default `"date"`).
+- OHLC: use `CandlestickChart` with `{ date, open, high, low, close }`.
+- Live line: `{ time, value }` points with a separate `value` prop on the root.
+- Sankey / funnel / pie: follow each chart’s doc for node/link or slice shape.
+
+## Docs
+
+- Composition patterns: https://ui.bklit.com/docs/components/line-chart
+- `useChart` hook: https://ui.bklit.com/docs/utility/use-chart
+- Grid: https://ui.bklit.com/docs/utility/grid
+- Legend: https://ui.bklit.com/docs/utility/legend

--- a/skills/bklit-ui/rules/installation.md
+++ b/skills/bklit-ui/rules/installation.md
@@ -1,0 +1,74 @@
+# Installation
+
+## Prerequisites
+
+Bklit UI is a shadcn registry. Initialize shadcn in the project first:
+
+```bash
+npx shadcn@latest init
+```
+
+## Registry namespace
+
+Add the `@bklit` namespace to `components.json` if it is not already present:
+
+```json
+{
+  "registries": {
+    "@bklit": "https://ui.bklit.com/r/{name}.json"
+  }
+}
+```
+
+New projects scaffolded with Bklit often include this automatically.
+
+## Install a chart
+
+```bash
+npx shadcn@latest add @bklit/line-chart
+```
+
+Replace `line-chart` with any chart slug from the catalog. The CLI copies source into your components directory and installs peer dependencies.
+
+## Verify project context
+
+```bash
+npx shadcn@latest info --json
+```
+
+Use the JSON to confirm framework, aliases, Tailwind version, and which `@bklit` components are already installed.
+
+## Import path
+
+After install, import from the charts entry (path may vary by alias — check `info --json`):
+
+```tsx
+import { LineChart, Line, Grid, XAxis, ChartTooltip } from "@/components/ui/line-chart";
+// or from package re-exports when using the npm package directly:
+import { LineChart, Line, Grid, XAxis, ChartTooltip } from "@bklitui/ui/charts";
+```
+
+Prefer the import path your project’s shadcn install actually generated.
+
+## Common peer dependencies
+
+| Chart | Typical dependencies |
+|-------|---------------------|
+| line-chart, area-chart | `@visx/curve`, `@visx/shape`, `motion` |
+| bar-chart | `@visx/gradient`, `@visx/pattern`, `@visx/shape`, `motion` |
+| candlestick-chart | `@visx/scale`, `@visx/shape`, `@visx/responsive`, `d3-array`, `motion` |
+| live-line-chart | `@visx/curve`, `@visx/scale`, `@visx/shape`, `@visx/responsive`, `@visx/event`, `d3-array`, `motion` |
+| choropleth-chart | `@visx/geo`, `@visx/responsive`, `@visx/zoom`, `d3-geo`, `topojson-client`, `motion` |
+| sankey-chart | `@visx/gradient`, `@visx/pattern`, `@visx/responsive`, `@visx/sankey`, `motion` |
+| scatter-chart | `d3-scale`, `d3-array`, `motion`, `react-use-measure` |
+| pie-chart, ring-chart | `@visx/responsive`, `@visx/shape`, `motion` |
+| radar-chart | `@visx/responsive`, `d3-shape`, `motion` |
+| funnel-chart | `motion` |
+| gauge-chart | `@visx/responsive`, `motion` |
+
+The CLI installs these when adding a chart — do not guess versions; let `shadcn add` resolve them.
+
+## Docs
+
+- Installation: https://ui.bklit.com/docs/installation
+- Per-chart install tabs: https://ui.bklit.com/docs/components/<slug>

--- a/skills/bklit-ui/rules/theming.md
+++ b/skills/bklit-ui/rules/theming.md
@@ -1,0 +1,55 @@
+# Theming
+
+## Use chartCssVars
+
+Prefer the typed `chartCssVars` export over raw CSS variable strings.
+
+### Incorrect
+
+```tsx
+<line stroke="var(--chart-crosshair)" />
+<rect fill="var(--chart-indicator-color)" />
+```
+
+### Correct
+
+```tsx
+import { chartCssVars } from "@bklitui/ui/charts";
+
+<line stroke={chartCssVars.crosshair} />
+<rect fill={chartCssVars.indicatorColor} />
+```
+
+## Series colors
+
+- Multi-series: `var(--chart-1)` through `var(--chart-5)` or theme tokens.
+- Line charts: `var(--chart-line-primary)` / `var(--chart-line-secondary)` for default strokes.
+- Do not hardcode hex colors unless the design explicitly requires brand colors outside the theme.
+
+## Tooltip and badge surfaces
+
+Tooltip boxes and live value badges should use shadcn popover tokens so text stays readable in light and dark mode:
+
+```tsx
+// Tooltip content / badges
+className="bg-popover text-popover-foreground"
+```
+
+## Dark mode
+
+Override chart variables in `:root` and `.dark` — do not sprinkle `dark:` on individual chart SVG elements.
+
+```css
+:root {
+  --chart-background: oklch(1 0 0);
+  --chart-grid: oklch(0.9 0 0);
+}
+.dark {
+  --chart-background: oklch(0.145 0.004 285);
+  --chart-grid: oklch(0.25 0 0);
+}
+```
+
+## Docs
+
+- Full theming guide: https://ui.bklit.com/docs/theming

--- a/skills/bklit-ui/rules/tooltips.md
+++ b/skills/bklit-ui/rules/tooltips.md
@@ -1,0 +1,71 @@
+# Tooltips
+
+## Default tooltip
+
+Use `ChartTooltip` as a child of the root chart. Defaults include crosshair, dots, and date pill where applicable.
+
+```tsx
+<LineChart data={data}>
+  <Line dataKey="users" />
+  <XAxis />
+  <ChartTooltip />
+</LineChart>
+```
+
+## Custom content
+
+```tsx
+<ChartTooltip
+  content={({ point, formattedDate }) => (
+    <div className="rounded-md bg-popover px-3 py-2 text-popover-foreground text-sm">
+      <div className="font-medium">{formattedDate}</div>
+      <div>{point.users as number} users</div>
+    </div>
+  )}
+/>
+```
+
+## indicatorColor (candlestick and crosshair)
+
+Match the crosshair to the hovered datum — e.g. green/red candles:
+
+```tsx
+<ChartTooltip
+  indicatorColor={(point) =>
+    (point.close as number) >= (point.open as number)
+      ? "var(--chart-1)"
+      : "var(--chart-3)"
+  }
+  showDots={false}
+/>
+```
+
+## Custom indicators
+
+For advanced crosshair/markers, use `useChart()` and the patterns in the custom indicator docs.
+
+### Incorrect
+
+```tsx
+// Reading mouse position manually outside chart context
+const [x, setX] = useState(0);
+useEffect(() => {
+  window.addEventListener("mousemove", ...);
+}, []);
+```
+
+### Correct
+
+```tsx
+import { useChart } from "@bklitui/ui/charts";
+
+function CustomIndicator() {
+  const { tooltipData } = useChart();
+  // render from tooltipData
+}
+```
+
+## Docs
+
+- ChartTooltip: https://ui.bklit.com/docs/utility/tooltip
+- Custom indicators: https://ui.bklit.com/docs/utility/custom-indicator


### PR DESCRIPTION
## Summary

- Add `/docs/skills` with install instructions for the public **bklit-ui** skill (`npx skills add bklit/bklit-ui`) and a Contributing footnote for clone-only skills
- Publish consumer skill at `skills/bklit-ui/` with composition, theming, animation, tooltip, and installation rules for any project using the `@bklit` registry
- Add contributor skills: **bklit-playground** (gitignored route + dev toolkit) and **bklit-ship** (prototype → production checklist, renamed from old bklit-ui skill)
- Add committed playground dev components: replay, viewport presets, resizable preview, and FPS counter

## Test plan

- [x] `pnpm lint` passes at repo root
- [x] `pnpm --filter web build` succeeds (includes `/docs/skills` SSG)
- [x] `npx skills add ./skills/bklit-ui --skill bklit-ui -y` installs locally
- [ ] `/docs/skills` renders in sidebar Getting Started with install command
- [ ] Contributor playground template copies to `apps/web/app/playground/page.tsx` and runs locally