### PR TITLE
fix(web): restore production build after profit-loss playground type gap

### DIFF
--- a/apps/web/components/playground/playground-profit-loss-line-chart.tsx
+++ b/apps/web/components/playground/playground-profit-loss-line-chart.tsx
@@ -17,6 +17,7 @@ export function PlaygroundProfitLossLineChart({
 }) {
   const ctx: StudioRenderContext = {
     animationKey: replayKey,
+    dataSeed: 0,
     committedState,
     motionCurveDragging,
     motionRemountKey: "",


### PR DESCRIPTION
## Summary

- Add the required `dataSeed` field to the profit-loss playground `StudioRenderContext` stub
- Fixes the production build failure on `main` after #100 merged — the error was unrelated to the tooltip change; `StudioRenderContext` gained `dataSeed` in the profit-loss work but the playground wrapper was never updated

## Test plan

- [x] `pnpm lint` passes at repo root
- [x] `pnpm build` succeeds
- [ ] `/playground` loads with profit-loss line chart selected (if used locally)