### PR TITLE
fix(studio): bezier editor drag performance and pattern keys

### DIFF
--- a/packages/studio/src/components/controls/motion-curve-editor.tsx
+++ b/packages/studio/src/components/controls/motion-curve-editor.tsx
@@ -92,6 +92,8 @@ export function MotionCurveEditor({
   const displayRef = useRef(displayPoints);
   const skipMorphRef = useRef(false);
   const hasMountedRef = useRef(false);
+  const previewRafRef = useRef<number | null>(null);
+  const pendingPreviewRef = useRef<string | null>(null);
   const [curveA11yLabel, setCurveA11yLabel] = useState(
     "Interactive motion curve"
   );
@@ -195,6 +197,36 @@ export function MotionCurveEditor({
 
   useEffect(() => () => stopPlay(), [stopPlay]);
 
+  const flushPreview = useCallback(() => {
+    previewRafRef.current = null;
+    const formatted = pendingPreviewRef.current;
+    if (!formatted) {
+      return;
+    }
+    pendingPreviewRef.current = null;
+    onPreview("motionBezier", formatted);
+    onPreview("motionEase", "custom");
+  }, [onPreview]);
+
+  const schedulePreview = useCallback(
+    (formatted: string) => {
+      pendingPreviewRef.current = formatted;
+      if (previewRafRef.current == null) {
+        previewRafRef.current = requestAnimationFrame(flushPreview);
+      }
+    },
+    [flushPreview]
+  );
+
+  useEffect(
+    () => () => {
+      if (previewRafRef.current != null) {
+        cancelAnimationFrame(previewRafRef.current);
+      }
+    },
+    []
+  );
+
   // Recover handles stuck off-canvas from a previous drag (URL may hold extreme values).
   useEffect(() => {
     if (state.motionEase !== "custom") {
@@ -237,11 +269,9 @@ export function MotionCurveEditor({
       setDisplayPoints(
         targetMotionCurvePoints({ ...state, motionType: "ease" }, clamped)
       );
-      const formatted = formatMotionBezier(clamped);
-      onPreview("motionBezier", formatted);
-      onPreview("motionEase", "custom");
+      schedulePreview(formatMotionBezier(clamped));
     },
-    [activeBezier, onPreview, state, width]
+    [activeBezier, schedulePreview, state, width]
   );
 
   useEffect(() => {
@@ -252,6 +282,11 @@ export function MotionCurveEditor({
       applyHandleDrag(e.clientX, e.clientY, dragging);
     };
     const onUp = () => {
+      if (previewRafRef.current != null) {
+        cancelAnimationFrame(previewRafRef.current);
+        previewRafRef.current = null;
+      }
+      flushPreview();
       setDragging(null);
       onDragActiveChange?.(false);
       const next = dragBezierRef.current
@@ -271,7 +306,7 @@ export function MotionCurveEditor({
       window.removeEventListener("pointermove", onMove);
       window.removeEventListener("pointerup", onUp);
     };
-  }, [applyHandleDrag, dragging, onCommit, onDragActiveChange]);
+  }, [applyHandleDrag, dragging, flushPreview, onCommit, onDragActiveChange]);
 
   return (
     <div className="flex flex-col">

--- a/packages/studio/src/components/studio-chart-render.tsx
+++ b/packages/studio/src/components/studio-chart-render.tsx
@@ -25,8 +25,10 @@ function studioChartRenderPropsEqual(
   prev: StudioChartRenderProps,
   next: StudioChartRenderProps
 ): boolean {
-  return (
-    prev.displayState === next.displayState &&
+  const frameEqual =
+    prev.frame.width === next.frame.width &&
+    prev.frame.height === next.frame.height;
+  const sharedEqual =
     prev.config === next.config &&
     prev.animationKey === next.animationKey &&
     prev.dataSeed === next.dataSeed &&
@@ -36,9 +38,14 @@ function studioChartRenderPropsEqual(
     prev.motionCurveDragging === next.motionCurveDragging &&
     prev.patternDefs === next.patternDefs &&
     prev.patternFillAt === next.patternFillAt &&
-    prev.frame.width === next.frame.width &&
-    prev.frame.height === next.frame.height
-  );
+    frameEqual;
+
+  // Bezier handle drags preview motion params every frame; chart stays on committed state.
+  if (prev.motionCurveDragging && next.motionCurveDragging) {
+    return sharedEqual;
+  }
+
+  return prev.displayState === next.displayState && sharedEqual;
 }
 
 /**
@@ -87,5 +94,7 @@ export const StudioChartRender = memo(function StudioChartRender(
     ]
   );
 
-  return config.render(displayState, renderCtx);
+  const chartState = motionCurveDragging ? committedState : displayState;
+
+  return config.render(chartState, renderCtx);
 }, studioChartRenderPropsEqual);

--- a/packages/studio/src/lib/chart-animation.ts
+++ b/packages/studio/src/lib/chart-animation.ts
@@ -71,7 +71,11 @@ export function getStudioCssRevealPropsForPreview(
     "motionCurveDragging" | "committedState" | "isRecording"
   >
 ) {
-  return getStudioCssRevealProps(displayState, {
+  const motionState = ctx.motionCurveDragging
+    ? ctx.committedState
+    : displayState;
+
+  return getStudioCssRevealProps(motionState, {
     revealFrom: ctx.motionCurveDragging ? ctx.committedState : undefined,
     linear: ctx.isRecording,
   });

--- a/packages/studio/src/lib/patterns.tsx
+++ b/packages/studio/src/lib/patterns.tsx
@@ -46,6 +46,7 @@ function patternLinesForPreset(
       return (
         <PatternLines
           {...common}
+          key={id}
           orientation={["diagonal"]}
           stroke={strokeVar}
         />
@@ -54,6 +55,7 @@ function patternLinesForPreset(
       return (
         <PatternLines
           {...common}
+          key={id}
           orientation={["horizontal"]}
           stroke={strokeVar}
         />
@@ -62,6 +64,7 @@ function patternLinesForPreset(
       return (
         <PatternLines
           {...common}
+          key={id}
           orientation={["vertical"]}
           stroke={strokeVar}
         />
@@ -71,6 +74,7 @@ function patternLinesForPreset(
         <PatternLines
           {...common}
           height={8}
+          key={id}
           orientation={["diagonal", "diagonalRightToLeft"]}
           stroke={strokeVar}
           width={8}
@@ -81,6 +85,7 @@ function patternLinesForPreset(
         <PatternLines
           {...common}
           height={4}
+          key={id}
           orientation={["diagonal"]}
           stroke={strokeVar}
           strokeWidth={2}
@@ -89,7 +94,12 @@ function patternLinesForPreset(
       );
     case "accent":
       return (
-        <PatternLines {...common} orientation={["diagonal"]} stroke="#e879f9" />
+        <PatternLines
+          {...common}
+          key={id}
+          orientation={["diagonal"]}
+          stroke="#e879f9"
+        />
       );
     default:
       return null;


### PR DESCRIPTION
## Summary

- Freeze chart preview during bezier handle drags so AreaChart (and siblings) skip full re-renders on every pointer move; URL preview updates are batched to one rAF per frame.
- Add React keys to `StudioPatternDefs` pattern nodes, fixing the missing-key console warning on the default AreaChart studio screen.

## Test plan

- [x] `pnpm lint` passes at repo root
- [x] `pnpm check-types` passes
- [x] `apps/web` production build succeeds
- [ ] `/studio?chart=area-chart` — no missing-key warnings in console
- [ ] Drag bezier handles in motion panel — FPS stays smooth; chart does not replay reveal mid-drag
- [ ] Release handle — bezier value commits and chart reflects new easing