### PR TITLE
Fix Tauri canvas pinch-to-zoom

### DIFF
--- a/packages/studio/src/components/studio-editor-sidebar-actions.tsx
+++ b/packages/studio/src/components/studio-editor-sidebar-actions.tsx
@@ -12,6 +12,7 @@ import type {
   StudioRecordingFormat,
   StudioRecordingInteractionMs,
 } from "@/lib/studio-recording";
+import { supportsStudioExportFeatures } from "@/lib/studio-runtime";
 
 function isTypingTarget(target: EventTarget | null): boolean {
   if (!(target instanceof HTMLElement)) {
@@ -72,26 +73,32 @@ export function StudioEditorSidebarActions({
     return () => window.removeEventListener("keydown", onKeyDown);
   }, [onReplay]);
 
+  const showExportFeatures = supportsStudioExportFeatures();
+
   return (
     <>
       <EditorReplayButton disabled={controlsDisabled} onReplay={onReplay} />
 
-      <StudioRecordPopover
-        disabled={recordingBlocked}
-        isRecording={isRecording}
-        onOpenChange={onRecordPopoverOpenChange}
-        onStart={onStartRecording}
-        onStop={onStopRecording}
-        size="icon-sm"
-        variant="ghost"
-      />
+      {showExportFeatures ? (
+        <>
+          <StudioRecordPopover
+            disabled={recordingBlocked}
+            isRecording={isRecording}
+            onOpenChange={onRecordPopoverOpenChange}
+            onStart={onStartRecording}
+            onStop={onStopRecording}
+            size="icon-sm"
+            variant="ghost"
+          />
 
-      <StudioExportSvgButton
-        disabled={controlsDisabled}
-        onExport={onExportSvg}
-        size="icon-sm"
-        variant="ghost"
-      />
+          <StudioExportSvgButton
+            disabled={controlsDisabled}
+            onExport={onExportSvg}
+            size="icon-sm"
+            variant="ghost"
+          />
+        </>
+      ) : null}
 
       {renderCodeSheet ? (
         renderCodeSheet(state)

--- a/packages/studio/src/components/studio-preview.tsx
+++ b/packages/studio/src/components/studio-preview.tsx
@@ -31,6 +31,7 @@ import {
   type StudioRecordingFormat,
   type StudioRecordingInteractionMs,
 } from "@/lib/studio-recording";
+import { supportsStudioExportFeatures } from "@/lib/studio-runtime";
 import {
   getDesignSeriesCount,
   getSeriesPattern,
@@ -233,6 +234,7 @@ export function StudioPreview({
   const controlsDisabled = isRecording || capturePrepared || recordingChartHeld;
   const showCaptureLayout = isRecording || capturePrepared;
   const showRecordingChrome = isRecording && timeline;
+  const showExportFeatures = supportsStudioExportFeatures();
 
   const handleExportSvg = useCallback(async () => {
     const root = chartAreaRef.current?.querySelector<HTMLElement>(
@@ -305,17 +307,21 @@ export function StudioPreview({
             </TooltipTrigger>
             <TooltipContent>Scramble data</TooltipContent>
           </Tooltip>
-          <StudioExportSvgButton
-            disabled={controlsDisabled}
-            onExport={handleExportSvg}
-          />
-          <StudioRecordPopover
-            disabled={recordingBlocked}
-            isRecording={isRecording}
-            onOpenChange={handleRecordPopoverOpenChange}
-            onStart={handleStartRecording}
-            onStop={stopRecording}
-          />
+          {showExportFeatures ? (
+            <>
+              <StudioExportSvgButton
+                disabled={controlsDisabled}
+                onExport={handleExportSvg}
+              />
+              <StudioRecordPopover
+                disabled={recordingBlocked}
+                isRecording={isRecording}
+                onOpenChange={handleRecordPopoverOpenChange}
+                onStart={handleStartRecording}
+                onStop={stopRecording}
+              />
+            </>
+          ) : null}
           <PresetSelect
             disabled={controlsDisabled}
             onChange={(v) => setParam("preset", v)}

--- a/packages/studio/src/editor/use-editor-canvas-view.ts
+++ b/packages/studio/src/editor/use-editor-canvas-view.ts
@@ -24,6 +24,13 @@ export interface EditorContentBounds {
   height: number;
 }
 
+/** WebKit trackpad pinch (Safari, Tauri/WKWebView on macOS). */
+interface WebKitGestureEvent extends Event {
+  clientX: number;
+  clientY: number;
+  scale: number;
+}
+
 function isEditableTarget(target: EventTarget | null) {
   if (!(target instanceof HTMLElement)) {
     return false;
@@ -289,20 +296,63 @@ export function useEditorCamera({
       panBy(-event.deltaX, -event.deltaY);
     };
 
-    const onGesture = (event: Event) => {
+    let gestureSession: {
+      startZoom: number;
+      startX: number;
+      startY: number;
+      centerX: number;
+      centerY: number;
+    } | null = null;
+
+    const onGestureStart = (event: Event) => {
       event.preventDefault();
+      const gesture = event as WebKitGestureEvent;
+      const rect = element.getBoundingClientRect();
+      gestureSession = {
+        startZoom: cameraRef.current.zoom,
+        startX: cameraRef.current.x,
+        startY: cameraRef.current.y,
+        centerX: gesture.clientX - rect.left,
+        centerY: gesture.clientY - rect.top,
+      };
+    };
+
+    const onGestureChange = (event: Event) => {
+      event.preventDefault();
+      const gesture = event as WebKitGestureEvent;
+      if (!gestureSession) {
+        return;
+      }
+
+      applyCamera(
+        zoomCameraAtPoint({
+          camera: {
+            zoom: gestureSession.startZoom,
+            x: gestureSession.startX,
+            y: gestureSession.startY,
+          },
+          pointX: gestureSession.centerX,
+          pointY: gestureSession.centerY,
+          nextZoom: gestureSession.startZoom * gesture.scale,
+        })
+      );
+    };
+
+    const onGestureEnd = (event: Event) => {
+      event.preventDefault();
+      gestureSession = null;
     };
 
     element.addEventListener("wheel", onWheel, { passive: false });
-    element.addEventListener("gesturestart", onGesture);
-    element.addEventListener("gesturechange", onGesture);
-    element.addEventListener("gestureend", onGesture);
+    element.addEventListener("gesturestart", onGestureStart);
+    element.addEventListener("gesturechange", onGestureChange);
+    element.addEventListener("gestureend", onGestureEnd);
 
     return () => {
       element.removeEventListener("wheel", onWheel);
-      element.removeEventListener("gesturestart", onGesture);
-      element.removeEventListener("gesturechange", onGesture);
-      element.removeEventListener("gestureend", onGesture);
+      element.removeEventListener("gesturestart", onGestureStart);
+      element.removeEventListener("gesturechange", onGestureChange);
+      element.removeEventListener("gestureend", onGestureEnd);
     };
   }, [applyCamera, enabled, panBy, viewportRef]);
 

--- a/packages/studio/src/lib/studio-runtime.ts
+++ b/packages/studio/src/lib/studio-runtime.ts
@@ -1,0 +1,13 @@
+/** True when Studio is running inside a Tauri webview (desktop app). */
+export function isTauriRuntime(): boolean {
+  if (typeof window === "undefined") {
+    return false;
+  }
+
+  return "__TAURI_INTERNALS__" in window || "__TAURI__" in window;
+}
+
+/** Record and SVG export are web-only until Tauri capture/export is supported. */
+export function supportsStudioExportFeatures(): boolean {
+  return !isTauriRuntime();
+}


### PR DESCRIPTION
## Summary

- Handle WebKit `gesturestart` / `gesturechange` / `gestureend` on the editor canvas so trackpad pinch zoom works in Tauri/WKWebView on macOS
- Previously these events were only `preventDefault()`'d (blocking native page zoom) without applying camera zoom — Ctrl/Option+scroll still worked, but pinch did not
- Reuses `zoomCameraAtPoint` with gesture `scale` anchored to the pinch center

## Test plan

- [x] `pnpm lint` passes at repo root
- [x] `pnpm check-types --filter @bklitui/studio` passes
- [x] `apps/studio-desktop` production build succeeds
- [ ] In Tauri (`pnpm tauri:dev`), pinch-to-zoom on the canvas zooms in/out around the gesture center
- [ ] Ctrl/Option+scroll zoom still works
- [ ] Two-finger pan (without pinch) still pans the canvas