### PR TITLE
feat(web): add OpenPanel analytics with proxy and event tracking

### DIFF
--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -1,2 +1,6 @@
 BKLIT_API_KEY=
 BKLIT_PROJECT_ID=
+
+# OpenPanel analytics (https://openpanel.dev)
+OPENPANEL_CLIENT_ID=
+OPENPANEL_CLIENT_SECRET=

--- a/apps/web/app/api/op/[[...path]]/route.ts
+++ b/apps/web/app/api/op/[[...path]]/route.ts
@@ -1,0 +1,3 @@
+import { createRouteHandler } from "@openpanel/nextjs/server";
+
+export const { GET, POST } = createRouteHandler();

--- a/apps/web/app/docs/[[...slug]]/page.tsx
+++ b/apps/web/app/docs/[[...slug]]/page.tsx
@@ -64,7 +64,11 @@ export default async function Page(props: {
                 </p>
               )}
             </div>
-            <CopyPageButton content={rawContent} url={page.url} />
+            <CopyPageButton
+              content={rawContent}
+              title={data.title}
+              url={page.url}
+            />
           </div>
         </header>
         <div className="prose prose-neutral dark:prose-invert max-w-none">

--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -1,10 +1,13 @@
 import { GithubStatsProvider } from "@/components/providers/github-stats-provider";
 import "./globals.css";
 import { BklitComponent } from "@bklit/sdk/nextjs";
+import { OpenPanelComponent } from "@openpanel/nextjs";
 import { RootProvider } from "fumadocs-ui/provider";
 import type { Metadata } from "next";
 import { Geist, Geist_Mono, Inter } from "next/font/google";
 import type { ReactNode } from "react";
+import { DocsSearchDialog } from "@/components/docs/docs-search-dialog";
+import { getOpenPanelClientId } from "@/lib/openpanel-env";
 import { cn } from "@/lib/utils";
 
 const inter = Inter({ subsets: ["latin"], variable: "--font-sans" });
@@ -42,6 +45,8 @@ export const metadata: Metadata = {
 };
 
 export default function RootLayout({ children }: { children: ReactNode }) {
+  const openPanelClientId = getOpenPanelClientId();
+
   return (
     <html
       className={cn(
@@ -58,8 +63,24 @@ export default function RootLayout({ children }: { children: ReactNode }) {
           apiKey={process.env.BKLIT_API_KEY ?? ""}
           projectId={process.env.BKLIT_PROJECT_ID ?? ""}
         />
+        {openPanelClientId ? (
+          <OpenPanelComponent
+            apiUrl="/api/op"
+            clientId={openPanelClientId}
+            scriptUrl="/api/op/op1.js"
+            trackAttributes
+            trackOutgoingLinks
+            trackScreenViews
+          />
+        ) : null}
         <GithubStatsProvider>
           <RootProvider
+            search={{
+              SearchDialog: DocsSearchDialog,
+              options: {
+                api: "/api/search",
+              },
+            }}
             theme={{
               attribute: "class",
               defaultTheme: "system",

--- a/apps/web/components/blocks/block-viewer.tsx
+++ b/apps/web/components/blocks/block-viewer.tsx
@@ -17,6 +17,7 @@ import {
   TooltipProvider,
   TooltipTrigger,
 } from "@/components/ui/tooltip";
+import { getAnalyticsUrl, trackEvent } from "@/lib/analytics/track-client";
 import {
   blockOpenInV0Href,
   blockShadcnAddCommand,
@@ -177,6 +178,17 @@ export function BlockViewer({
                 <a
                   aria-label="Open in v0"
                   href={blockOpenInV0Href(registryName)}
+                  onClick={() => {
+                    trackEvent("blocks_open_v0", {
+                      name,
+                      description,
+                      registry_name: registryName,
+                      install_command: installCommand,
+                      preview_height: previewHeight,
+                      mobile_preview_width: mobilePreviewWidth,
+                      url: getAnalyticsUrl(),
+                    });
+                  }}
                   rel="noreferrer"
                   target="_blank"
                 />

--- a/apps/web/components/docs/component-preview.tsx
+++ b/apps/web/components/docs/component-preview.tsx
@@ -46,7 +46,10 @@ export function ComponentPreview({
           </h2>
           <div className="flex shrink-0 flex-wrap items-center justify-end gap-2">
             {studioSlug ? <OpenInStudioButton slug={studioSlug} /> : null}
-            <OpenInV0Button registryJsonUrl={registryJsonUrl} />
+            <OpenInV0Button
+              chart={registryName}
+              registryJsonUrl={registryJsonUrl}
+            />
           </div>
         </div>
       ) : null}

--- a/apps/web/components/docs/copy-page-button.tsx
+++ b/apps/web/components/docs/copy-page-button.tsx
@@ -2,6 +2,7 @@
 
 import { CheckIcon, ChevronDownIcon, CopyIcon } from "lucide-react";
 import { useState } from "react";
+import { getAnalyticsUrl, trackEvent } from "@/lib/analytics/track-client";
 import { Button } from "../ui/button";
 import {
   DropdownMenu,
@@ -13,6 +14,7 @@ import {
 interface CopyPageButtonProps {
   content: string;
   url: string;
+  title?: string;
 }
 
 function getPromptUrl(baseURL: string, url: string, content: string) {
@@ -26,16 +28,30 @@ Help me understand how to use it. Be ready to explain concepts, give examples, o
   return `${baseURL}?q=${encodeURIComponent(prompt)}`;
 }
 
-export function CopyPageButton({ content, url }: CopyPageButtonProps) {
+export function CopyPageButton({ content, url, title }: CopyPageButtonProps) {
   const [copied, setCopied] = useState(false);
 
   const handleCopy = async () => {
     await navigator.clipboard.writeText(content);
+    trackEvent("docs_copy_page", {
+      url: getAnalyticsUrl() || url,
+      page_path: url,
+      title,
+    });
     setCopied(true);
     setTimeout(() => setCopied(false), 2000);
   };
 
   const fullUrl = typeof window === "undefined" ? url : window.location.href;
+
+  const trackLlmOpen = (provider: "chatgpt" | "claude") => {
+    trackEvent("docs_copy_page_llm", {
+      provider,
+      url: fullUrl,
+      page_path: url,
+      title,
+    });
+  };
 
   return (
     <div className="hidden md:flex">
@@ -87,6 +103,7 @@ export function CopyPageButton({ content, url }: CopyPageButtonProps) {
                 aria-label="Open in ChatGPT"
                 className="whitespace-nowrap"
                 href={getPromptUrl("https://chatgpt.com", fullUrl, content)}
+                onClick={() => trackLlmOpen("chatgpt")}
                 rel="noreferrer"
                 target="_blank"
               />
@@ -104,6 +121,7 @@ export function CopyPageButton({ content, url }: CopyPageButtonProps) {
                 aria-label="Open in Claude"
                 className="whitespace-nowrap"
                 href={getPromptUrl("https://claude.ai/new", fullUrl, content)}
+                onClick={() => trackLlmOpen("claude")}
                 rel="noreferrer"
                 target="_blank"
               />

--- a/apps/web/components/docs/docs-search-dialog.tsx
+++ b/apps/web/components/docs/docs-search-dialog.tsx
@@ -1,0 +1,165 @@
+"use client";
+
+import { useDocsSearch } from "fumadocs-core/search/client";
+import { useOnChange } from "fumadocs-core/utils/use-on-change";
+import {
+  SearchDialog,
+  SearchDialogClose,
+  SearchDialogContent,
+  SearchDialogFooter,
+  SearchDialogHeader,
+  SearchDialogIcon,
+  SearchDialogInput,
+  SearchDialogList,
+  SearchDialogListItem,
+  SearchDialogOverlay,
+  TagsList,
+  TagsListItem,
+} from "fumadocs-ui/components/dialog/search";
+import type { DefaultSearchDialogProps } from "fumadocs-ui/components/dialog/search-default";
+import { useI18n } from "fumadocs-ui/contexts/i18n";
+import { useEffect, useMemo, useRef, useState } from "react";
+import { consumeSearchOpenSource } from "@/lib/analytics/search-source";
+import { trackEvent } from "@/lib/analytics/track-client";
+
+export function DocsSearchDialog({
+  defaultTag,
+  tags = [],
+  api = "/api/search",
+  delayMs,
+  type = "fetch",
+  allowClear = false,
+  links = [],
+  footer,
+  open,
+  onOpenChange,
+  ...props
+}: DefaultSearchDialogProps) {
+  const { locale } = useI18n();
+  const [tag, setTag] = useState(defaultTag);
+  const queryTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const lastTrackedQueryRef = useRef("");
+  const { search, setSearch, query } = useDocsSearch(
+    type === "fetch"
+      ? {
+          type: "fetch",
+          api,
+          locale,
+          tag,
+          delayMs,
+        }
+      : {
+          type: "static",
+          from: api,
+          locale,
+          tag,
+          delayMs,
+        }
+  );
+
+  const defaultItems = useMemo(() => {
+    if (links.length === 0) {
+      return null;
+    }
+    return links.map(([name, link]) => ({
+      type: "page" as const,
+      id: name,
+      content: name,
+      url: link,
+    }));
+  }, [links]);
+
+  useOnChange(defaultTag, (value) => {
+    setTag(value);
+  });
+
+  useEffect(() => {
+    if (!open) {
+      return;
+    }
+    trackEvent("search_open", { source: consumeSearchOpenSource() });
+  }, [open]);
+
+  useEffect(() => {
+    if (!open) {
+      return;
+    }
+
+    const trimmed = search.trim();
+    if (trimmed.length < 2 || trimmed === lastTrackedQueryRef.current) {
+      return;
+    }
+
+    if (queryTimerRef.current) {
+      clearTimeout(queryTimerRef.current);
+    }
+
+    queryTimerRef.current = setTimeout(() => {
+      lastTrackedQueryRef.current = trimmed;
+      trackEvent("search_query", { query: trimmed });
+    }, 500);
+
+    return () => {
+      if (queryTimerRef.current) {
+        clearTimeout(queryTimerRef.current);
+      }
+    };
+  }, [open, search]);
+
+  useEffect(() => {
+    if (!open) {
+      lastTrackedQueryRef.current = "";
+    }
+  }, [open]);
+
+  return (
+    <SearchDialog
+      isLoading={query.isLoading}
+      onOpenChange={onOpenChange}
+      onSearchChange={setSearch}
+      open={open}
+      search={search}
+      {...props}
+    >
+      <SearchDialogOverlay />
+      <SearchDialogContent>
+        <SearchDialogHeader>
+          <SearchDialogIcon />
+          <SearchDialogInput />
+          <SearchDialogClose />
+        </SearchDialogHeader>
+        <SearchDialogList
+          Item={({ item, onClick }) => (
+            <SearchDialogListItem
+              item={item}
+              onClick={() => {
+                if (item.type !== "action") {
+                  trackEvent("search_select", {
+                    query: search.trim(),
+                    result_url: item.url,
+                    result_title: item.content,
+                    result_type: item.type,
+                  });
+                }
+                onClick();
+              }}
+            />
+          )}
+          items={query.data === "empty" ? defaultItems : query.data}
+        />
+      </SearchDialogContent>
+      <SearchDialogFooter>
+        {tags.length > 0 ? (
+          <TagsList allowClear={allowClear} onTagChange={setTag} tag={tag}>
+            {tags.map((tagItem) => (
+              <TagsListItem key={tagItem.value} value={tagItem.value}>
+                {tagItem.name}
+              </TagsListItem>
+            ))}
+          </TagsList>
+        ) : null}
+        {footer}
+      </SearchDialogFooter>
+    </SearchDialog>
+  );
+}

--- a/apps/web/components/docs/docs-search-trigger.tsx
+++ b/apps/web/components/docs/docs-search-trigger.tsx
@@ -4,6 +4,7 @@ import { Search01Icon } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 import { useSearchContext } from "fumadocs-ui/contexts/search";
 import { useEffect, useState } from "react";
+import { markSearchOpenedFromClick } from "@/lib/analytics/search-source";
 import { cn } from "@/lib/utils";
 
 function SearchShortcut() {
@@ -46,7 +47,10 @@ export function DocsSearchTrigger({
         className
       )}
       data-search-full=""
-      onClick={() => setOpenSearch(true)}
+      onClick={() => {
+        markSearchOpenedFromClick();
+        setOpenSearch(true);
+      }}
       type="button"
     >
       <HugeiconsIcon

--- a/apps/web/components/docs/open-in-studio-button.tsx
+++ b/apps/web/components/docs/open-in-studio-button.tsx
@@ -3,14 +3,23 @@
 import Link from "next/link";
 import type { ChartSlug } from "@/components/charts/chart-slugs";
 import { Button } from "@/components/ui/button";
+import { getAnalyticsUrl, trackEvent } from "@/lib/analytics/track-client";
 import { studioChartHref } from "@/lib/studio/chart-links";
 
 export function OpenInStudioButton({ slug }: { slug: ChartSlug }) {
+  const handleClick = () => {
+    trackEvent("docs_open_studio", {
+      chart: slug,
+      url: getAnalyticsUrl(),
+      studio_url: studioChartHref(slug),
+    });
+  };
+
   return (
     <Button
       className="h-8 gap-1 px-3 text-xs"
       nativeButton={false}
-      render={<Link href={studioChartHref(slug)} />}
+      render={<Link href={studioChartHref(slug)} onClick={handleClick} />}
       variant="outline"
     >
       Open in Studio

--- a/apps/web/components/docs/open-in-v0-button.tsx
+++ b/apps/web/components/docs/open-in-v0-button.tsx
@@ -2,6 +2,7 @@
 
 import { V0Icon } from "@/components/icons/v0";
 import { Button } from "@/components/ui/button";
+import { getAnalyticsUrl, trackEvent } from "@/lib/analytics/track-client";
 import { openInV0Href } from "@/lib/studio/chart-links";
 
 /**
@@ -10,9 +11,21 @@ import { openInV0Href } from "@/lib/studio/chart-links";
  */
 export function OpenInV0Button({
   registryJsonUrl,
+  chart,
+  surface = "docs",
 }: {
   registryJsonUrl: string;
+  chart?: string;
+  surface?: "docs" | "studio";
 }) {
+  const handleClick = () => {
+    trackEvent(surface === "studio" ? "studio_open_v0" : "docs_open_v0", {
+      chart,
+      url: getAnalyticsUrl(),
+      registry_json_url: registryJsonUrl,
+    });
+  };
+
   return (
     <Button
       aria-label="Open in v0"
@@ -23,6 +36,7 @@ export function OpenInV0Button({
         <a
           aria-label="Open in v0"
           href={openInV0Href(registryJsonUrl)}
+          onClick={handleClick}
           rel="noreferrer"
           target="_blank"
         />

--- a/apps/web/components/docs/site-header.tsx
+++ b/apps/web/components/docs/site-header.tsx
@@ -4,6 +4,7 @@ import Link from "fumadocs-core/link";
 import { useTheme } from "next-themes";
 import { useEffect, useState } from "react";
 import { ModeToggle } from "@/components/mode-toggle";
+import { getAnalyticsUrl, trackEvent } from "@/lib/analytics/track-client";
 import { GithubStarCount } from "../github-star-count";
 import { BklitLogo } from "../icons/bklit";
 import { DiscordIcon } from "../icons/discord";
@@ -12,6 +13,13 @@ import { Button } from "../ui/button";
 import { Separator } from "../ui/separator";
 import { DocsSearchTrigger } from "./docs-search-trigger";
 import { NavLinkLabel } from "./nav-link-label";
+
+function trackDiscordClick(location: "header" | "mobile_menu") {
+  trackEvent("discord_click", {
+    location,
+    url: getAnalyticsUrl(),
+  });
+}
 
 interface NavLink {
   text: string;
@@ -292,7 +300,10 @@ function MobileMenu({
                   className="transition-[filter] duration-300 ease-out"
                   external
                   href={discordUrl}
-                  onClick={onClose}
+                  onClick={() => {
+                    trackDiscordClick("mobile_menu");
+                    onClose();
+                  }}
                   style={getBlurStyle(
                     externalLinksStartIndex + (githubUrl ? 1 : 0)
                   )}
@@ -406,6 +417,7 @@ export function SiteHeader({
                 className="hidden md:block"
                 external
                 href={discordUrl}
+                onClick={() => trackDiscordClick("header")}
               >
                 <Button size="default" variant="ghost">
                   <DiscordIcon />

--- a/apps/web/components/docs/toc.tsx
+++ b/apps/web/components/docs/toc.tsx
@@ -7,6 +7,7 @@ import {
   type TOCItemType,
 } from "fumadocs-core/toc";
 import { useRef } from "react";
+import { getAnalyticsUrl, trackEvent } from "@/lib/analytics/track-client";
 import { Button } from "../ui/button";
 
 interface TableOfContentsProps {
@@ -28,6 +29,12 @@ function SidebarCTA() {
       <a
         className="absolute inset-0"
         href="https://discord.com/invite/9yyK8FwPcU"
+        onClick={() => {
+          trackEvent("discord_click", {
+            location: "docs_toc",
+            url: getAnalyticsUrl(),
+          });
+        }}
         rel="noreferrer"
         target="_blank"
       >

--- a/apps/web/components/home-sponsors-section.tsx
+++ b/apps/web/components/home-sponsors-section.tsx
@@ -11,6 +11,7 @@ import {
   TooltipProvider,
   TooltipTrigger,
 } from "@/components/ui/tooltip";
+import { getAnalyticsUrl, trackEvent } from "@/lib/analytics/track-client";
 import { cn } from "@/lib/utils";
 
 const sponsorLink = "https://github.com/sponsors/uixmat";
@@ -30,6 +31,14 @@ const containerVariants = {
   },
 };
 
+function trackSponsorClick(location: "button" | "card") {
+  trackEvent("homepage_sponsor_click", {
+    location,
+    url: getAnalyticsUrl(),
+    sponsor_url: sponsorLink,
+  });
+}
+
 function SponsorSkeletonCard({ className }: { className?: string }) {
   return (
     <Link
@@ -40,6 +49,7 @@ function SponsorSkeletonCard({ className }: { className?: string }) {
       )}
       external
       href={sponsorLink}
+      onClick={() => trackSponsorClick("card")}
     >
       <span className="font-light font-mono text-muted-foreground text-xs transition-colors group-hover:text-foreground">
         +
@@ -164,7 +174,11 @@ export function HomeSponsorsSection() {
           <Button
             nativeButton={false}
             render={
-              <Link external href={sponsorLink}>
+              <Link
+                external
+                href={sponsorLink}
+                onClick={() => trackSponsorClick("button")}
+              >
                 Become a sponsor
               </Link>
             }

--- a/apps/web/components/home-studio-section.tsx
+++ b/apps/web/components/home-studio-section.tsx
@@ -18,6 +18,7 @@ import {
   useState,
 } from "react";
 import { Button } from "@/components/ui/button";
+import { getAnalyticsUrl, trackEvent } from "@/lib/analytics/track-client";
 import { cn } from "@/lib/utils";
 
 const coverSrc = "/img/bklit-studio-cover.png";
@@ -98,6 +99,8 @@ function FloatingVideoControl({
 export function HomeStudioSection() {
   const reducedMotion = useReducedMotion();
   const videoRef = useRef<HTMLVideoElement>(null);
+  const sectionRef = useRef<HTMLElement>(null);
+  const hasTrackedViewRef = useRef(false);
   const [isActive, setIsActive] = useState(false);
   const [isPlaying, setIsPlaying] = useState(false);
   const [isMuted, setIsMuted] = useState(true);
@@ -119,6 +122,30 @@ export function HomeStudioSection() {
     return () => mq.removeEventListener("change", update);
   }, []);
 
+  useEffect(() => {
+    const section = sectionRef.current;
+    if (!section) {
+      return;
+    }
+
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (!entry?.isIntersecting || hasTrackedViewRef.current) {
+          return;
+        }
+        hasTrackedViewRef.current = true;
+        trackEvent("homepage_video_view", {
+          url: getAnalyticsUrl(),
+          video_src: videoSrc,
+        });
+      },
+      { threshold: 0.5 }
+    );
+
+    observer.observe(section);
+    return () => observer.disconnect();
+  }, []);
+
   const resetToPoster = useCallback(() => {
     const video = videoRef.current;
     if (video) {
@@ -126,12 +153,21 @@ export function HomeStudioSection() {
       video.currentTime = 0;
       video.muted = true;
     }
+    trackEvent("homepage_video_complete", {
+      url: getAnalyticsUrl(),
+      video_src: videoSrc,
+    });
     setIsActive(false);
     setIsPlaying(false);
     setIsMuted(true);
   }, []);
 
   const startPlayback = useCallback(() => {
+    trackEvent("homepage_video_click", {
+      action: "start",
+      url: getAnalyticsUrl(),
+      video_src: videoSrc,
+    });
     setIsActive(true);
 
     requestAnimationFrame(() => {
@@ -156,11 +192,22 @@ export function HomeStudioSection() {
     }
 
     if (video.paused) {
+      trackEvent("homepage_video_click", {
+        action: "play",
+        url: getAnalyticsUrl(),
+        video_src: videoSrc,
+      });
       video
         .play()
         .then(() => setIsPlaying(true))
         .catch(() => setIsPlaying(false));
     } else {
+      trackEvent("homepage_video_click", {
+        action: "pause",
+        url: getAnalyticsUrl(),
+        video_src: videoSrc,
+        current_time: video.currentTime,
+      });
       video.pause();
       setIsPlaying(false);
     }
@@ -174,12 +221,19 @@ export function HomeStudioSection() {
 
     video.muted = !video.muted;
     setIsMuted(video.muted);
+    trackEvent("homepage_video_click", {
+      action: video.muted ? "mute" : "unmute",
+      url: getAnalyticsUrl(),
+      video_src: videoSrc,
+      current_time: video.currentTime,
+    });
   }, []);
 
   return (
     <section
       aria-label="Studio"
       className="mx-auto w-full max-w-4xl space-y-5 text-center"
+      ref={sectionRef}
     >
       <div className="space-y-4">
         <div className="space-y-2">
@@ -237,7 +291,15 @@ export function HomeStudioSection() {
             )}
             onEnded={resetToPoster}
             onPause={() => setIsPlaying(false)}
-            onPlay={() => setIsPlaying(true)}
+            onPlay={() => {
+              setIsPlaying(true);
+              const video = videoRef.current;
+              trackEvent("homepage_video_play", {
+                url: getAnalyticsUrl(),
+                video_src: videoSrc,
+                current_time: video?.currentTime ?? 0,
+              });
+            }}
             playsInline
             preload="metadata"
             ref={videoRef}

--- a/apps/web/components/studio/studio-code-sheet.tsx
+++ b/apps/web/components/studio/studio-code-sheet.tsx
@@ -17,6 +17,7 @@ import {
   SheetTitle,
   SheetTrigger,
 } from "@/components/ui/sheet";
+import { getAnalyticsUrl, trackEvent } from "@/lib/analytics/track-client";
 import {
   registryV0ExampleJsonUrl,
   studioChartDocsHref,
@@ -48,7 +49,18 @@ export function StudioCodeSheet({ state }: { state: StudioUrlState }) {
   const { code, data, title } = generated;
 
   return (
-    <Sheet onOpenChange={setOpen} open={open}>
+    <Sheet
+      onOpenChange={(nextOpen) => {
+        if (nextOpen) {
+          trackEvent("studio_get_code", {
+            chart: state.chart,
+            url: getAnalyticsUrl(),
+          });
+        }
+        setOpen(nextOpen);
+      }}
+      open={open}
+    >
       <SheetTrigger
         render={
           <Button
@@ -81,7 +93,9 @@ export function StudioCodeSheet({ state }: { state: StudioUrlState }) {
                 Documentation
               </Button>
               <OpenInV0Button
+                chart={state.chart}
                 registryJsonUrl={registryV0ExampleJsonUrl(state.chart)}
+                surface="studio"
               />
             </div>
           </div>

--- a/apps/web/components/studio/studio-preview.tsx
+++ b/apps/web/components/studio/studio-preview.tsx
@@ -27,6 +27,7 @@ import {
   TooltipProvider,
   TooltipTrigger,
 } from "@/components/ui/tooltip";
+import { getAnalyticsUrl, trackEvent } from "@/lib/analytics/track-client";
 import { presetStyle } from "@/lib/studio/color-presets";
 import { StudioPatternDefs, studioPatternFill } from "@/lib/studio/patterns";
 import type { StudioRenderContext } from "@/lib/studio/render-context";
@@ -155,6 +156,14 @@ export function StudioPreview() {
       }
 
       try {
+        trackEvent("studio_recording_start", {
+          chart: state.chart,
+          format,
+          aspect,
+          interaction_ms: interactionMs,
+          url: getAnalyticsUrl(),
+        });
+
         await startRecording({
           element,
           width: dimensions.captureWidth,
@@ -211,7 +220,15 @@ export function StudioPreview() {
       height: state.frameH,
       filename: `${state.chart}.svg`,
     });
-  }, [state.chart, state.frameH, state.frameW]);
+
+    trackEvent("studio_export_svg", {
+      chart: state.chart,
+      url: getAnalyticsUrl(),
+      frame_w: state.frameW,
+      frame_h: state.frameH,
+      preset: displayState.preset,
+    });
+  }, [displayState.preset, state.chart, state.frameH, state.frameW]);
 
   return (
     <TooltipProvider>

--- a/apps/web/components/studio/use-studio-recording.ts
+++ b/apps/web/components/studio/use-studio-recording.ts
@@ -1,6 +1,7 @@
 "use client";
 
 import { useCallback, useRef, useState } from "react";
+import { getAnalyticsUrl, trackEvent } from "@/lib/analytics/track-client";
 import { captureChartFrames } from "@/lib/studio/capture-chart-frames";
 import { encodeStudioRecording } from "@/lib/studio/encode-studio-recording";
 import {
@@ -151,6 +152,15 @@ export function useStudioRecording() {
             onProgress: (encodeProgress) => {
               setProgress(0.7 + encodeProgress * 0.3);
             },
+          });
+        }
+
+        if (!controller.signal.aborted) {
+          trackEvent("studio_recording_complete", {
+            chart,
+            format,
+            method: useStream ? "stream" : "frames",
+            url: getAnalyticsUrl(),
           });
         }
       } catch (caught) {

--- a/apps/web/lib/analytics/search-source.ts
+++ b/apps/web/lib/analytics/search-source.ts
@@ -1,0 +1,11 @@
+let pendingSearchOpenSource: "click" | "keyboard" = "keyboard";
+
+export function markSearchOpenedFromClick() {
+  pendingSearchOpenSource = "click";
+}
+
+export function consumeSearchOpenSource() {
+  const source = pendingSearchOpenSource;
+  pendingSearchOpenSource = "keyboard";
+  return source;
+}

--- a/apps/web/lib/analytics/track-client.ts
+++ b/apps/web/lib/analytics/track-client.ts
@@ -5,7 +5,11 @@ export function trackEvent(name: string, properties?: Record<string, unknown>) {
     return;
   }
 
-  (window.op as (...args: unknown[]) => void)("track", name, properties);
+  (window.op as unknown as (...args: unknown[]) => void)(
+    "track",
+    name,
+    properties
+  );
 }
 
 export function getAnalyticsUrl() {

--- a/apps/web/lib/analytics/track-client.ts
+++ b/apps/web/lib/analytics/track-client.ts
@@ -1,0 +1,16 @@
+"use client";
+
+export function trackEvent(name: string, properties?: Record<string, unknown>) {
+  if (typeof window === "undefined" || !("op" in window)) {
+    return;
+  }
+
+  (window.op as (...args: unknown[]) => void)("track", name, properties);
+}
+
+export function getAnalyticsUrl() {
+  if (typeof window === "undefined") {
+    return "";
+  }
+  return window.location.href;
+}

--- a/apps/web/lib/openpanel-env.ts
+++ b/apps/web/lib/openpanel-env.ts
@@ -1,0 +1,11 @@
+export function getOpenPanelClientId() {
+  return process.env.OPENPANEL_CLIENT_ID ?? process.env.CLIENT_ID ?? "";
+}
+
+export function getOpenPanelClientSecret() {
+  return process.env.OPENPANEL_CLIENT_SECRET ?? process.env.CLIENT_SECRET ?? "";
+}
+
+export function isOpenPanelConfigured() {
+  return getOpenPanelClientId().length > 0;
+}

--- a/apps/web/lib/openpanel-server.ts
+++ b/apps/web/lib/openpanel-server.ts
@@ -1,0 +1,16 @@
+import "server-only";
+
+import { OpenPanel } from "@openpanel/nextjs";
+
+import {
+  getOpenPanelClientId,
+  getOpenPanelClientSecret,
+  isOpenPanelConfigured,
+} from "./openpanel-env";
+
+export const opServer = isOpenPanelConfigured()
+  ? new OpenPanel({
+      clientId: getOpenPanelClientId(),
+      clientSecret: getOpenPanelClientSecret(),
+    })
+  : null;

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -20,6 +20,7 @@
     "@hugeicons/core-free-icons": "^4.1.4",
     "@hugeicons/react": "^1.1.6",
     "@number-flow/react": "^0.5.4",
+    "@openpanel/nextjs": "^1.5.1",
     "@remotion/web-renderer": "4.0.462",
     "@visx/brush": "3.12.0",
     "@visx/curve": "4.0.1-alpha.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -50,6 +50,9 @@ importers:
       '@number-flow/react':
         specifier: ^0.5.4
         version: 0.5.11(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@openpanel/nextjs':
+        specifier: ^1.5.1
+        version: 1.5.1(next@15.5.9(@babel/core@7.29.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@remotion/web-renderer':
         specifier: 4.0.462
         version: 4.0.462(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
@@ -1407,6 +1410,19 @@ packages:
   '@open-draft/until@2.1.0':
     resolution: {integrity: sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg==}
 
+  '@openpanel/nextjs@1.5.1':
+    resolution: {integrity: sha512-60vhKw29weFWmwntx/cSIYU1TcwNzRykeg8P70onr3jzeyMGsEd78d/wgF5Mp/NIxQDN0IT4LneS6hIDIyrTpw==}
+    peerDependencies:
+      next: ^12.0.0 || ^13.0.0 || ^14.0.0 || ^15.0.0 || ^16.0.0
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
+  '@openpanel/sdk@1.3.1':
+    resolution: {integrity: sha512-mQ5xaBUGXnyRg3qYxwnbVaUYyW7w8u+munrWk/ClnqxEeR2j+FYPiA6noHbHMCFC2aZutYD5OoRzEvw3FBNFxw==}
+
+  '@openpanel/web@1.4.1':
+    resolution: {integrity: sha512-DgUWeocZw+b57YiJjefZPg+6sceR7TdOF8x7Ut75lu3CwcwqGi5jZNPXjikNemGL37aNWXCB4buhcoNan2j7RA==}
+
   '@orama/orama@3.1.18':
     resolution: {integrity: sha512-a61ljmRVVyG5MC/698C8/FfFDw5a8LOIvyOLW5fztgUXqUpc1jOfQzOitSCbge657OgXXThmY3Tk8fpiDb4UcA==}
     engines: {node: '>= 20.0.0'}
@@ -1785,6 +1801,12 @@ packages:
       react: '>=18.0.0'
       react-dom: '>=18.0.0'
 
+  '@rrweb/types@2.0.0-alpha.20':
+    resolution: {integrity: sha512-RbnDgKxA/odwB1R4gF7eUUj+rdSrq6ROQJsnMw7MIsGzlbSYvJeZN8YY4XqU0G6sKJvXI6bSzk7w/G94jNwzhw==}
+
+  '@rrweb/utils@2.0.0-alpha.20':
+    resolution: {integrity: sha512-MTQOmhPRe39C0fYaCnnVYOufQsyGzwNXpUStKiyFSfGLUJrzuwhbRoUAKR5w6W2j5XuA0bIz3ZDIBztkquOhLw==}
+
   '@sec-ant/readable-stream@0.4.1':
     resolution: {integrity: sha512-831qok9r2t8AlxLko40y2ebgSDhenenCatLVeW/uBtnHPyhHOvG0C7TvfgecV+wHzIm5KUICgzmVpWS+IMEAeg==}
 
@@ -1926,6 +1948,9 @@ packages:
 
   '@ts-morph/common@0.27.0':
     resolution: {integrity: sha512-Wf29UqxWDpc+i61k3oIOzcUfQt79PIT9y/MWfAGlrkjg6lBC1hwDECLXPVJAhWjiGbfBCxZd65F/LIZF3+jeJQ==}
+
+  '@types/css-font-loading-module@0.0.7':
+    resolution: {integrity: sha512-nl09VhutdjINdWyXxHWN/w9zlNCfr60JUqJbd24YXUuCwgeL0TpFSdElCwb6cxfB6ybE19Gjj4g0jsgkXxKv1Q==}
 
   '@types/d3-array@3.0.3':
     resolution: {integrity: sha512-Reoy+pKnvsksN0lQUlcH6dOGjRZ/3WRwXR//m+/8lt1BXeI4xyaUZoqULNjyXXRuh0Mj4LNpkCvhUpQlY3X5xQ==}
@@ -2214,6 +2239,9 @@ packages:
     peerDependencies:
       react: ^16.14.0 || ^17.0.0-0 || ^18.0.0-0 || ^19.0.0-0
 
+  '@xstate/fsm@1.6.5':
+    resolution: {integrity: sha512-b5o1I6aLNeYlU/3CPlj/Z91ybk1gUsKT+5NAJI+2W4UjvS5KLG28K9v5UvNoFVjHV8PajVZ00RH3vnjyQO7ZAw==}
+
   accepts@2.0.0:
     resolution: {integrity: sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==}
     engines: {node: '>= 0.6'}
@@ -2313,6 +2341,10 @@ packages:
 
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
+
+  base64-arraybuffer@1.0.2:
+    resolution: {integrity: sha512-I3yl4r9QB5ZRY3XuJVEPfc2XhZO6YweFPI+UovAzn+8/hb3oJ6lnysaFcjVpkCPfVWFUDvoZ8kmVDP7WyRtYtQ==}
+    engines: {node: '>= 0.6.0'}
 
   base64-js@1.5.1:
     resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
@@ -3988,6 +4020,9 @@ packages:
     resolution: {integrity: sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==}
     engines: {node: '>=16 || 14 >=14.17'}
 
+  mitt@3.0.1:
+    resolution: {integrity: sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==}
+
   mkdirp@2.1.6:
     resolution: {integrity: sha512-+hEnITedc8LAtIP9u3HJDFIdcLV2vXP33sqLLIzkv1Db1zO/1OxbvYf0Y1OC/S/Qo5dxHXepofhmxL02PsKe+A==}
     engines: {node: '>=10'}
@@ -4530,6 +4565,15 @@ packages:
   router@2.2.0:
     resolution: {integrity: sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==}
     engines: {node: '>= 18'}
+
+  rrdom@2.0.0-alpha.20:
+    resolution: {integrity: sha512-hoqjS4662LtBp82qEz9GrqU36UpEmCvTA2Hns3qdF7cklLFFy3G+0Th8hLytJENleHHWxsB5nWJ3eXz5mSRxdQ==}
+
+  rrweb-snapshot@2.0.0-alpha.20:
+    resolution: {integrity: sha512-YTNf9YVeaGRo/jxY3FKBge2c/Ojd/KTHmuWloUSB+oyPXuY73ZeeG873qMMmhIpqEn7hn7aBF1eWEQmP7wjf8A==}
+
+  rrweb@2.0.0-alpha.20:
+    resolution: {integrity: sha512-CZKDlm+j1VA50Ko3gnMbpvguCAleljsTNXPnVk9aeNP8o6T6kolRbISHyDZpqZ4G+bdDLlQOignPP3jEsXs8Gg==}
 
   run-applescript@7.1.0:
     resolution: {integrity: sha512-DPe5pVFaAsinSaV6QjQ6gdiedWDcRCbUuiQfQa2wmWV7+xC9bGulGI8+TdRmoFkAPaBXk8CrAbnlY2ISniJ47Q==}
@@ -6100,6 +6144,21 @@ snapshots:
 
   '@open-draft/until@2.1.0': {}
 
+  '@openpanel/nextjs@1.5.1(next@15.5.9(@babel/core@7.29.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
+    dependencies:
+      '@openpanel/web': 1.4.1
+      next: 15.5.9(@babel/core@7.29.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      react: 19.2.0
+      react-dom: 19.2.0(react@19.2.0)
+
+  '@openpanel/sdk@1.3.1': {}
+
+  '@openpanel/web@1.4.1':
+    dependencies:
+      '@openpanel/sdk': 1.3.1
+      '@rrweb/types': 2.0.0-alpha.20
+      rrweb: 2.0.0-alpha.20
+
   '@orama/orama@3.1.18': {}
 
   '@radix-ui/number@1.1.1': {}
@@ -6471,6 +6530,10 @@ snapshots:
       react-dom: 19.2.0(react@19.2.0)
       remotion: 4.0.462(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
 
+  '@rrweb/types@2.0.0-alpha.20': {}
+
+  '@rrweb/utils@2.0.0-alpha.20': {}
+
   '@sec-ant/readable-stream@0.4.1': {}
 
   '@shikijs/core@3.21.0':
@@ -6615,6 +6678,8 @@ snapshots:
       fast-glob: 3.3.3
       minimatch: 10.1.1
       path-browserify: 1.0.1
+
+  '@types/css-font-loading-module@0.0.7': {}
 
   '@types/d3-array@3.0.3': {}
 
@@ -7032,6 +7097,8 @@ snapshots:
       '@visx/event': 4.0.1-alpha.0
       react: 19.2.0
 
+  '@xstate/fsm@1.6.5': {}
+
   accepts@2.0.0:
     dependencies:
       mime-types: 3.0.2
@@ -7149,6 +7216,8 @@ snapshots:
   bail@2.0.2: {}
 
   balanced-match@1.0.2: {}
+
+  base64-arraybuffer@1.0.2: {}
 
   base64-js@1.5.1: {}
 
@@ -9248,6 +9317,8 @@ snapshots:
 
   minipass@7.1.2: {}
 
+  mitt@3.0.1: {}
+
   mkdirp@2.1.6: {}
 
   modern-screenshot@4.7.0: {}
@@ -9850,6 +9921,25 @@ snapshots:
       path-to-regexp: 8.3.0
     transitivePeerDependencies:
       - supports-color
+
+  rrdom@2.0.0-alpha.20:
+    dependencies:
+      rrweb-snapshot: 2.0.0-alpha.20
+
+  rrweb-snapshot@2.0.0-alpha.20:
+    dependencies:
+      postcss: 8.5.6
+
+  rrweb@2.0.0-alpha.20:
+    dependencies:
+      '@rrweb/types': 2.0.0-alpha.20
+      '@rrweb/utils': 2.0.0-alpha.20
+      '@types/css-font-loading-module': 0.0.7
+      '@xstate/fsm': 1.6.5
+      base64-arraybuffer: 1.0.2
+      mitt: 3.0.1
+      rrdom: 2.0.0-alpha.20
+      rrweb-snapshot: 2.0.0-alpha.20
 
   run-applescript@7.1.0: {}
 

--- a/turbo.json
+++ b/turbo.json
@@ -1,7 +1,14 @@
 {
   "$schema": "https://turborepo.dev/schema.json",
   "ui": "tui",
-  "globalEnv": ["BKLIT_API_KEY", "BKLIT_PROJECT_ID"],
+  "globalEnv": [
+    "BKLIT_API_KEY",
+    "BKLIT_PROJECT_ID",
+    "OPENPANEL_CLIENT_ID",
+    "OPENPANEL_CLIENT_SECRET",
+    "CLIENT_ID",
+    "CLIENT_SECRET"
+  ],
   "tasks": {
     "build": {
       "dependsOn": ["^build"],


### PR DESCRIPTION
## Summary

- Integrates OpenPanel alongside existing Bklit Analytics via `@openpanel/nextjs`, with a first-party `/api/op` proxy route to reduce ad-blocker drops.
- Adds custom events across search (Cmd+K), Studio (SVG export, recordings, get code, v0), docs (v0, studio, copy page, Discord TOC), blocks (v0), homepage (promo video, sponsor CTA), and site header Discord.
- Documents `OPENPANEL_CLIENT_ID` / `OPENPANEL_CLIENT_SECRET` in `.env.example` and registers env vars in `turbo.json`.

## Deploy notes

Set these in Vercel (production + preview as needed):

- `OPENPANEL_CLIENT_ID` — from OpenPanel dashboard
- `OPENPANEL_CLIENT_SECRET` — for server-side events only (optional today)

Bklit Analytics env vars (`BKLIT_API_KEY`, `BKLIT_PROJECT_ID`) are unchanged.

## Test plan

- [x] `pnpm lint` passes at repo root
- [x] `apps/web` production build succeeds
- [ ] With env vars set locally, confirm `/api/op/track` requests fire on page load and custom events (e.g. Cmd+K search, Studio SVG export)
- [ ] Verify Bklit Analytics still loads when `BKLIT_*` env vars are present
- [ ] After deploy, confirm events appear in OpenPanel dashboard