### PR TITLE
Standardize studio components panel icons with Hugeicons

### DIFF
--- a/packages/studio/src/components/chart-type-icons.tsx
+++ b/packages/studio/src/components/chart-type-icons.tsx
@@ -20,7 +20,7 @@ import {
 import { HugeiconsIcon, type IconSvgElement } from "@hugeicons/react";
 import type { ChartSlug } from "@/lib/types";
 
-const CHART_TYPE_ICONS: Record<ChartSlug, IconSvgElement> = {
+export const CHART_TYPE_ICONS: Record<ChartSlug, IconSvgElement> = {
   "area-chart": ChartAreaIcon,
   "bar-chart": BarChartIcon,
   "line-chart": ChartLineData01Icon,
@@ -37,6 +37,10 @@ const CHART_TYPE_ICONS: Record<ChartSlug, IconSvgElement> = {
   "choropleth-chart": GlobeIcon,
   "sankey-chart": Flowchart02Icon,
 };
+
+export function getChartTypeIcon(slug: ChartSlug): IconSvgElement {
+  return CHART_TYPE_ICONS[slug];
+}
 
 export function ChartTypeIcon({
   slug,

--- a/packages/studio/src/components/studio-components-panel.tsx
+++ b/packages/studio/src/components/studio-components-panel.tsx
@@ -1,21 +1,12 @@
 "use client";
 
 import { cn } from "@bklitui/ui/lib/utils";
-import {
-  BarChart3Icon,
-  ChartPieIcon,
-  CircleDotIcon,
-  DatabaseIcon,
-  EyeIcon,
-  EyeOffIcon,
-  FilterIcon,
-  LayersIcon,
-  LineChartIcon,
-  TypeIcon,
-} from "lucide-react";
+import { HugeiconsIcon } from "@hugeicons/react";
+import { EyeIcon, EyeOffIcon } from "lucide-react";
 import { StudioControlGroup } from "@/components/studio-control-group";
 import { StudioScrambleDataButton } from "@/components/studio-scramble-data-button";
 import { resolveCssColor } from "@/lib/chart-theme-color";
+import { resolveStudioComponentTreeIcon } from "@/lib/studio-component-tree-icon";
 import {
   isStudioComponentConfigurable,
   isStudioComponentVisible,
@@ -26,46 +17,14 @@ import {
   studioComponentDepth,
 } from "@/lib/studio-components";
 import type { StudioUrlState } from "@/lib/studio-parsers";
-import type {
-  StudioComponentDefinition,
-  StudioComponentKind,
-  StudioComponentTreeIcon,
-} from "@/lib/types";
-
-function componentIcon(
-  kind: StudioComponentKind | undefined,
-  treeIcon?: StudioComponentTreeIcon
-) {
-  if (treeIcon === "pie-chart") {
-    return ChartPieIcon;
-  }
-  if (treeIcon === "funnel") {
-    return FilterIcon;
-  }
-  if (treeIcon === "line-chart") {
-    return LineChartIcon;
-  }
-
-  switch (kind) {
-    case "data":
-      return DatabaseIcon;
-    case "series":
-      return BarChart3Icon;
-    case "line":
-      return LineChartIcon;
-    case "text":
-      return TypeIcon;
-    case "geometry":
-      return CircleDotIcon;
-    default:
-      return LayersIcon;
-  }
-}
+import type { StudioComponentDefinition } from "@/lib/types";
 
 function ComponentListMarker({
   component,
+  chartSlug,
 }: {
   component: StudioComponentDefinition;
+  chartSlug: StudioUrlState["chart"];
 }) {
   if (component.listMarker === "color-dot") {
     const color = resolveCssColor(component.swatchColor ?? "var(--chart-1)");
@@ -78,8 +37,13 @@ function ComponentListMarker({
     );
   }
 
-  const Icon = componentIcon(component.kind, component.treeIcon);
-  return <Icon className="size-3.5 shrink-0 opacity-70" strokeWidth={1.75} />;
+  return (
+    <HugeiconsIcon
+      className="size-3.5 shrink-0 opacity-70"
+      icon={resolveStudioComponentTreeIcon(component, chartSlug)}
+      strokeWidth={1.75}
+    />
+  );
 }
 
 export function StudioComponentsPanel({
@@ -142,7 +106,10 @@ export function StudioComponentsPanel({
                   }}
                   type="button"
                 >
-                  <ComponentListMarker component={component} />
+                  <ComponentListMarker
+                    chartSlug={state.chart}
+                    component={component}
+                  />
                   <span className="truncate">{component.label}</span>
                 </button>
                 <button

--- a/packages/studio/src/lib/__tests__/studio-component-tree-icon.test.ts
+++ b/packages/studio/src/lib/__tests__/studio-component-tree-icon.test.ts
@@ -1,0 +1,119 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import {
+  AlignBottomIcon,
+  AlignLeftIcon,
+  ChartAreaIcon,
+  CursorPointer01Icon,
+  GridIcon,
+  LayerIcon,
+  LeftToRightListDashIcon,
+} from "@hugeicons/core-free-icons";
+import { resolveStudioComponentTreeIcon } from "../studio-component-tree-icon";
+import type { StudioComponentDefinition } from "../types";
+
+function component(
+  overrides: Partial<StudioComponentDefinition> &
+    Pick<StudioComponentDefinition, "id" | "label">
+): StudioComponentDefinition {
+  return {
+    controlGroups: [],
+    ...overrides,
+  };
+}
+
+describe("resolveStudioComponentTreeIcon", () => {
+  it("uses the chart-type icon for the root chart node", () => {
+    assert.equal(
+      resolveStudioComponentTreeIcon(
+        component({ id: "area.chart", label: "AreaChart" }),
+        "area-chart"
+      ),
+      ChartAreaIcon
+    );
+  });
+
+  it("maps structural chart layers to their dedicated icons", () => {
+    assert.equal(
+      resolveStudioComponentTreeIcon(
+        component({
+          id: "area.grid",
+          label: "Grid",
+          parentId: "area.chart",
+        }),
+        "area-chart"
+      ),
+      GridIcon
+    );
+    assert.equal(
+      resolveStudioComponentTreeIcon(
+        component({
+          id: "area.xaxis",
+          label: "XAxis",
+          parentId: "area.chart",
+        }),
+        "area-chart"
+      ),
+      AlignBottomIcon
+    );
+    assert.equal(
+      resolveStudioComponentTreeIcon(
+        component({
+          id: "live-line.yaxis",
+          label: "LiveYAxis",
+          parentId: "live-line.chart",
+        }),
+        "live-line-chart"
+      ),
+      AlignLeftIcon
+    );
+    assert.equal(
+      resolveStudioComponentTreeIcon(
+        component({
+          id: "area.tooltip",
+          label: "ChartTooltip",
+          parentId: "area.chart",
+        }),
+        "area-chart"
+      ),
+      CursorPointer01Icon
+    );
+    assert.equal(
+      resolveStudioComponentTreeIcon(
+        component({
+          id: "area.legend",
+          label: "ChartLegend",
+          parentId: "area.chart",
+        }),
+        "area-chart"
+      ),
+      LeftToRightListDashIcon
+    );
+    assert.equal(
+      resolveStudioComponentTreeIcon(
+        component({
+          id: "choropleth.graticule",
+          label: "ChoroplethGraticule",
+          parentId: "choropleth.chart",
+        }),
+        "choropleth-chart"
+      ),
+      GridIcon
+    );
+  });
+
+  it("falls back to LayerIcon for other components", () => {
+    assert.equal(
+      resolveStudioComponentTreeIcon(
+        component({
+          id: "area.series.0",
+          label: "Area · desktop",
+          parentId: "area.chart",
+          listMarker: "icon",
+        }),
+        "area-chart"
+      ),
+      LayerIcon
+    );
+  });
+});

--- a/packages/studio/src/lib/__tests__/studio-component-tree-icon.test.ts
+++ b/packages/studio/src/lib/__tests__/studio-component-tree-icon.test.ts
@@ -4,10 +4,11 @@ import {
   AlignBottomIcon,
   AlignLeftIcon,
   ChartAreaIcon,
-  CursorPointer01Icon,
+  CursorPointer02Icon,
   GridIcon,
   LayerIcon,
   LeftToRightListDashIcon,
+  TextIcon,
 } from "@hugeicons/core-free-icons";
 import { resolveStudioComponentTreeIcon } from "../studio-component-tree-icon";
 import type { StudioComponentDefinition } from "../types";
@@ -76,7 +77,7 @@ describe("resolveStudioComponentTreeIcon", () => {
         }),
         "area-chart"
       ),
-      CursorPointer01Icon
+      CursorPointer02Icon
     );
     assert.equal(
       resolveStudioComponentTreeIcon(
@@ -99,6 +100,28 @@ describe("resolveStudioComponentTreeIcon", () => {
         "choropleth-chart"
       ),
       GridIcon
+    );
+    assert.equal(
+      resolveStudioComponentTreeIcon(
+        component({
+          id: "pie.center",
+          label: "PieCenter",
+          parentId: "pie.chart",
+        }),
+        "pie-chart"
+      ),
+      TextIcon
+    );
+    assert.equal(
+      resolveStudioComponentTreeIcon(
+        component({
+          id: "gauge.center",
+          label: "PieCenterShell",
+          parentId: "gauge.chart",
+        }),
+        "gauge-chart"
+      ),
+      TextIcon
     );
   });
 

--- a/packages/studio/src/lib/studio-component-tree-icon.ts
+++ b/packages/studio/src/lib/studio-component-tree-icon.ts
@@ -1,10 +1,11 @@
 import {
   AlignBottomIcon,
   AlignLeftIcon,
-  CursorPointer01Icon,
+  CursorPointer02Icon,
   GridIcon,
   LayerIcon,
   LeftToRightListDashIcon,
+  TextIcon,
 } from "@hugeicons/core-free-icons";
 import type { IconSvgElement } from "@hugeicons/react";
 import { getChartTypeIcon } from "@/components/chart-type-icons";
@@ -46,6 +47,12 @@ function isTooltip(component: StudioComponentDefinition): boolean {
   );
 }
 
+function isCenterText(component: StudioComponentDefinition): boolean {
+  return (
+    component.label === "PieCenter" || component.label === "PieCenterShell"
+  );
+}
+
 /** Hugeicons marker for a row in the studio components panel (excluding color dots). */
 export function resolveStudioComponentTreeIcon(
   component: StudioComponentDefinition,
@@ -67,7 +74,10 @@ export function resolveStudioComponentTreeIcon(
     return AlignBottomIcon;
   }
   if (isTooltip(component)) {
-    return CursorPointer01Icon;
+    return CursorPointer02Icon;
+  }
+  if (isCenterText(component)) {
+    return TextIcon;
   }
   return LayerIcon;
 }

--- a/packages/studio/src/lib/studio-component-tree-icon.ts
+++ b/packages/studio/src/lib/studio-component-tree-icon.ts
@@ -1,0 +1,73 @@
+import {
+  AlignBottomIcon,
+  AlignLeftIcon,
+  CursorPointer01Icon,
+  GridIcon,
+  LayerIcon,
+  LeftToRightListDashIcon,
+} from "@hugeicons/core-free-icons";
+import type { IconSvgElement } from "@hugeicons/react";
+import { getChartTypeIcon } from "@/components/chart-type-icons";
+import type { ChartSlug, StudioComponentDefinition } from "@/lib/types";
+
+function isChartRoot(component: StudioComponentDefinition): boolean {
+  return !component.parentId && component.id.endsWith(".chart");
+}
+
+function isLegend(component: StudioComponentDefinition): boolean {
+  return component.label.includes("Legend") || component.id.endsWith(".legend");
+}
+
+function isGrid(component: StudioComponentDefinition): boolean {
+  return (
+    component.label === "Grid" ||
+    component.label === "RadarGrid" ||
+    component.id.endsWith(".grid")
+  );
+}
+
+function isGraticule(component: StudioComponentDefinition): boolean {
+  return (
+    component.label.includes("Graticule") || component.id.includes("graticule")
+  );
+}
+
+function isYAxis(component: StudioComponentDefinition): boolean {
+  return component.label.includes("YAxis");
+}
+
+function isXAxis(component: StudioComponentDefinition): boolean {
+  return component.label.includes("XAxis");
+}
+
+function isTooltip(component: StudioComponentDefinition): boolean {
+  return (
+    component.label.includes("Tooltip") || component.id.endsWith(".tooltip")
+  );
+}
+
+/** Hugeicons marker for a row in the studio components panel (excluding color dots). */
+export function resolveStudioComponentTreeIcon(
+  component: StudioComponentDefinition,
+  chartSlug: ChartSlug
+): IconSvgElement {
+  if (isChartRoot(component)) {
+    return getChartTypeIcon(chartSlug);
+  }
+  if (isLegend(component)) {
+    return LeftToRightListDashIcon;
+  }
+  if (isGrid(component) || isGraticule(component)) {
+    return GridIcon;
+  }
+  if (isYAxis(component)) {
+    return AlignLeftIcon;
+  }
+  if (isXAxis(component)) {
+    return AlignBottomIcon;
+  }
+  if (isTooltip(component)) {
+    return CursorPointer01Icon;
+  }
+  return LayerIcon;
+}


### PR DESCRIPTION
## Summary

- Replace mixed Lucide tree icons in the studio Components panel with consistent Hugeicons rules: chart roots use the chart-type selector icon, Grid/Graticule use `GridIcon`, axes use `AlignLeftIcon`/`AlignBottomIcon`, legend uses `LeftToRightListDashIcon`, tooltip uses `CursorPointer02Icon`, pie/gauge center labels use `TextIcon`, and everything else uses `LayerIcon`.
- Series rows keep color-dot swatches; icon resolution lives in a pure helper with unit tests.

## Test plan

- [x] `pnpm lint` passes at repo root
- [x] `pnpm build` succeeds
- [x] `pnpm registry:build` succeeds (no output changes)
- [x] `pnpm --filter @bklitui/studio test` passes
- [ ] Open studio/playground and verify Components panel icons for area, bar, line, pie, gauge, and choropleth charts