### PR TITLE
fix(charts): improve Studio pie chart render performance

### DIFF
--- a/packages/studio/src/components/charts/pie-studio-preview.tsx
+++ b/packages/studio/src/components/charts/pie-studio-preview.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { PieCenter, PieChart, PieSlice } from "@bklitui/ui/charts";
+import { memo, useMemo } from "react";
 import {
   StudioRadialCenter,
   studioRadialSize,
@@ -21,18 +22,45 @@ import {
   getSeriesFillMode,
 } from "@/lib/studio-series-design";
 
-function PieChartBody({
+const PieChartBody = memo(function PieChartBody({
   state,
   ctx,
   data,
   motionEnter,
+  showPatternDefs,
 }: {
   state: StudioUrlState;
   ctx: StudioRenderContext;
   data: ReturnType<typeof getPieData>;
   motionEnter: ReturnType<typeof getStudioMotionEnterProps>;
+  showPatternDefs: boolean;
 }) {
   const { hoveredIndex, setHoveredIndex } = useStudioLegendHover();
+
+  const slices = useMemo(
+    () =>
+      data.map((item, index) => {
+        if (!isStudioComponentVisible(state, `pie.slice.${index}`)) {
+          return null;
+        }
+        const patternFill = ctx.patternFillAt(index);
+        const fill =
+          getSeriesFillMode(state, index) === "pattern" && patternFill
+            ? patternFill
+            : item.color;
+
+        return (
+          <PieSlice
+            fill={fill}
+            hoverEffect={state.pieHoverEffect}
+            index={index}
+            key={item.label}
+            showGlow={false}
+          />
+        );
+      }),
+    [ctx.patternFillAt, data, state]
+  );
 
   return (
     <StudioRadialCenter frame={ctx.frame}>
@@ -51,27 +79,8 @@ function PieChartBody({
         size={studioRadialSize(ctx.frame, state.pieSize)}
         startAngle={(state.pieStartAngleDeg * Math.PI) / 180}
       >
-        {ctx.patternDefs}
-        {data.map((item, index) => {
-          if (!isStudioComponentVisible(state, `pie.slice.${index}`)) {
-            return null;
-          }
-          const patternFill = ctx.patternFillAt(index);
-          const fill =
-            getSeriesFillMode(state, index) === "pattern" && patternFill
-              ? patternFill
-              : item.color;
-
-          return (
-            <PieSlice
-              fill={fill}
-              hoverEffect={state.pieHoverEffect}
-              index={index}
-              key={item.label}
-              showGlow={false}
-            />
-          );
-        })}
+        {showPatternDefs ? ctx.patternDefs : null}
+        {slices}
         {state.innerRadius > 0 &&
         isStudioComponentVisible(state, "pie.center") ? (
           <PieCenter
@@ -83,7 +92,7 @@ function PieChartBody({
       </PieChart>
     </StudioRadialCenter>
   );
-}
+});
 
 export function PieStudioPreview({
   state,
@@ -92,24 +101,42 @@ export function PieStudioPreview({
   state: StudioUrlState;
   ctx: StudioRenderContext;
 }) {
-  const motionEnter = getStudioMotionEnterProps(state, {
-    linear: ctx.isRecording,
-  });
-  const data = getPieData(ctx.dataSeed).map((item, index) => ({
-    ...item,
-    color: getEffectiveSeriesColor(state, index),
-  }));
+  const motionEnter = useMemo(
+    () =>
+      getStudioMotionEnterProps(state, {
+        linear: ctx.isRecording,
+      }),
+    [ctx.isRecording, state]
+  );
+
+  const data = useMemo(
+    () =>
+      getPieData(ctx.dataSeed).map((item, index) => ({
+        ...item,
+        color: getEffectiveSeriesColor(state, index),
+      })),
+    [ctx.dataSeed, state]
+  );
+
+  const showPatternDefs = useMemo(
+    () =>
+      data.some((_, index) => getSeriesFillMode(state, index) === "pattern"),
+    [data, state]
+  );
+
+  const legendItems = useMemo(() => studioStaticPieLegendItems(state), [state]);
 
   return (
     <StudioChartShell
       legendComponentId="pie.legend"
-      legendItems={studioStaticPieLegendItems(state)}
+      legendItems={legendItems}
       state={state}
     >
       <PieChartBody
         ctx={ctx}
         data={data}
         motionEnter={motionEnter}
+        showPatternDefs={showPatternDefs}
         state={state}
       />
     </StudioChartShell>

--- a/packages/studio/src/lib/studio-legend-hover.tsx
+++ b/packages/studio/src/lib/studio-legend-hover.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { createContext, type ReactNode, useContext } from "react";
+import { createContext, type ReactNode, useContext, useMemo } from "react";
 
 interface StudioLegendHoverContextValue {
   hoveredIndex: number | null;
@@ -19,10 +19,13 @@ export function StudioLegendHoverProvider({
   onHoverChange: (index: number | null) => void;
   children: ReactNode;
 }) {
+  const value = useMemo(
+    () => ({ hoveredIndex, setHoveredIndex: onHoverChange }),
+    [hoveredIndex, onHoverChange]
+  );
+
   return (
-    <StudioLegendHoverContext.Provider
-      value={{ hoveredIndex, setHoveredIndex: onHoverChange }}
-    >
+    <StudioLegendHoverContext.Provider value={value}>
       {children}
     </StudioLegendHoverContext.Provider>
   );

--- a/packages/ui/src/charts/index.ts
+++ b/packages/ui/src/charts/index.ts
@@ -188,6 +188,8 @@ export {
   PieProvider,
   pieCssVars,
   usePie,
+  usePieHover,
+  usePieStable,
 } from "./pie-context";
 export {
   PieSlice,

--- a/packages/ui/src/charts/pie-center.tsx
+++ b/packages/ui/src/charts/pie-center.tsx
@@ -12,7 +12,7 @@ import {
   type ChartStatFlowFormat,
   defaultChartStatFlowFormat,
 } from "./chart-stat-flow";
-import { usePie } from "./pie-context";
+import { usePieHover, usePieStable } from "./pie-context";
 
 export interface PieCenterProps {
   /** Label shown below the value. Default: "Total" when not hovering */
@@ -58,7 +58,8 @@ export function PieCenter({
   prefix,
   suffix,
 }: PieCenterProps) {
-  const { data, hoveredIndex, totalValue, innerRadius } = usePie();
+  const { data, totalValue, innerRadius } = usePieStable();
+  const { hoveredIndex } = usePieHover();
 
   const hoveredData = hoveredIndex === null ? null : data[hoveredIndex];
   const displayValue = hoveredData ? hoveredData.value : totalValue;

--- a/packages/ui/src/charts/pie-chart.tsx
+++ b/packages/ui/src/charts/pie-chart.tsx
@@ -11,6 +11,7 @@ import {
   type ReactElement,
   type ReactNode,
   useCallback,
+  useEffect,
   useMemo,
   useRef,
   useState,
@@ -213,13 +214,14 @@ const PieChartCore = memo(function PieChartCore({
     })) as PieArcData[];
   }, [data, startAngle, endAngle, padAngle]);
 
-  // Mark as loaded after initial render
-  useState(() => {
+  // biome-ignore lint/correctness/useExhaustiveDependencies: enterTransition
+  useEffect(() => {
+    setIsLoaded(false);
     const timer = setTimeout(() => {
       setIsLoaded(true);
     }, 100);
     return () => clearTimeout(timer);
-  });
+  }, [enterTransition, enterStaggerScale]);
 
   // Separate children into categories
   const { svgChildren, centerChildren, defsChildren } = useMemo(() => {
@@ -249,27 +251,50 @@ const PieChartCore = memo(function PieChartCore({
     };
   }, [children]);
 
-  const contextValue: PieContextValue = {
-    data,
-    arcs,
-    size,
-    center,
-    outerRadius,
-    innerRadius,
-    padAngle,
-    cornerRadius,
-    hoverOffset,
-    hoveredIndex,
-    setHoveredIndex,
-    animationKey,
-    isLoaded,
-    enterTransition,
-    enterStaggerScale,
-    containerRef,
-    totalValue,
-    getColor,
-    getFill,
-  };
+  const contextValue: PieContextValue = useMemo(
+    () => ({
+      data,
+      arcs,
+      size,
+      center,
+      outerRadius,
+      innerRadius,
+      padAngle,
+      cornerRadius,
+      hoverOffset,
+      hoveredIndex,
+      setHoveredIndex,
+      animationKey,
+      isLoaded,
+      enterTransition,
+      enterStaggerScale,
+      containerRef,
+      totalValue,
+      getColor,
+      getFill,
+    }),
+    [
+      data,
+      arcs,
+      size,
+      center,
+      outerRadius,
+      innerRadius,
+      padAngle,
+      cornerRadius,
+      hoverOffset,
+      hoveredIndex,
+      setHoveredIndex,
+      animationKey,
+      isLoaded,
+      enterTransition,
+      enterStaggerScale,
+      containerRef,
+      totalValue,
+      getColor,
+      getFill,
+    ]
+  );
 
   // Use CSS Grid stacking to layer SVG and HTML content
   // This avoids Safari's foreignObject rendering bugs

--- a/packages/ui/src/charts/pie-context.tsx
+++ b/packages/ui/src/charts/pie-context.tsx
@@ -1,7 +1,13 @@
 "use client";
 
 import type { Transition } from "motion/react";
-import { createContext, type RefObject, useContext } from "react";
+import {
+  createContext,
+  type ReactNode,
+  type RefObject,
+  useContext,
+  useMemo,
+} from "react";
 
 // CSS variable references for pie chart theming
 export const pieCssVars = {
@@ -47,7 +53,12 @@ export interface PieArcData {
   value: number;
 }
 
-export interface PieContextValue {
+export interface PieHoverContextValue {
+  hoveredIndex: number | null;
+  setHoveredIndex: (index: number | null) => void;
+}
+
+export interface PieStableContextValue {
   // Data
   data: PieData[];
   arcs: PieArcData[];
@@ -62,10 +73,6 @@ export interface PieContextValue {
 
   // Hover effect
   hoverOffset: number;
-
-  // Hover state
-  hoveredIndex: number | null;
-  setHoveredIndex: (index: number | null) => void;
 
   // Animation state
   animationKey: number;
@@ -86,27 +93,100 @@ export interface PieContextValue {
   getFill: (index: number) => string;
 }
 
-const PieContext = createContext<PieContextValue | null>(null);
+export type PieContextValue = PieStableContextValue & PieHoverContextValue;
+
+const PieStableContext = createContext<PieStableContextValue | null>(null);
+const PieHoverContext = createContext<PieHoverContextValue | null>(null);
 
 export function PieProvider({
   children,
   value,
 }: {
-  children: React.ReactNode;
+  children: ReactNode;
   value: PieContextValue;
 }) {
-  return <PieContext.Provider value={value}>{children}</PieContext.Provider>;
+  const stable = useMemo<PieStableContextValue>(
+    () => ({
+      data: value.data,
+      arcs: value.arcs,
+      size: value.size,
+      center: value.center,
+      outerRadius: value.outerRadius,
+      innerRadius: value.innerRadius,
+      padAngle: value.padAngle,
+      cornerRadius: value.cornerRadius,
+      hoverOffset: value.hoverOffset,
+      animationKey: value.animationKey,
+      isLoaded: value.isLoaded,
+      enterTransition: value.enterTransition,
+      enterStaggerScale: value.enterStaggerScale,
+      containerRef: value.containerRef,
+      totalValue: value.totalValue,
+      getColor: value.getColor,
+      getFill: value.getFill,
+    }),
+    [
+      value.data,
+      value.arcs,
+      value.size,
+      value.center,
+      value.outerRadius,
+      value.innerRadius,
+      value.padAngle,
+      value.cornerRadius,
+      value.hoverOffset,
+      value.animationKey,
+      value.isLoaded,
+      value.enterTransition,
+      value.enterStaggerScale,
+      value.containerRef,
+      value.totalValue,
+      value.getColor,
+      value.getFill,
+    ]
+  );
+
+  const hover = useMemo<PieHoverContextValue>(
+    () => ({
+      hoveredIndex: value.hoveredIndex,
+      setHoveredIndex: value.setHoveredIndex,
+    }),
+    [value.hoveredIndex, value.setHoveredIndex]
+  );
+
+  return (
+    <PieStableContext.Provider value={stable}>
+      <PieHoverContext.Provider value={hover}>
+        {children}
+      </PieHoverContext.Provider>
+    </PieStableContext.Provider>
+  );
 }
 
-export function usePie(): PieContextValue {
-  const context = useContext(PieContext);
+export function usePieStable(): PieStableContextValue {
+  const context = useContext(PieStableContext);
   if (!context) {
     throw new Error(
-      "usePie must be used within a PieProvider. " +
+      "usePieStable must be used within a PieProvider. " +
         "Make sure your component is wrapped in <PieChart>."
     );
   }
   return context;
 }
 
-export default PieContext;
+export function usePieHover(): PieHoverContextValue {
+  const context = useContext(PieHoverContext);
+  if (!context) {
+    throw new Error(
+      "usePieHover must be used within a PieProvider. " +
+        "Make sure your component is wrapped in <PieChart>."
+    );
+  }
+  return context;
+}
+
+export function usePie(): PieContextValue {
+  return { ...usePieStable(), ...usePieHover() };
+}
+
+export default PieStableContext;

--- a/packages/ui/src/charts/pie-slice.tsx
+++ b/packages/ui/src/charts/pie-slice.tsx
@@ -1,9 +1,10 @@
 "use client";
 
 import { arc as arcGenerator } from "@visx/shape";
+import type { MotionValue } from "motion/react";
 import { motion, useSpring, useTransform } from "motion/react";
-import { useEffect, useRef } from "react";
-import { usePie } from "./pie-context";
+import { memo, useEffect, useState } from "react";
+import { usePieHover, usePieStable } from "./pie-context";
 import { useMountProgress } from "./use-mount-progress";
 
 // Helper to generate arc path using d3 arc generator
@@ -38,6 +39,25 @@ function getSliceOffset(
     x: Math.sin(midAngle) * distance,
     y: -Math.cos(midAngle) * distance,
   };
+}
+
+function useEnterComplete(mountProgress: MotionValue<number>): boolean {
+  const [complete, setComplete] = useState(() => mountProgress.get() >= 1);
+
+  useEffect(() => {
+    if (mountProgress.get() >= 1) {
+      setComplete(true);
+      return;
+    }
+
+    return mountProgress.on("change", (value) => {
+      if (value >= 1) {
+        setComplete(true);
+      }
+    });
+  }, [mountProgress]);
+
+  return complete;
 }
 
 /** Hover effect types */
@@ -104,13 +124,14 @@ function AnimatedSliceTranslate({
     enterTransition,
     enterStaggerScale,
     animationKey: pieAnimationKey,
-  } = usePie();
+  } = usePieStable();
   const animationDelay = (0.1 + index * 0.08) * enterStaggerScale;
   const mountProgress = useMountProgress(
     enterTransition,
     animationDelay,
     pieAnimationKey
   );
+  const enterComplete = useEnterComplete(mountProgress);
 
   const animatedPath = useTransform(mountProgress, (mount) => {
     const currentEndAngle = startAngle + (endAngle - startAngle) * mount;
@@ -129,6 +150,41 @@ function AnimatedSliceTranslate({
 
   const offset = getSliceOffset(startAngle, endAngle, hoverOffset);
   const glowColor = color;
+  const hitboxPath = generateArcPath(
+    innerRadius,
+    outerRadius,
+    startAngle,
+    endAngle,
+    cornerRadius,
+    padAngle
+  );
+
+  if (enterComplete) {
+    const shouldTranslate = isHovered;
+    return (
+      <motion.path
+        animate={{
+          opacity: isFaded ? 0.4 : 1,
+          x: shouldTranslate ? offset.x : 0,
+          y: shouldTranslate ? offset.y : 0,
+        }}
+        d={hitboxPath}
+        fill={fill}
+        pointerEvents="none"
+        style={{
+          filter:
+            showGlow && isHovered
+              ? `drop-shadow(0 0 12px ${glowColor})`
+              : "none",
+        }}
+        transition={{
+          opacity: { duration: 0.15 },
+          x: { type: "spring", stiffness: 400, damping: 25 },
+          y: { type: "spring", stiffness: 400, damping: 25 },
+        }}
+      />
+    );
+  }
 
   return (
     <motion.path
@@ -191,13 +247,14 @@ function AnimatedSliceGrow({
     enterTransition,
     enterStaggerScale,
     animationKey: pieAnimationKey,
-  } = usePie();
+  } = usePieStable();
   const animationDelay = (0.1 + index * 0.08) * enterStaggerScale;
   const mountProgress = useMountProgress(
     enterTransition,
     animationDelay,
     pieAnimationKey
   );
+  const enterComplete = useEnterComplete(mountProgress);
 
   const growSpring = useSpring(outerRadius, {
     stiffness: 400,
@@ -228,6 +285,39 @@ function AnimatedSliceGrow({
   );
 
   const glowColor = color;
+  const grownOuterRadius = isHovered ? outerRadius + hoverOffset : outerRadius;
+  const grownPath = generateArcPath(
+    innerRadius,
+    grownOuterRadius,
+    startAngle,
+    endAngle,
+    cornerRadius,
+    padAngle
+  );
+
+  if (enterComplete) {
+    return (
+      <motion.path
+        animate={{
+          opacity: isFaded ? 0.4 : 1,
+          d: grownPath,
+        }}
+        d={grownPath}
+        fill={fill}
+        pointerEvents="none"
+        style={{
+          filter:
+            showGlow && isHovered
+              ? `drop-shadow(0 0 12px ${glowColor})`
+              : "none",
+        }}
+        transition={{
+          opacity: { duration: 0.15 },
+          d: { type: "spring", stiffness: 400, damping: 25 },
+        }}
+      />
+    );
+  }
 
   return (
     <motion.path
@@ -249,7 +339,7 @@ function AnimatedSliceGrow({
   );
 }
 
-export function PieSlice({
+export const PieSlice = memo(function PieSlice({
   index,
   color: colorProp,
   fill: fillProp,
@@ -264,31 +354,14 @@ export function PieSlice({
     outerRadius,
     cornerRadius,
     hoverOffset: contextHoverOffset,
-    hoveredIndex,
-    setHoveredIndex,
     animationKey,
     getColor,
     getFill,
-  } = usePie();
+  } = usePieStable();
+  const { hoveredIndex, setHoveredIndex } = usePieHover();
 
   // Use prop if provided, otherwise use context value
   const hoverOffset = hoverOffsetProp ?? contextHoverOffset;
-
-  // Track if initial mount animation is complete
-  const hasAnimated = useRef(false);
-  const sliceExpandDelay = index * 0.08;
-
-  useEffect(() => {
-    if (animate && !hasAnimated.current) {
-      const timeout = setTimeout(
-        () => {
-          hasAnimated.current = true;
-        },
-        (sliceExpandDelay + 0.5) * 1000
-      );
-      return () => clearTimeout(timeout);
-    }
-  }, [animate, sliceExpandDelay]);
 
   const arcData = arcs[index];
   if (!arcData) {
@@ -440,7 +513,7 @@ export function PieSlice({
       {animate ? renderAnimatedSlice() : renderStaticSlice()}
     </g>
   );
-}
+});
 
 PieSlice.displayName = "PieSlice";
 


### PR DESCRIPTION
## Summary

- Audited Studio pie chart vs radar/ring: pie slices kept Motion `d` path subscriptions active after enter animation, pie context re-rendered all slices on every hover, and the studio preview passed pattern defs on every frame even when unused.
- Split `PieProvider` into stable/hover contexts (matching cartesian charts), fixed `isLoaded` timing via `useEffect`, and switch slices to static SVG paths once enter animation completes so slider drags no longer pay per-frame arc generation through Motion.
- Studio preview now skips pattern defs when no slice uses patterns, memoizes chart body/data, and stabilizes legend hover context to reduce unnecessary child reconciliation.

## Test plan

- [x] `pnpm lint` passes at repo root
- [x] `pnpm check-types` passes
- [x] `apps/web` production build succeeds
- [ ] Open `/studio?chart=pie-chart` — confirm enter animation still plays, hover/legend sync works
- [ ] Drag pad angle / corner radius / inner radius sliders — confirm canvas stays responsive vs radar chart baseline
- [ ] Enable slice patterns in design panel — confirm pattern fills still render