### PR TITLE
fix(docs): improve manual tab file header contrast

### DIFF
--- a/apps/web/components/docs/installation-tabs.tsx
+++ b/apps/web/components/docs/installation-tabs.tsx
@@ -48,12 +48,14 @@ function CodeFileBlock({
       open={isOpen}
     >
       {/* Header with filename */}
-      <div className="flex items-center justify-between border-border border-b bg-muted/40 px-4 py-2">
+      <div className="relative z-10 flex items-center justify-between border-border border-b bg-muted/20 px-4 py-2">
         <div className="flex items-center gap-2">
-          <span className="font-mono text-muted-foreground text-xs">TS</span>
-          <span className="font-mono text-sm">{file.target}</span>
+          <span className="font-mono text-foreground/70 text-xs">TS</span>
+          <span className="font-mono text-foreground text-sm">
+            {file.target}
+          </span>
         </div>
-        <CollapsibleTrigger className="font-medium text-muted-foreground text-xs hover:text-foreground">
+        <CollapsibleTrigger className="font-medium text-foreground/70 text-xs hover:text-foreground">
           {isOpen ? "Collapse" : "Expand"}
         </CollapsibleTrigger>
       </div>


### PR DESCRIPTION
### Summary:

Improves readability of the file header shown in the Manual tab of the docs installation tabs. The filename and TS label were hard to read against the code block; this bumps contrast, softens the header background, and lifts the header above sibling layers.

### Changes

`apps/web/components/docs/installation-tabs.tsx`

- Header wrapper: `relative z-10`, bg `muted/40` → `muted/20`
- TS label + trigger: `text-muted-foreground` → `text-foreground/70`
- Filename: now uses `text-foreground` for full contrast

### Before / After

| Before | After |
| --- | --- |
| <img width="100%" alt="Before" src="https://github.com/user-attachments/assets/bfd384b5-aa38-4280-904c-7b2a1ccd4a8f" /> | <img width="100%" alt="After" src="https://github.com/user-attachments/assets/0a3c8640-93b3-4bc7-a5f0-a7af2dac2653" /> |
