### PR TITLE
fix(web): prefer canonical ui domain for crawlers

### DIFF
--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -8,6 +8,7 @@ import { Geist, Geist_Mono, Inter } from "next/font/google";
 import type { ReactNode } from "react";
 import { DocsSearchDialog } from "@/components/docs/docs-search-dialog";
 import { getOpenPanelClientId } from "@/lib/openpanel-env";
+import { SITE_URL } from "@/lib/site-url";
 import { cn } from "@/lib/utils";
 
 const inter = Inter({ subsets: ["latin"], variable: "--font-sans" });
@@ -23,6 +24,7 @@ const geistHeading = Geist({
 });
 
 export const metadata: Metadata = {
+  metadataBase: new URL(SITE_URL),
   title: {
     default: "Bklit UI - Charts & Data Visualization Components",
     template: "%s | Bklit UI",
@@ -34,7 +36,7 @@ export const metadata: Metadata = {
     description:
       "Bklit UI is a component library built on top of shadcn/ui to help you build charts and data visualizations more easily.",
     type: "website",
-    url: "https://ui.bklit.com",
+    url: SITE_URL,
   },
   twitter: {
     card: "summary_large_image",

--- a/apps/web/app/robots.ts
+++ b/apps/web/app/robots.ts
@@ -1,0 +1,13 @@
+import type { MetadataRoute } from "next";
+import { SITE_URL } from "@/lib/site-url";
+
+export default function robots(): MetadataRoute.Robots {
+  return {
+    rules: {
+      userAgent: "*",
+      allow: "/",
+    },
+    sitemap: `${SITE_URL}/sitemap.xml`,
+    host: SITE_URL,
+  };
+}

--- a/apps/web/middleware.ts
+++ b/apps/web/middleware.ts
@@ -1,4 +1,4 @@
-import { NextResponse, type NextRequest } from "next/server";
+import { type NextRequest, NextResponse } from "next/server";
 import { SITE_URL } from "@/lib/site-url";
 
 const canonicalUrl = new URL(SITE_URL);

--- a/apps/web/middleware.ts
+++ b/apps/web/middleware.ts
@@ -5,7 +5,9 @@ const canonicalUrl = new URL(SITE_URL);
 const CANONICAL_HOST = canonicalUrl.host;
 
 export function middleware(request: NextRequest) {
-  const requestHost = request.nextUrl.host.toLowerCase();
+  const requestHost = (
+    request.headers.get("host") ?? request.nextUrl.host
+  ).toLowerCase();
   const canonicalHost = CANONICAL_HOST.toLowerCase();
 
   if (

--- a/apps/web/middleware.ts
+++ b/apps/web/middleware.ts
@@ -1,0 +1,37 @@
+import { NextResponse, type NextRequest } from "next/server";
+import { SITE_URL } from "@/lib/site-url";
+
+const canonicalUrl = new URL(SITE_URL);
+const CANONICAL_HOST = canonicalUrl.host;
+
+export function middleware(request: NextRequest) {
+  const requestHost = request.nextUrl.host.toLowerCase();
+  const canonicalHost = CANONICAL_HOST.toLowerCase();
+
+  if (
+    process.env.VERCEL_ENV === "production" &&
+    requestHost !== canonicalHost &&
+    requestHost.endsWith(".vercel.app")
+  ) {
+    const redirectUrl = request.nextUrl.clone();
+    redirectUrl.protocol = canonicalUrl.protocol;
+    redirectUrl.host = CANONICAL_HOST;
+    redirectUrl.port = "";
+
+    return NextResponse.redirect(redirectUrl, 308);
+  }
+
+  const response = NextResponse.next();
+  const canonicalPageUrl = new URL(request.nextUrl.pathname, SITE_URL);
+  response.headers.set("Link", `<${canonicalPageUrl.href}>; rel="canonical"`);
+
+  return response;
+}
+
+export const config = {
+  matcher: [
+    "/((?!api|_next/static|_next/image|favicon.ico|.*\\..*).*)",
+    "/robots.txt",
+    "/sitemap.xml",
+  ],
+};


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Adds canonical-site metadata based on the shared `SITE_URL` constant.
- Redirects production `*.vercel.app` page requests to `https://ui.bklit.com` with a permanent redirect while preserving paths and query strings.
- Adds a robots route that points crawlers at the canonical sitemap.

## Test plan

- [x] `pnpm lint`
- [x] `pnpm --filter web check-types`
- [x] `VERCEL_ENV=production pnpm --filter web build`
- [x] `pnpm --filter web build`
- [x] Smoke-tested `Host: bklit-ui.vercel.app` returns `308` to `https://ui.bklit.com/docs/installation?utm_source=test`.
- [x] Smoke-tested canonical host returns `200` with `Link: <https://ui.bklit.com/docs/installation>; rel="canonical"`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0d6163d8-c4cb-48c2-b560-121a3cd7985a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0d6163d8-c4cb-48c2-b560-121a3cd7985a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

