### PR TITLE
Polish Studio V2 homepage badge and default canvas zoom

### DIFF
--- a/apps/web/components/hero/index.tsx
+++ b/apps/web/components/hero/index.tsx
@@ -4,6 +4,8 @@ import { ArrowRightIcon } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 import Link from "next/link";
 import type { ComponentProps, ReactNode } from "react";
+import { ParticleBadge } from "@/components/particle-badge";
+import { ShimmeringText } from "@/components/shimmering-text";
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
 
@@ -17,26 +19,27 @@ export function HeroShell({ children }: { children: ReactNode }) {
 }
 
 export function HeroBadgeRow({ children }: { children: ReactNode }) {
-  return <div className="mx-auto flex w-fit">{children}</div>;
+  return <div className="mx-auto flex w-fit overflow-visible">{children}</div>;
 }
 
 export function HeroStudioPill() {
   return (
-    <Button
-      className="h-auto rounded-full px-0.5 py-0.5"
-      nativeButton={false}
-      render={<Link href="/studio" title="Studio" />}
-      size="lg"
-      variant="outline"
-    >
-      <span className="flex items-center gap-1 rounded-full bg-muted px-2.5 py-1 text-xs">
-        Introducing
-      </span>
-      <span className="flex items-center gap-1 px-2.5 py-1 text-xs">
-        Studio
-        <HugeiconsIcon icon={ArrowRightIcon} size={14} />
-      </span>
-    </Button>
+    <ParticleBadge>
+      <Button
+        className="relative isolate inline-flex h-auto items-center gap-0 rounded-full bg-background px-0.5 py-0.5 text-xs"
+        nativeButton={false}
+        render={<Link aria-label="Studio Version 2" href="/studio" />}
+        variant="outline"
+      >
+        <span className="flex h-6 items-center rounded-full bg-muted px-2.5 text-xs leading-none">
+          Studio
+        </span>
+        <span className="flex h-6 items-center gap-1 px-2.5 text-xs leading-none">
+          <ShimmeringText className="leading-none" text="Version 2" />
+          <HugeiconsIcon className="size-3.5" icon={ArrowRightIcon} />
+        </span>
+      </Button>
+    </ParticleBadge>
   );
 }
 

--- a/apps/web/components/particle-badge.tsx
+++ b/apps/web/components/particle-badge.tsx
@@ -1,0 +1,415 @@
+"use client";
+
+import {
+  type ComponentProps,
+  type ReactNode,
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+} from "react";
+import { cn } from "@/lib/utils";
+
+interface Particle {
+  x: number;
+  y: number;
+  vx: number;
+  vy: number;
+  life: number;
+  maxLife: number;
+  size: number;
+  color: { r: number; g: number; b: number };
+}
+
+export type ParticleBadgeProps = ComponentProps<"div"> & {
+  children: ReactNode;
+  /** Extra canvas bleed around the badge for particles. */
+  bleed?: number;
+};
+
+function compileShader(
+  gl: WebGLRenderingContext,
+  type: number,
+  source: string
+) {
+  const shader = gl.createShader(type);
+  if (!shader) {
+    return null;
+  }
+
+  gl.shaderSource(shader, source);
+  gl.compileShader(shader);
+
+  if (!gl.getShaderParameter(shader, gl.COMPILE_STATUS)) {
+    gl.deleteShader(shader);
+    return null;
+  }
+
+  return shader;
+}
+
+export function ParticleBadge({
+  children,
+  className,
+  bleed = 64,
+  ...props
+}: ParticleBadgeProps) {
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+  const containerRef = useRef<HTMLDivElement>(null);
+  const targetRef = useRef<HTMLDivElement>(null);
+  const particlesRef = useRef<Particle[]>([]);
+  const animationFrameRef = useRef<number | undefined>(undefined);
+  const emitIntervalRef = useRef<ReturnType<typeof setInterval> | undefined>(
+    undefined
+  );
+  const glRef = useRef<WebGLRenderingContext | null>(null);
+  const programRef = useRef<WebGLProgram | null>(null);
+  const [isHovering, setIsHovering] = useState(false);
+
+  const getColors = useCallback((bright = false) => {
+    if (bright) {
+      return [
+        { r: 150, g: 240, b: 255 },
+        { r: 180, g: 250, b: 255 },
+        { r: 200, g: 255, b: 255 },
+      ];
+    }
+
+    return [
+      { r: 119, g: 222, b: 232 },
+      { r: 100, g: 200, b: 220 },
+      { r: 80, g: 180, b: 200 },
+    ];
+  }, []);
+
+  const initWebGL = useCallback(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) {
+      return false;
+    }
+
+    const gl = canvas.getContext("webgl", {
+      alpha: true,
+      premultipliedAlpha: false,
+      antialias: true,
+    });
+
+    if (!gl) {
+      return false;
+    }
+
+    const vertexShader = compileShader(
+      gl,
+      gl.VERTEX_SHADER,
+      `
+      attribute vec2 a_position;
+      attribute float a_size;
+      attribute vec4 a_color;
+      varying vec4 v_color;
+      uniform vec2 u_resolution;
+
+      void main() {
+        vec2 clipSpace = (a_position / u_resolution) * 2.0 - 1.0;
+        gl_Position = vec4(clipSpace * vec2(1, -1), 0, 1);
+        gl_PointSize = a_size;
+        v_color = a_color;
+      }
+    `
+    );
+
+    const fragmentShader = compileShader(
+      gl,
+      gl.FRAGMENT_SHADER,
+      `
+      precision mediump float;
+      varying vec4 v_color;
+
+      void main() {
+        vec2 center = gl_PointCoord - vec2(0.5);
+        float dist = length(center);
+
+        float alpha = 1.0 - smoothstep(0.0, 0.5, dist);
+        alpha *= v_color.a;
+
+        float glow = exp(-dist * 4.0) * 0.6;
+
+        gl_FragColor = vec4(v_color.rgb, alpha + glow * v_color.a);
+      }
+    `
+    );
+
+    if (!(vertexShader && fragmentShader)) {
+      return false;
+    }
+
+    const program = gl.createProgram();
+    if (!program) {
+      return false;
+    }
+
+    gl.attachShader(program, vertexShader);
+    gl.attachShader(program, fragmentShader);
+    gl.linkProgram(program);
+
+    if (!gl.getProgramParameter(program, gl.LINK_STATUS)) {
+      return false;
+    }
+
+    // biome-ignore lint/correctness/useHookAtTopLevel: WebGL API, not a React hook
+    gl.useProgram(program);
+    gl.enable(gl.BLEND);
+    gl.blendFunc(gl.SRC_ALPHA, gl.ONE);
+
+    glRef.current = gl;
+    programRef.current = program;
+
+    return true;
+  }, []);
+
+  const createParticle = useCallback(
+    (x: number, y: number, bright = false): Particle => {
+      const colors = getColors(bright);
+      const color = colors[Math.floor(Math.random() * colors.length)] ?? {
+        r: 119,
+        g: 222,
+        b: 232,
+      };
+      const angle = Math.random() * Math.PI * 2;
+      const speed = bright ? 0.8 + Math.random() * 2 : 0.2 + Math.random() * 1;
+      const maxLife = bright
+        ? 50 + Math.random() * 50
+        : 70 + Math.random() * 80;
+
+      return {
+        x,
+        y,
+        vx: Math.cos(angle) * speed,
+        vy: Math.sin(angle) * speed - (bright ? 1 : 0.2),
+        life: maxLife,
+        maxLife,
+        size: bright ? 2 + Math.random() * 5 : 1 + Math.random() * 3,
+        color,
+      };
+    },
+    [getColors]
+  );
+
+  const emitFromEdges = useCallback(
+    (aggressive = false) => {
+      const target = targetRef.current;
+      const container = containerRef.current;
+      if (!(target && container)) {
+        return;
+      }
+
+      const containerRect = container.getBoundingClientRect();
+      const targetRect = target.getBoundingClientRect();
+      const offsetX = targetRect.left - containerRect.left;
+      const offsetY = targetRect.top - containerRect.top;
+      const targetWidth = targetRect.width;
+      const targetHeight = targetRect.height;
+      const particleCount = aggressive ? 4 : 2;
+
+      for (let index = 0; index < particleCount; index++) {
+        const edge = Math.floor(Math.random() * 4);
+        let x = offsetX;
+        let y = offsetY;
+
+        switch (edge) {
+          case 0:
+            x = offsetX + Math.random() * targetWidth;
+            y = offsetY;
+            break;
+          case 1:
+            x = offsetX + targetWidth;
+            y = offsetY + Math.random() * targetHeight;
+            break;
+          case 2:
+            x = offsetX + Math.random() * targetWidth;
+            y = offsetY + targetHeight;
+            break;
+          default:
+            x = offsetX;
+            y = offsetY + Math.random() * targetHeight;
+            break;
+        }
+
+        particlesRef.current.push(createParticle(x, y, aggressive));
+      }
+
+      if (particlesRef.current.length > 400) {
+        particlesRef.current = particlesRef.current.slice(-400);
+      }
+    },
+    [createParticle]
+  );
+
+  const render = useCallback(() => {
+    const gl = glRef.current;
+    const program = programRef.current;
+    const canvas = canvasRef.current;
+
+    if (!(gl && program && canvas)) {
+      animationFrameRef.current = requestAnimationFrame(render);
+      return;
+    }
+
+    gl.clearColor(0, 0, 0, 0);
+    gl.clear(gl.COLOR_BUFFER_BIT);
+
+    particlesRef.current = particlesRef.current.filter((particle) => {
+      particle.x += particle.vx;
+      particle.y += particle.vy;
+      particle.vy += 0.015;
+      particle.vx *= 0.995;
+      particle.life--;
+      return particle.life > 0;
+    });
+
+    if (particlesRef.current.length > 0) {
+      const dpr = window.devicePixelRatio || 1;
+      const positions: number[] = [];
+      const sizes: number[] = [];
+      const colors: number[] = [];
+
+      for (const particle of particlesRef.current) {
+        const alpha = (particle.life / particle.maxLife) * 0.9;
+        positions.push(particle.x * dpr, particle.y * dpr);
+        sizes.push(
+          particle.size * dpr * (particle.life / particle.maxLife + 0.5)
+        );
+        colors.push(
+          particle.color.r / 255,
+          particle.color.g / 255,
+          particle.color.b / 255,
+          alpha
+        );
+      }
+
+      const resolutionLocation = gl.getUniformLocation(program, "u_resolution");
+      gl.uniform2f(resolutionLocation, canvas.width, canvas.height);
+
+      const positionBuffer = gl.createBuffer();
+      gl.bindBuffer(gl.ARRAY_BUFFER, positionBuffer);
+      gl.bufferData(
+        gl.ARRAY_BUFFER,
+        new Float32Array(positions),
+        gl.STATIC_DRAW
+      );
+      const positionLocation = gl.getAttribLocation(program, "a_position");
+      gl.enableVertexAttribArray(positionLocation);
+      gl.vertexAttribPointer(positionLocation, 2, gl.FLOAT, false, 0, 0);
+
+      const sizeBuffer = gl.createBuffer();
+      gl.bindBuffer(gl.ARRAY_BUFFER, sizeBuffer);
+      gl.bufferData(gl.ARRAY_BUFFER, new Float32Array(sizes), gl.STATIC_DRAW);
+      const sizeLocation = gl.getAttribLocation(program, "a_size");
+      gl.enableVertexAttribArray(sizeLocation);
+      gl.vertexAttribPointer(sizeLocation, 1, gl.FLOAT, false, 0, 0);
+
+      const colorBuffer = gl.createBuffer();
+      gl.bindBuffer(gl.ARRAY_BUFFER, colorBuffer);
+      gl.bufferData(gl.ARRAY_BUFFER, new Float32Array(colors), gl.STATIC_DRAW);
+      const colorLocation = gl.getAttribLocation(program, "a_color");
+      gl.enableVertexAttribArray(colorLocation);
+      gl.vertexAttribPointer(colorLocation, 4, gl.FLOAT, false, 0, 0);
+
+      gl.drawArrays(gl.POINTS, 0, particlesRef.current.length);
+
+      gl.deleteBuffer(positionBuffer);
+      gl.deleteBuffer(sizeBuffer);
+      gl.deleteBuffer(colorBuffer);
+    }
+
+    animationFrameRef.current = requestAnimationFrame(render);
+  }, []);
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    const container = containerRef.current;
+    if (!(canvas && container)) {
+      return;
+    }
+
+    const resizeCanvas = () => {
+      const rect = container.getBoundingClientRect();
+      const dpr = window.devicePixelRatio || 1;
+
+      canvas.width = rect.width * dpr;
+      canvas.height = rect.height * dpr;
+      canvas.style.width = `${rect.width}px`;
+      canvas.style.height = `${rect.height}px`;
+
+      if (glRef.current) {
+        glRef.current.viewport(0, 0, canvas.width, canvas.height);
+      }
+    };
+
+    resizeCanvas();
+    initWebGL();
+
+    const resizeObserver = new ResizeObserver(resizeCanvas);
+    resizeObserver.observe(container);
+    animationFrameRef.current = requestAnimationFrame(render);
+
+    return () => {
+      resizeObserver.disconnect();
+      if (animationFrameRef.current) {
+        cancelAnimationFrame(animationFrameRef.current);
+      }
+    };
+  }, [initWebGL, render]);
+
+  useEffect(() => {
+    emitIntervalRef.current = setInterval(
+      () => {
+        emitFromEdges(isHovering);
+      },
+      isHovering ? 30 : 60
+    );
+
+    return () => {
+      if (emitIntervalRef.current) {
+        clearInterval(emitIntervalRef.current);
+      }
+    };
+  }, [emitFromEdges, isHovering]);
+
+  useEffect(() => {
+    const target = targetRef.current;
+    if (!target) {
+      return;
+    }
+
+    const onEnter = () => setIsHovering(true);
+    const onLeave = () => setIsHovering(false);
+
+    target.addEventListener("mouseenter", onEnter);
+    target.addEventListener("mouseleave", onLeave);
+
+    return () => {
+      target.removeEventListener("mouseenter", onEnter);
+      target.removeEventListener("mouseleave", onLeave);
+    };
+  }, []);
+
+  return (
+    <div
+      className={cn(
+        "relative isolate inline-flex items-center justify-center overflow-visible",
+        className
+      )}
+      ref={containerRef}
+      style={{ padding: bleed }}
+      {...props}
+    >
+      <canvas
+        className="pointer-events-none absolute inset-0 z-0"
+        ref={canvasRef}
+      />
+      <div className="relative z-10 inline-flex items-center" ref={targetRef}>
+        {children}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/components/shimmering-text.tsx
+++ b/apps/web/components/shimmering-text.tsx
@@ -1,0 +1,84 @@
+"use client";
+
+import { motion, useReducedMotion, type Variants } from "motion/react";
+import { type ComponentProps, useCallback } from "react";
+import { cn } from "@/lib/utils";
+
+export type ShimmeringTextProps = Omit<
+  ComponentProps<typeof motion.span>,
+  "children"
+> & {
+  /** The text to render with the shimmering effect. */
+  text: string;
+  /**
+   * Duration in seconds for one shimmer cycle.
+   * @defaultValue 1
+   */
+  duration?: number;
+  /**
+   * Whether the shimmer animation is paused.
+   * @defaultValue false
+   */
+  isStopped?: boolean;
+};
+
+export function ShimmeringText({
+  text,
+  duration = 1,
+  isStopped = false,
+  className,
+  ...props
+}: ShimmeringTextProps) {
+  const reducedMotion = useReducedMotion();
+  const stopped = isStopped || reducedMotion === true;
+
+  const createCharVariants = useCallback(
+    (charIndex: number): Variants => ({
+      running: {
+        color: ["var(--color)", "var(--shimmering-color)", "var(--color)"],
+        transition: {
+          duration,
+          repeat: Number.POSITIVE_INFINITY,
+          repeatType: "loop",
+          repeatDelay: text.length * 0.05,
+          delay: (charIndex * duration) / text.length,
+          ease: "easeInOut",
+        },
+      },
+      stopped: {
+        color: "var(--color)",
+        transition: {
+          duration: duration * 0.5,
+          ease: "easeOut",
+        },
+      },
+    }),
+    [duration, text.length]
+  );
+
+  return (
+    <motion.span
+      className={cn(
+        "inline-flex select-none items-center leading-none",
+        "[--color:var(--muted-foreground)] [--shimmering-color:var(--foreground)]",
+        className
+      )}
+      {...props}
+    >
+      {text.split("").map((char, index) => (
+        <motion.span
+          animate={stopped ? "stopped" : "running"}
+          aria-hidden
+          className="inline-block whitespace-pre leading-none"
+          initial="stopped"
+          // biome-ignore lint/suspicious/noArrayIndexKey: static label text, order never changes
+          key={index}
+          variants={createCharVariants(index)}
+        >
+          {char}
+        </motion.span>
+      ))}
+      <span className="sr-only">{text}</span>
+    </motion.span>
+  );
+}

--- a/packages/studio/src/editor/editor-camera.ts
+++ b/packages/studio/src/editor/editor-camera.ts
@@ -1,6 +1,6 @@
 export const EDITOR_CAMERA_MIN_ZOOM = 0.25;
 export const EDITOR_CAMERA_MAX_ZOOM = 4;
-export const EDITOR_CAMERA_SESSION_KEY = "bklit-studio-canvas-view";
+export const EDITOR_CAMERA_SESSION_KEY = "bklit-studio-canvas-view-v2";
 export const EDITOR_CAMERA_VIEW_PADDING = 64;
 
 /** Viewport camera in screen space. */
@@ -71,6 +71,37 @@ export function computeFitCamera({
     zoom,
     x: (viewportWidth - worldWidth * zoom) / 2 - worldX * zoom,
     y: (viewportHeight - worldHeight * zoom) / 2 - worldY * zoom,
+  };
+}
+
+export function compute100PercentCamera({
+  viewportWidth,
+  viewportHeight,
+  worldX,
+  worldY,
+  worldWidth,
+  worldHeight,
+}: {
+  viewportWidth: number;
+  viewportHeight: number;
+  worldX: number;
+  worldY: number;
+  worldWidth: number;
+  worldHeight: number;
+}): EditorCamera {
+  const zoom = 1;
+
+  return {
+    zoom,
+    ...computeCenterCamera({
+      viewportWidth,
+      viewportHeight,
+      worldX,
+      worldY,
+      worldWidth,
+      worldHeight,
+      zoom,
+    }),
   };
 }
 

--- a/packages/studio/src/editor/use-editor-canvas-view.ts
+++ b/packages/studio/src/editor/use-editor-canvas-view.ts
@@ -9,11 +9,10 @@ import {
 } from "react";
 import {
   clampCameraZoom,
-  computeCenterCamera,
+  compute100PercentCamera,
   computeFitCamera,
   type EditorCamera,
   persistCamera,
-  readPersistedCamera,
   zoomCameraAtPoint,
 } from "@/editor/editor-camera";
 
@@ -82,6 +81,7 @@ export function useEditorCamera({
   cameraRef.current = camera;
   const getContentBoundsRef = useRef(getContentBounds);
   getContentBoundsRef.current = getContentBounds;
+  const userAdjustedCameraRef = useRef(false);
 
   const getViewportSize = useCallback(() => {
     const element = viewportRef.current;
@@ -95,9 +95,14 @@ export function useEditorCamera({
   }, [viewportRef]);
 
   const applyCamera = useCallback(
-    (next: EditorCamera) => {
+    (next: EditorCamera, options?: { userInitiated?: boolean }) => {
+      if (options?.userInitiated) {
+        userAdjustedCameraRef.current = true;
+      }
+
       setCamera(next);
-      if (persist) {
+
+      if (persist && userAdjustedCameraRef.current) {
         persistCamera(next);
       }
     },
@@ -118,7 +123,8 @@ export function useEditorCamera({
         worldY: bounds.y,
         worldWidth: bounds.width,
         worldHeight: bounds.height,
-      })
+      }),
+      { userInitiated: true }
     );
   }, [applyCamera, getViewportSize]);
 
@@ -128,19 +134,41 @@ export function useEditorCamera({
     if (!(width && height && bounds.width && bounds.height)) {
       return;
     }
-    applyCamera({
-      zoom: 1,
-      ...computeCenterCamera({
+    applyCamera(
+      compute100PercentCamera({
         viewportWidth: width,
         viewportHeight: height,
         worldX: bounds.x,
         worldY: bounds.y,
         worldWidth: bounds.width,
         worldHeight: bounds.height,
-        zoom: 1,
       }),
-    });
+      { userInitiated: true }
+    );
   }, [applyCamera, getViewportSize]);
+
+  const applyDefaultCamera = useCallback(() => {
+    if (userAdjustedCameraRef.current) {
+      return;
+    }
+
+    const { width, height } = getViewportSize();
+    const bounds = getContentBoundsRef.current();
+    if (!(width && height && bounds.width && bounds.height)) {
+      return;
+    }
+
+    setCamera(
+      compute100PercentCamera({
+        viewportWidth: width,
+        viewportHeight: height,
+        worldX: bounds.x,
+        worldY: bounds.y,
+        worldWidth: bounds.width,
+        worldHeight: bounds.height,
+      })
+    );
+  }, [getViewportSize]);
 
   const zoomBy = useCallback(
     (factor: number, anchor?: { x: number; y: number }) => {
@@ -156,7 +184,8 @@ export function useEditorCamera({
           pointX: point.x,
           pointY: point.y,
           nextZoom: cameraRef.current.zoom * factor,
-        })
+        }),
+        { userInitiated: true }
       );
     },
     [applyCamera, getViewportSize]
@@ -164,25 +193,44 @@ export function useEditorCamera({
 
   const panBy = useCallback(
     (deltaX: number, deltaY: number) => {
-      applyCamera({
-        ...cameraRef.current,
-        x: cameraRef.current.x + deltaX,
-        y: cameraRef.current.y + deltaY,
-      });
+      applyCamera(
+        {
+          ...cameraRef.current,
+          x: cameraRef.current.x + deltaX,
+          y: cameraRef.current.y + deltaY,
+        },
+        { userInitiated: true }
+      );
     },
     [applyCamera]
   );
 
   const setPan = useCallback(
     (x: number, y: number) => {
-      applyCamera({
-        ...cameraRef.current,
-        x,
-        y,
-      });
+      applyCamera(
+        {
+          ...cameraRef.current,
+          x,
+          y,
+        },
+        { userInitiated: true }
+      );
     },
     [applyCamera]
   );
+
+  useEffect(() => {
+    if (!enabled) {
+      return;
+    }
+
+    userAdjustedCameraRef.current = false;
+  }, [enabled]);
+
+  // biome-ignore lint/correctness/useExhaustiveDependencies: re-center when artboard bounds change
+  useEffect(() => {
+    applyDefaultCamera();
+  }, [applyDefaultCamera, getContentBounds]);
 
   useEffect(() => {
     if (!enabled) {
@@ -194,44 +242,11 @@ export function useEditorCamera({
       return;
     }
 
-    let initialized = false;
-
-    const initializeCamera = () => {
-      if (initialized) {
-        return;
-      }
-
-      const { width, height } = getViewportSize();
-      const bounds = getContentBoundsRef.current();
-      if (!(width && height && bounds.width && bounds.height)) {
-        return;
-      }
-
-      initialized = true;
-
-      const persisted = persist ? readPersistedCamera() : null;
-      if (persisted) {
-        setCamera(persisted);
-        return;
-      }
-
-      applyCamera(
-        computeFitCamera({
-          viewportWidth: width,
-          viewportHeight: height,
-          worldX: bounds.x,
-          worldY: bounds.y,
-          worldWidth: bounds.width,
-          worldHeight: bounds.height,
-        })
-      );
-    };
-
-    initializeCamera();
-    const observer = new ResizeObserver(initializeCamera);
+    applyDefaultCamera();
+    const observer = new ResizeObserver(applyDefaultCamera);
     observer.observe(element);
     return () => observer.disconnect();
-  }, [enabled, persist, applyCamera, getViewportSize, viewportRef]);
+  }, [applyDefaultCamera, enabled, viewportRef]);
 
   useEffect(() => {
     if (!enabled) {
@@ -281,7 +296,8 @@ export function useEditorCamera({
             pointX: event.clientX - rect.left,
             pointY: event.clientY - rect.top,
             nextZoom: cameraRef.current.zoom * factor,
-          })
+          }),
+          { userInitiated: true }
         );
         return;
       }
@@ -334,7 +350,8 @@ export function useEditorCamera({
           pointX: gestureSession.centerX,
           pointY: gestureSession.centerY,
           nextZoom: gestureSession.startZoom * gesture.scale,
-        })
+        }),
+        { userInitiated: true }
       );
     };
 
@@ -397,11 +414,14 @@ export function useEditorCamera({
         return;
       }
 
-      applyCamera({
-        ...cameraRef.current,
-        x: session.originX + (event.clientX - session.startX),
-        y: session.originY + (event.clientY - session.startY),
-      });
+      applyCamera(
+        {
+          ...cameraRef.current,
+          x: session.originX + (event.clientX - session.startX),
+          y: session.originY + (event.clientY - session.startY),
+        },
+        { userInitiated: true }
+      );
     },
     [applyCamera]
   );
@@ -497,11 +517,14 @@ export function useEditorCamera({
         const worldX = (session.centerX - session.startX) / session.startZoom;
         const worldY = (session.centerY - session.startY) / session.startZoom;
 
-        applyCamera({
-          zoom: nextZoom,
-          x: session.centerX - worldX * nextZoom,
-          y: session.centerY - worldY * nextZoom,
-        });
+        applyCamera(
+          {
+            zoom: nextZoom,
+            x: session.centerX - worldX * nextZoom,
+            y: session.centerY - worldY * nextZoom,
+          },
+          { userInitiated: true }
+        );
       };
 
       const onPointerUp = (event: PointerEvent) => {


### PR DESCRIPTION
## Summary

- Replace the homepage "Introducing Studio" pill with a two-part **Studio** / **Version 2** CTA, including shimmering text and a reusable WebGL particle badge wrapper.
- Default the Studio editor canvas to **100% zoom, centered** on load instead of restoring fit-to-view zoom from session storage.

## Test plan

- [x] `pnpm lint` passes at repo root
- [x] `pnpm check-types` passes
- [x] `pnpm build` succeeds
- [ ] Homepage hero shows aligned Studio / Version 2 pills with particles behind the button
- [ ] `/studio` loads at 100% zoom with the chart centered (fresh session)