### PR TITLE
Studio papercuts: area chart default and nav new badges

### DIFF
--- a/apps/web/lib/is-new-nav-link.ts
+++ b/apps/web/lib/is-new-nav-link.ts
@@ -1,3 +1,3 @@
 export function isNewNavLink(url: string) {
-  return url === "/studio" || url === "/docs/skills" || url === "/showcase";
+  return url === "/studio";
 }

--- a/packages/studio/src/components/studio-state-provider.tsx
+++ b/packages/studio/src/components/studio-state-provider.tsx
@@ -142,7 +142,9 @@ export function StudioStateProvider({
         ...(slug === "live-line-chart" ? { curve: "monotoneX" } : {}),
         ...(slug === "profit-loss-line" ? lineChartProfitLossDefaults : {}),
         ...(slug === "line-chart" ? lineChartStandardDefaults : {}),
-        ...(slug === "composed-chart" ? { dataSeries: 2 } : {}),
+        ...(slug === "area-chart" || slug === "composed-chart"
+          ? { dataSeries: 2 }
+          : {}),
       });
     },
     [setParams]

--- a/packages/studio/src/lib/studio-parsers.ts
+++ b/packages/studio/src/lib/studio-parsers.ts
@@ -15,7 +15,7 @@ import { PATTERN_PRESET_IDS } from "./pattern-presets";
 import type { ChartSlug } from "./types";
 
 export const studioSearchParams = {
-  chart: parseAsStringLiteral(validChartSlugs).withDefault("gauge-chart"),
+  chart: parseAsStringLiteral(validChartSlugs).withDefault("area-chart"),
   preset: parseAsStringLiteral(COLOR_PRESET_IDS).withDefault("default"),
   chartAccent: parseAsString.withDefault(""),
   seriesColors: parseAsString.withDefault(""),
@@ -153,7 +153,7 @@ export const studioSearchParams = {
   seriesDashTail: parseAsBoolean.withDefault(false),
   seriesDashFromIndex: parseAsInteger.withDefault(4),
   seriesDashArray: parseAsString.withDefault("6,4"),
-  dataSeries: parseAsInteger.withDefault(1),
+  dataSeries: parseAsInteger.withDefault(2),
   dataPoints: parseAsInteger.withDefault(12),
   lineChartMode: parseAsStringLiteral(["standard", "profitLoss"]).withDefault(
     "standard"
@@ -339,7 +339,7 @@ export function defaultStudioState(
   overrides: Partial<StudioUrlState> = {}
 ): StudioUrlState {
   return {
-    chart: "gauge-chart",
+    chart: "area-chart",
     preset: "default",
     chartAccent: "",
     seriesColors: "",
@@ -451,7 +451,7 @@ export function defaultStudioState(
     seriesDashTail: false,
     seriesDashFromIndex: 4,
     seriesDashArray: "6,4",
-    dataSeries: 1,
+    dataSeries: 2,
     dataPoints: 12,
     lineChartMode: "standard",
     showZeroLine: true,


### PR DESCRIPTION
## Summary

- Default Studio to an Area Chart with two data series instead of the Gauge chart with one series.
- Limit the orange "new" nav dot to Studio only — remove it from Showcase and Skills in the top header and docs sidebar.

## Test plan

- [x] `pnpm lint` passes at repo root
- [x] `pnpm check-types` passes
- [x] `apps/web` production build succeeds
- [ ] Open `/studio` with no query params — Area Chart with two series loads by default
- [ ] Top nav shows the new dot only on Studio (not Showcase or Skills)