### PR TITLE
feat(web): add community showcase page

### DIFF
--- a/apps/web/app/(home)/showcase/layout.tsx
+++ b/apps/web/app/(home)/showcase/layout.tsx
@@ -1,0 +1,15 @@
+"use client";
+
+import type { ReactNode } from "react";
+import { useEffect } from "react";
+
+export default function ShowcaseLayout({ children }: { children: ReactNode }) {
+  useEffect(() => {
+    document.documentElement.style.scrollbarGutter = "stable";
+    return () => {
+      document.documentElement.style.scrollbarGutter = "";
+    };
+  }, []);
+
+  return <div className="flex flex-1 flex-col">{children}</div>;
+}

--- a/apps/web/app/(home)/showcase/page.tsx
+++ b/apps/web/app/(home)/showcase/page.tsx
@@ -1,0 +1,23 @@
+import type { Metadata } from "next";
+import { ShowcaseGrid } from "@/components/showcase/showcase-grid";
+import { ShowcaseHero } from "@/components/showcase/showcase-hero";
+
+export const metadata: Metadata = {
+  title: "Showcase",
+  description:
+    "Real dashboards and data experiences built with Bklit UI — curated from the community.",
+};
+
+export default function ShowcasePage() {
+  return (
+    <>
+      <section className="flex flex-col items-center px-4 py-18 text-center">
+        <ShowcaseHero />
+      </section>
+
+      <div className="mx-auto w-full max-w-7xl scroll-mt-14 px-6 py-8">
+        <ShowcaseGrid />
+      </div>
+    </>
+  );
+}

--- a/apps/web/components/showcase/showcase-card.tsx
+++ b/apps/web/components/showcase/showcase-card.tsx
@@ -1,0 +1,133 @@
+"use client";
+
+import Link from "fumadocs-core/link";
+import { AnimatePresence, motion, useReducedMotion } from "motion/react";
+import { useEffect, useState } from "react";
+import { Button } from "@/components/ui/button";
+import type { ShowcaseProject } from "@/lib/showcase/projects";
+import { getShowcaseImageTransform } from "@/lib/showcase/transform";
+import { cn } from "@/lib/utils";
+
+const easeOutQuint = [0.23, 1, 0.32, 1] as const;
+const actionEnterDuration = 0.2;
+const actionExitDuration = 0.16;
+
+function ViewProjectAction({
+  visible,
+  reducedMotion,
+}: {
+  visible: boolean;
+  reducedMotion: boolean | null;
+}) {
+  return (
+    <AnimatePresence>
+      {visible && (
+        <motion.div
+          animate={
+            reducedMotion
+              ? { opacity: 1, y: 0 }
+              : {
+                  opacity: 1,
+                  y: 0,
+                  transition: {
+                    duration: actionEnterDuration,
+                    ease: easeOutQuint,
+                  },
+                }
+          }
+          className="pointer-events-none absolute inset-x-0 bottom-4 z-10 flex justify-center"
+          exit={
+            reducedMotion
+              ? undefined
+              : {
+                  opacity: 0,
+                  y: 8,
+                  transition: {
+                    duration: actionExitDuration,
+                    ease: easeOutQuint,
+                  },
+                }
+          }
+          initial={reducedMotion ? false : { opacity: 0, y: 8 }}
+        >
+          <Button size="sm" tabIndex={-1} variant="white">
+            View project
+          </Button>
+        </motion.div>
+      )}
+    </AnimatePresence>
+  );
+}
+
+export function ShowcaseCard({ project }: { project: ShowcaseProject }) {
+  const reducedMotion = useReducedMotion();
+  const [hoverFine, setHoverFine] = useState(false);
+  const [focused, setFocused] = useState(false);
+  const [coarsePointer, setCoarsePointer] = useState(false);
+
+  useEffect(() => {
+    const mq = window.matchMedia("(hover: hover) and (pointer: fine)");
+    const update = () => setCoarsePointer(!mq.matches);
+    update();
+    mq.addEventListener("change", update);
+    return () => mq.removeEventListener("change", update);
+  }, []);
+
+  const showAction =
+    reducedMotion === true || coarsePointer || hoverFine || focused;
+
+  const imageHovered =
+    !reducedMotion && (hoverFine || focused || coarsePointer);
+
+  return (
+    <Link
+      aria-label={`View ${project.title}`}
+      className="group block rounded-xl focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background"
+      external
+      href={project.url}
+      onBlurCapture={(e) => {
+        if (!e.currentTarget.contains(e.relatedTarget)) {
+          setFocused(false);
+        }
+      }}
+      onFocusCapture={() => setFocused(true)}
+      onPointerEnter={() => setHoverFine(true)}
+      onPointerLeave={() => setHoverFine(false)}
+    >
+      <div className="relative overflow-hidden rounded-xl border border-border bg-card">
+        <div className="relative aspect-[4/3] w-full overflow-hidden [perspective:1400px]">
+          {/* biome-ignore lint/performance/noImgElement: external showcase thumbnail */}
+          <img
+            alt={project.imageAlt}
+            className={cn(
+              "absolute inset-0 size-full origin-center object-cover",
+              !reducedMotion &&
+                "transition-transform duration-500 ease-[cubic-bezier(0.23,1,0.32,1)]"
+            )}
+            height={900}
+            src={project.image}
+            style={{
+              transform: reducedMotion
+                ? undefined
+                : getShowcaseImageTransform(imageHovered),
+            }}
+            width={1200}
+          />
+
+          <div className="pointer-events-none absolute inset-0 z-[1] bg-gradient-to-t from-black/50 via-transparent to-black/20" />
+
+          <div className="pointer-events-none absolute inset-x-0 top-0 z-[1] p-4">
+            <p className="font-medium text-sm text-white drop-shadow-sm">
+              {project.title}
+            </p>
+          </div>
+
+          <ViewProjectAction
+            reducedMotion={reducedMotion}
+            visible={showAction}
+          />
+        </div>
+      </div>
+    </Link>
+  );
+}

--- a/apps/web/components/showcase/showcase-grid.tsx
+++ b/apps/web/components/showcase/showcase-grid.tsx
@@ -1,0 +1,14 @@
+import { ShowcaseCard } from "@/components/showcase/showcase-card";
+import { ShowcaseSubmitCard } from "@/components/showcase/showcase-submit-card";
+import { showcaseProjects } from "@/lib/showcase/projects";
+
+export function ShowcaseGrid() {
+  return (
+    <div className="grid grid-cols-3 gap-4">
+      {showcaseProjects.map((project) => (
+        <ShowcaseCard key={project.url} project={project} />
+      ))}
+      <ShowcaseSubmitCard />
+    </div>
+  );
+}

--- a/apps/web/components/showcase/showcase-hero.tsx
+++ b/apps/web/components/showcase/showcase-hero.tsx
@@ -1,0 +1,35 @@
+"use client";
+
+import Link from "fumadocs-core/link";
+import {
+  HeroActions,
+  HeroDescription,
+  HeroShell,
+  HeroTitle,
+} from "@/components/hero";
+import { Button } from "@/components/ui/button";
+import { showcaseSubmitUrl } from "@/lib/showcase/constants";
+
+export function ShowcaseHero() {
+  return (
+    <HeroShell>
+      <HeroTitle>Showcase</HeroTitle>
+
+      <HeroDescription>
+        Real dashboards and data experiences built with Bklit UI — curated from
+        the community.
+      </HeroDescription>
+
+      <HeroActions>
+        <Button
+          nativeButton={false}
+          render={<Link external href={showcaseSubmitUrl} />}
+          size="lg"
+          variant="white"
+        >
+          Submit yours
+        </Button>
+      </HeroActions>
+    </HeroShell>
+  );
+}

--- a/apps/web/components/showcase/showcase-submit-card.tsx
+++ b/apps/web/components/showcase/showcase-submit-card.tsx
@@ -1,0 +1,31 @@
+"use client";
+
+import Link from "fumadocs-core/link";
+import { Button } from "@/components/ui/button";
+import { showcaseSubmitUrl } from "@/lib/showcase/constants";
+import { cn } from "@/lib/utils";
+
+export function ShowcaseSubmitCard({ className }: { className?: string }) {
+  return (
+    <Link
+      aria-label="Submit your project to the showcase"
+      className={cn(
+        "group block rounded-xl focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background",
+        className
+      )}
+      external
+      href={showcaseSubmitUrl}
+    >
+      <div className="flex aspect-[4/3] flex-col items-center justify-center rounded-xl border border-border border-dashed bg-card/40 p-4 transition-colors hover:border-foreground/20 hover:bg-card/70">
+        <Button
+          className="opacity-50 transition-opacity group-hover:opacity-100 group-focus-visible:opacity-100"
+          size="sm"
+          tabIndex={-1}
+          variant="outline"
+        >
+          Submit yours
+        </Button>
+      </div>
+    </Link>
+  );
+}

--- a/apps/web/lib/is-new-nav-link.ts
+++ b/apps/web/lib/is-new-nav-link.ts
@@ -1,3 +1,3 @@
 export function isNewNavLink(url: string) {
-  return url === "/studio" || url === "/docs/skills";
+  return url === "/studio" || url === "/docs/skills" || url === "/showcase";
 }

--- a/apps/web/lib/showcase/constants.ts
+++ b/apps/web/lib/showcase/constants.ts
@@ -1,0 +1,2 @@
+export const showcaseSubmitUrl =
+  "https://github.com/bklit/bklit-ui/discussions/82";

--- a/apps/web/lib/showcase/projects.ts
+++ b/apps/web/lib/showcase/projects.ts
@@ -1,0 +1,16 @@
+export interface ShowcaseProject {
+  title: string;
+  url: string;
+  image: string;
+  imageAlt: string;
+}
+
+export const showcaseProjects: ShowcaseProject[] = [
+  {
+    title: "Chánh Đại",
+    url: "https://chanhdai.com",
+    image:
+      "https://github.com/user-attachments/assets/b4fdc21a-2b8f-465b-9eb4-11f03f3a9fd0",
+    imageAlt: "Chánh Đại portfolio",
+  },
+];

--- a/apps/web/lib/showcase/transform.ts
+++ b/apps/web/lib/showcase/transform.ts
@@ -1,0 +1,14 @@
+const showcaseImageTransform = {
+  rotateX: 30,
+  rotateY: -5,
+  rotateZ: -15,
+  scale: 1.5,
+} as const;
+
+const showcaseHoverScale = 1.6;
+
+export function getShowcaseImageTransform(hovered: boolean): string {
+  const scale = hovered ? showcaseHoverScale : showcaseImageTransform.scale;
+
+  return `rotateX(${showcaseImageTransform.rotateX}deg) rotateY(${showcaseImageTransform.rotateY}deg) rotateZ(${showcaseImageTransform.rotateZ}deg) scale(${scale})`;
+}

--- a/apps/web/lib/site-nav-links.ts
+++ b/apps/web/lib/site-nav-links.ts
@@ -2,7 +2,7 @@ export const siteNavLinks = [
   { text: "Docs", url: "/docs/installation" },
   { text: "Components", url: "/docs/components" },
   { text: "Blocks", url: "/blocks" },
-  { text: "Theming", url: "/docs/theming" },
+  { text: "Showcase", url: "/showcase" },
   { text: "Charts", url: "/charts" },
   { text: "Studio", url: "/studio" },
   { text: "Skills", url: "/docs/skills" },


### PR DESCRIPTION
## Summary

- Add `/showcase` with a hero, 3-column project grid, and submit CTA card linking to GitHub Discussion #82
- Replace **Theming** with **Showcase** in shared site navigation (desktop and mobile)
- Showcase cards apply a fixed 3D tilt to project images (30° / −5° / −15°, scale 1.5 → 1.6 on hover) with title and button overlays unaffected

## Test plan

- [x] `pnpm lint` passes at repo root
- [x] `apps/web` production build succeeds
- [ ] Visit `/showcase` — hero, Chánh Đại card, and submit CTA render in a 3-column grid
- [ ] Confirm nav shows Showcase (with new dot) instead of Theming on home, docs, and studio
- [ ] Hover a project card — image scales to 1.6×, “View project” button appears; title stays flat