### PR TITLE
fix(studio): oklch-only fill picker for theme colors

### DIFF
--- a/packages/studio/src/components/controls/fill-picker.tsx
+++ b/packages/studio/src/components/controls/fill-picker.tsx
@@ -15,25 +15,20 @@ import { PresetSwatch } from "@/components/controls/preset-select";
 import { StudioColorPicker } from "@/components/controls/studio-color-picker";
 import { StudioSingleToggleGroup } from "@/components/controls/studio-toggle-group";
 import {
-  isValidOklchColor,
   parseColorMix,
   parseOpacityFromColor,
   resolveCssColor,
-  stripOklchWrapper,
 } from "@/lib/chart-theme-color";
 import { COLOR_PRESETS, type ColorPresetId } from "@/lib/color-presets";
 import type { PatternPresetId } from "@/lib/pattern-presets";
-import { studioColorHexField } from "@/lib/studio-color-picker-value";
+import { studioColorToOklchField } from "@/lib/studio-color-picker-value";
 import type { SeriesFillMode } from "@/lib/studio-series-design";
 import { Popover, PopoverContent, PopoverTrigger } from "@/ui/popover";
 import { ToggleGroupItem } from "@/ui/toggle-group";
 
 function formatTriggerLabel(color: string): string {
-  if (isValidOklchColor(color)) {
-    const body = stripOklchWrapper(color);
-    return `oklch(${body})`;
-  }
-  return studioColorHexField(color);
+  const body = studioColorToOklchField(color);
+  return body ? `oklch(${body})` : color;
 }
 
 export function FillPicker({

--- a/packages/studio/src/components/controls/studio-color-picker.tsx
+++ b/packages/studio/src/components/controls/studio-color-picker.tsx
@@ -5,37 +5,17 @@ import { useEffect, useState } from "react";
 import type { Color } from "react-aria-components";
 import { ColorPicker as AriaColorPicker } from "react-aria-components";
 import { studioInputSurfaceClass } from "@/components/controls/control-field-helpers";
-import {
-  applyOpacityToColor,
-  isValidOklchColor,
-  normalizeColorInput,
-  parseColorMix,
-} from "@/lib/chart-theme-color";
+import { isValidOklchColor, parseColorMix } from "@/lib/chart-theme-color";
 import {
   pickerColorToStudioColor,
-  studioColorHexField,
   studioColorToOklchField,
   studioColorToPickerColor,
-  studioColorUsesOklchInput,
 } from "@/lib/studio-color-picker-value";
 import { ColorArea } from "@/ui/color-picker/color-area";
 import { ColorSlider } from "@/ui/color-picker/color-slider";
 
-type ColorInputMode = "hex" | "oklch";
-
 const OKLCH_PREFIX_RE = /^oklch\(/i;
 const OKLCH_COMPONENTS_BODY_RE = /^[\d.]+\s+[\d.]+\s+[\d.]+/;
-
-function colorInputMode(color: string): ColorInputMode {
-  return studioColorUsesOklchInput(color) ? "oklch" : "hex";
-}
-
-function formatInputField(color: string, mode: ColorInputMode): string {
-  if (mode === "oklch") {
-    return studioColorToOklchField(color);
-  }
-  return studioColorHexField(color);
-}
 
 function commitOklchDraft(
   raw: string,
@@ -73,47 +53,25 @@ export function StudioColorPicker({
   disabled?: boolean;
   onChange: (value: string) => void;
 }) {
-  const [inputMode, setInputMode] = useState<ColorInputMode>(() =>
-    colorInputMode(color)
-  );
-  const [draft, setDraft] = useState(() =>
-    formatInputField(color, colorInputMode(color))
-  );
+  const [draft, setDraft] = useState(() => studioColorToOklchField(color));
   const [pickerColor, setPickerColor] = useState(() =>
     studioColorToPickerColor(color)
   );
 
   useEffect(() => {
-    const mode = colorInputMode(color);
-    setInputMode(mode);
-    setDraft(formatInputField(color, mode));
+    setDraft(studioColorToOklchField(color));
     setPickerColor(studioColorToPickerColor(color));
   }, [color]);
 
-  const commitPickerColor = (next: Color, mode: ColorInputMode = inputMode) => {
+  const commitPickerColor = (next: Color) => {
     setPickerColor(next);
-    const studioColor = pickerColorToStudioColor(next, mode);
+    const studioColor = pickerColorToStudioColor(next);
     onChange(studioColor);
-    if (mode === "hex") {
-      setDraft(next.toString("hex").replace("#", "").toUpperCase());
-    } else {
-      setDraft(formatInputField(studioColor, mode));
-    }
-    setInputMode(mode);
+    setDraft(studioColorToOklchField(studioColor));
   };
 
-  const commitDraft = (raw: string, mode: ColorInputMode) => {
-    if (mode === "oklch") {
-      commitOklchDraft(raw, pickerColor, onChange);
-      return;
-    }
-
-    const normalized = normalizeColorInput(raw);
-    if (!normalized) {
-      return;
-    }
-    const opacity = Math.round(pickerColor.getChannelValue("alpha") * 100);
-    onChange(applyOpacityToColor(normalized, opacity));
+  const commitDraft = (raw: string) => {
+    commitOklchDraft(raw, pickerColor, onChange);
   };
 
   const opacity = Math.round(pickerColor.getChannelValue("alpha") * 100);
@@ -137,41 +95,23 @@ export function StudioColorPicker({
         </div>
 
         <div className="flex items-center gap-1.5">
-          <div className="flex rounded-md border border-input p-0.5">
-            {(["hex", "oklch"] as const).map((mode) => (
-              <button
-                className={cn(
-                  "rounded px-2 py-1 font-medium text-[10px] uppercase tracking-wide transition-colors",
-                  inputMode === mode
-                    ? "bg-muted text-foreground"
-                    : "text-muted-foreground hover:text-foreground"
-                )}
-                disabled={disabled}
-                key={mode}
-                onClick={() => {
-                  setInputMode(mode);
-                  setDraft(formatInputField(color, mode));
-                }}
-                type="button"
-              >
-                {mode}
-              </button>
-            ))}
-          </div>
+          <span className="shrink-0 px-1 font-medium text-[10px] text-muted-foreground uppercase tracking-wide">
+            oklch
+          </span>
           <input
             className={cn(
               "h-8 min-w-0 flex-1 rounded-md px-2 font-mono text-foreground text-xs outline-none focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50",
               studioInputSurfaceClass
             )}
             disabled={disabled}
-            onBlur={() => commitDraft(draft, inputMode)}
+            onBlur={() => commitDraft(draft)}
             onChange={(event) => setDraft(event.target.value)}
             onKeyDown={(event) => {
               if (event.key === "Enter") {
-                commitDraft(draft, inputMode);
+                commitDraft(draft);
               }
             }}
-            placeholder={inputMode === "hex" ? "000000" : "0.84 0.18 128"}
+            placeholder="0.865 0.127 207"
             value={draft}
           />
           <input
@@ -212,5 +152,3 @@ export function StudioColorPicker({
     </AriaColorPicker>
   );
 }
-
-export { colorInputMode };

--- a/packages/studio/src/lib/__tests__/chart-theme-color.test.ts
+++ b/packages/studio/src/lib/__tests__/chart-theme-color.test.ts
@@ -1,0 +1,62 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import {
+  applyOpacityToColor,
+  isValidOklchColor,
+  oklchBodyFromColor,
+  resolveStudioColorForPicker,
+  srgbBytesToOklchBody,
+} from "../chart-theme-color";
+
+const HEX_PARSEABLE_RE = /^#[0-9A-F]{6}$/;
+
+describe("resolveStudioColorForPicker", () => {
+  it("keeps oklch palette colors parseable for the picker", () => {
+    const color = "oklch(0.865 0.127 207.078)";
+    const resolved = resolveStudioColorForPicker(color);
+
+    assert.match(resolved.parseable, HEX_PARSEABLE_RE);
+    assert.equal(resolved.opacity, 100);
+    assert.equal(isValidOklchColor(color), true);
+  });
+
+  it("preserves opacity from color-mix values", () => {
+    const resolved = resolveStudioColorForPicker(
+      "color-mix(in oklch, oklch(0.865 0.127 207.078) 40%, transparent)"
+    );
+
+    assert.match(resolved.parseable, HEX_PARSEABLE_RE);
+    assert.equal(resolved.opacity, 40);
+  });
+
+  it("returns hex parseable values for hex inputs", () => {
+    const resolved = resolveStudioColorForPicker("#336699");
+
+    assert.equal(resolved.parseable, "#336699");
+    assert.equal(resolved.opacity, 100);
+  });
+});
+
+describe("applyOpacityToColor", () => {
+  it("applies alpha to oklch colors", () => {
+    assert.equal(
+      applyOpacityToColor("oklch(0.865 0.127 207.078)", 40),
+      "oklch(0.865 0.127 207.078 / 0.4)"
+    );
+  });
+});
+
+describe("oklchBodyFromColor", () => {
+  it("preserves Mist chart-1 oklch tokens", () => {
+    assert.equal(
+      oklchBodyFromColor("oklch(0.865 0.127 207.078)"),
+      "0.865 0.127 207.078"
+    );
+  });
+});
+
+describe("srgbBytesToOklchBody", () => {
+  it("converts srgb bytes to oklch components", () => {
+    assert.equal(srgbBytesToOklchBody(51, 102, 153), "0.499 0.099 250.433");
+  });
+});

--- a/packages/studio/src/lib/chart-theme-color.ts
+++ b/packages/studio/src/lib/chart-theme-color.ts
@@ -9,13 +9,16 @@ const HEX6_RE = /^[0-9a-f]{6}$/i;
 const OKLCH_RE = /^oklch\(/i;
 const OKLCH_OPEN_WS_RE = /^oklch\(\s*/i;
 const OKLCH_CLOSE_RE = /\)\s*$/;
-const OKLCH_CLOSE_SIMPLE_RE = /\)$/;
 const OKLCH_ALPHA_SUFFIX_RE = /\/\s*[\d.]+%?\s*$/;
+const HEX6_PAIR_RE = /^(..)(..)(..)$/;
 const CSS_VAR_RE = /var\((--[^,)]+)/;
 const OKLCH_INLINE_OPACITY_RE = /\/\s*([\d.]+%?)\s*\)/;
 const COLOR_MIX_RE =
   /^color-mix\(\s*in\s+[\w-]+\s*,\s*(.+?)\s+([\d.]+)%\s*,\s*transparent\s*\)$/i;
 const OKLCH_COMPONENTS_RE = /^[\d.]+\s+[\d.]+\s+[\d.]+/;
+const RGB_COLOR_RE = /^rgba?\(\s*(\d+)[,\s]+(\d+)[,\s]+(\d+)/;
+const SRGB_COLOR_RE = /^color\(srgb\s+([\d.]+)\s+([\d.]+)\s+([\d.]+)/;
+const LAB_COLOR_RE = /^lab\(/i;
 
 export function stripOklchWrapper(value: string): string {
   return value.replace(OKLCH_RE, "").replace(OKLCH_CLOSE_RE, "");
@@ -82,44 +85,169 @@ export function resolveStudioColorForPicker(
   }
 
   const opacity = parseOpacityFromColor(value);
-  const normalized = normalizeColorInput(value);
 
-  if (normalized?.startsWith("#")) {
-    return { parseable: normalized, opacity };
-  }
-
-  if (normalized && isValidOklchColor(normalized)) {
-    return { parseable: `#${cssColorToHex(normalized)}`, opacity };
+  if (value.startsWith("#")) {
+    return { parseable: value, opacity };
   }
 
   return { parseable: `#${cssColorToHex(value)}`, opacity };
 }
-
-export function normalizeColorInput(raw: string): string | null {
-  const value = raw.trim();
-  if (!value) {
-    return null;
-  }
-  if (isOklchColor(value)) {
-    return isValidOklchColor(value) ? value : null;
-  }
-  if (value.startsWith("#")) {
-    const hex = value.slice(1);
-    return HEX6_RE.test(hex) ? `#${hex.toLowerCase()}` : null;
-  }
-  if (HEX6_RE.test(value)) {
-    return `#${value.toLowerCase()}`;
-  }
-  return null;
-}
-
-const RGB_COLOR_RE = /^rgba?\(\s*(\d+)[,\s]+(\d+)[,\s]+(\d+)/;
 
 function rgbComponentsToHex(r: number, g: number, b: number): string {
   return [r, g, b]
     .map((n) => Math.min(255, Math.max(0, n)).toString(16).padStart(2, "0"))
     .join("")
     .toUpperCase();
+}
+
+function srgbChannelToLinear(channel: number): number {
+  const normalized = channel / 255;
+  return normalized <= 0.040_45
+    ? normalized / 12.92
+    : ((normalized + 0.055) / 1.055) ** 2.4;
+}
+
+function formatOklchComponent(value: number): string {
+  return Number(value.toFixed(3)).toString();
+}
+
+export function srgbBytesToOklchBody(r: number, g: number, b: number): string {
+  const red = srgbChannelToLinear(r);
+  const green = srgbChannelToLinear(g);
+  const blue = srgbChannelToLinear(b);
+
+  const long =
+    0.412_221_470_8 * red + 0.536_332_536_3 * green + 0.051_445_992_9 * blue;
+  const medium =
+    0.211_903_498_2 * red + 0.680_699_545_1 * green + 0.107_396_956_6 * blue;
+  const short =
+    0.088_302_461_9 * red + 0.281_718_837_6 * green + 0.629_978_700_5 * blue;
+
+  const longRoot = Math.cbrt(long);
+  const mediumRoot = Math.cbrt(medium);
+  const shortRoot = Math.cbrt(short);
+
+  const lightness =
+    0.210_454_255_3 * longRoot +
+    0.793_617_785 * mediumRoot -
+    0.004_072_046_8 * shortRoot;
+  const a =
+    1.977_998_495_1 * longRoot -
+    2.428_592_205 * mediumRoot +
+    0.450_593_709_9 * shortRoot;
+  const bLab =
+    0.025_904_037_1 * longRoot +
+    0.782_771_766_2 * mediumRoot -
+    0.808_675_766 * shortRoot;
+
+  const chroma = Math.sqrt(a * a + bLab * bLab);
+  let hue = (Math.atan2(bLab, a) * 180) / Math.PI;
+  if (hue < 0) {
+    hue += 360;
+  }
+
+  return `${formatOklchComponent(lightness)} ${formatOklchComponent(chroma)} ${formatOklchComponent(hue)}`;
+}
+
+function browserOklchFromCssColor(color: string): string | null {
+  if (typeof document === "undefined") {
+    return null;
+  }
+
+  const trimmed = color.trim();
+  if (!trimmed || isValidOklchColor(trimmed)) {
+    return trimmed || null;
+  }
+
+  const probe = document.createElement("span");
+  probe.hidden = true;
+  document.documentElement.appendChild(probe);
+
+  try {
+    if (LAB_COLOR_RE.test(trimmed) || trimmed.startsWith("rgb")) {
+      probe.style.color = `oklch(from ${trimmed} l c h)`;
+    } else {
+      probe.style.color = trimmed;
+    }
+
+    const computed = getComputedStyle(probe).color.trim();
+    return isValidOklchColor(computed) ? computed : null;
+  } finally {
+    probe.remove();
+  }
+}
+
+function normalizeResolvedCssColor(color: string): string {
+  return browserOklchFromCssColor(color) ?? color;
+}
+
+export function oklchBodyFromColor(color: string): string | null {
+  const resolved = unwrapStudioColorValue(
+    normalizeResolvedCssColor(resolveCssColor(color.trim()))
+  );
+  if (isValidOklchColor(resolved)) {
+    return stripOklchAlphaSuffix(stripOklchWrapper(resolved));
+  }
+
+  const mix = parseColorMix(resolved);
+  if (mix) {
+    return oklchBodyFromColor(mix.base);
+  }
+
+  if (typeof document === "undefined") {
+    return null;
+  }
+
+  const hex = cssColorToHex(resolved);
+  const match = hex.match(HEX6_PAIR_RE);
+  if (!(match?.[1] && match[2] && match[3])) {
+    return null;
+  }
+
+  return srgbBytesToOklchBody(
+    Number.parseInt(match[1], 16),
+    Number.parseInt(match[2], 16),
+    Number.parseInt(match[3], 16)
+  );
+}
+
+function cssColorToRgbBytes(color: string): [number, number, number] | null {
+  if (typeof document === "undefined") {
+    return null;
+  }
+
+  const probe = document.createElement("span");
+  probe.hidden = true;
+  document.documentElement.appendChild(probe);
+
+  try {
+    const source = normalizeResolvedCssColor(color);
+    probe.style.color = source;
+    let computed = getComputedStyle(probe).color.trim();
+
+    if (isValidOklchColor(computed) || LAB_COLOR_RE.test(computed)) {
+      probe.style.color = `color(from ${computed} srgb r g b)`;
+      computed = getComputedStyle(probe).color.trim();
+    }
+
+    const rgbMatch = computed.match(RGB_COLOR_RE);
+    if (rgbMatch?.[1] && rgbMatch[2] && rgbMatch[3]) {
+      return [Number(rgbMatch[1]), Number(rgbMatch[2]), Number(rgbMatch[3])];
+    }
+
+    const srgbMatch = computed.match(SRGB_COLOR_RE);
+    if (srgbMatch?.[1] && srgbMatch[2] && srgbMatch[3]) {
+      return [
+        Math.round(Number(srgbMatch[1]) * 255),
+        Math.round(Number(srgbMatch[2]) * 255),
+        Math.round(Number(srgbMatch[3]) * 255),
+      ];
+    }
+
+    return null;
+  } finally {
+    probe.remove();
+  }
 }
 
 export function cssColorToHex(color: string): string {
@@ -141,23 +269,12 @@ export function cssColorToHex(color: string): string {
   const resolved = trimmed.includes("var(")
     ? resolveCssColor(trimmed)
     : trimmed;
-  const probe = document.createElement("span");
-  probe.hidden = true;
-  probe.style.color = resolved;
-  document.documentElement.appendChild(probe);
-  const computed = getComputedStyle(probe).color;
-  probe.remove();
-
-  const match = computed.match(RGB_COLOR_RE);
-  if (!(match?.[1] && match[2] && match[3])) {
+  const bytes = cssColorToRgbBytes(resolved);
+  if (!bytes) {
     return "000000";
   }
 
-  return rgbComponentsToHex(
-    Number(match[1]),
-    Number(match[2]),
-    Number(match[3])
-  );
+  return rgbComponentsToHex(bytes[0], bytes[1], bytes[2]);
 }
 
 export function resolveCssColor(color: string): string {
@@ -173,7 +290,7 @@ export function resolveCssColor(color: string): string {
   const value = getComputedStyle(document.documentElement)
     .getPropertyValue(match[1])
     .trim();
-  return value || color;
+  return normalizeResolvedCssColor(value || color);
 }
 
 export function getEffectiveChartAccent(
@@ -213,14 +330,11 @@ export function parseOpacityFromColor(color: string): number {
 export function applyOpacityToColor(color: string, opacity: number): string {
   const alpha = Math.min(100, Math.max(0, opacity)) / 100;
   const trimmed = unwrapStudioColorValue(color.trim());
-  if (isValidOklchColor(trimmed)) {
-    const body = stripOklchWrapper(trimmed).replace(OKLCH_CLOSE_SIMPLE_RE, "");
-    const withoutAlpha = stripOklchAlphaSuffix(body);
-    return `oklch(${withoutAlpha} / ${alpha})`;
+  const body = oklchBodyFromColor(trimmed);
+
+  if (body) {
+    return alpha >= 0.999 ? `oklch(${body})` : `oklch(${body} / ${alpha})`;
   }
-  const hex = normalizeColorInput(trimmed);
-  if (!hex) {
-    return trimmed;
-  }
-  return `color-mix(in oklch, ${hex} ${Math.round(alpha * 100)}%, transparent)`;
+
+  return `color-mix(in oklch, ${trimmed} ${Math.round(alpha * 100)}%, transparent)`;
 }

--- a/packages/studio/src/lib/studio-color-picker-value.ts
+++ b/packages/studio/src/lib/studio-color-picker-value.ts
@@ -1,12 +1,10 @@
 import type { Color } from "react-aria-components";
 import { parseColor } from "react-aria-components";
 import {
-  applyOpacityToColor,
   cssColorToHex,
-  isValidOklchColor,
+  oklchBodyFromColor,
   resolveStudioColorForPicker,
-  stripOklchAlphaSuffix,
-  stripOklchWrapper,
+  srgbBytesToOklchBody,
 } from "@/lib/chart-theme-color";
 
 export function studioColorToPickerColor(color: string): Color {
@@ -25,59 +23,18 @@ export function studioColorToPickerColor(color: string): Color {
   return parsed.withChannelValue("alpha", opacity / 100);
 }
 
-export function pickerColorToStudioColor(
-  color: Color,
-  inputMode: "hex" | "oklch"
-): string {
+export function pickerColorToStudioColor(color: Color): string {
   const opacity = Math.round(color.getChannelValue("alpha") * 100);
+  const alpha = opacity / 100;
+  const body = srgbBytesToOklchBody(
+    color.getChannelValue("red"),
+    color.getChannelValue("green"),
+    color.getChannelValue("blue")
+  );
 
-  if (inputMode === "oklch") {
-    try {
-      const css = color.toString("css");
-      if (opacity >= 100) {
-        return css;
-      }
-      if (css.startsWith("oklch(")) {
-        const body = stripOklchWrapper(css);
-        const withoutAlpha = stripOklchAlphaSuffix(body);
-        return `oklch(${withoutAlpha} / ${opacity / 100})`;
-      }
-      return applyOpacityToColor(css, opacity);
-    } catch {
-      // Fall through to hex when oklch conversion is unavailable.
-    }
-  }
-
-  const hex = color.toString("hex");
-  return applyOpacityToColor(hex.startsWith("#") ? hex : `#${hex}`, opacity);
+  return alpha >= 0.999 ? `oklch(${body})` : `oklch(${body} / ${alpha})`;
 }
 
 export function studioColorToOklchField(color: string): string {
-  if (isValidOklchColor(color)) {
-    const body = stripOklchWrapper(color);
-    return stripOklchAlphaSuffix(body);
-  }
-
-  try {
-    const parsed = studioColorToPickerColor(color);
-    const css = parsed.toString("css");
-    if (css.startsWith("oklch(")) {
-      return stripOklchWrapper(css);
-    }
-  } catch {
-    // Fall through to hex display.
-  }
-  return cssColorToHex(color);
-}
-
-export function studioColorHexField(color: string): string {
-  const { parseable } = resolveStudioColorForPicker(color);
-  if (parseable.startsWith("#")) {
-    return parseable.slice(1).toUpperCase();
-  }
-  return cssColorToHex(parseable);
-}
-
-export function studioColorUsesOklchInput(color: string): boolean {
-  return isValidOklchColor(color);
+  return oklchBodyFromColor(color) ?? "";
 }


### PR DESCRIPTION
## Summary

- Remove hex mode from the studio color picker and fill trigger labels; colors are displayed and stored as oklch.
- Resolve CSS theme variables (`var(--chart-1)`) through browser lab/oklch conversion so the Mist default shows `oklch(0.865 0.127 207.078)` on load instead of hex or black.
- Add oklch conversion helpers and unit tests for theme color resolution.

## Test plan

- [x] `pnpm lint` passes at repo root
- [x] `pnpm build` succeeds
- [x] `pnpm --filter @bklitui/studio test` passes
- [x] Open `/studio` with Mist (default) preset — fill trigger and picker input show oklch values
- [ ] Pick a new color and confirm chart updates while URL/state stores oklch