### PR TITLE
Unify Studio palette, fill, and control surface styling

### DIFF
--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -159,7 +159,7 @@
   --accent-foreground: oklch(0.987 0.002 197.1);
   --destructive: oklch(0.704 0.191 22.216);
   --border: oklch(0.56 0.0195 267.65 / 0.1);
-  --input: oklch(1 0 0 / 15%);
+  --input: oklch(0.53 0.0251 265.6 / 0.2);
   --ring: oklch(0.56 0.021 213.5);
   --chart-1: oklch(0.865 0.127 207.078);
   --chart-2: oklch(0.715 0.143 215.221);

--- a/packages/studio/src/components/chart-type-icons.tsx
+++ b/packages/studio/src/components/chart-type-icons.tsx
@@ -56,7 +56,7 @@ export function ChartTypeIcon({
       className={cn(
         variant === "plain"
           ? "inline-flex size-5 shrink-0 items-center justify-center text-foreground"
-          : "inline-flex size-8 shrink-0 items-center justify-center rounded-md bg-muted/50 text-foreground",
+          : "inline-flex size-8 shrink-0 items-center justify-center rounded-sm bg-muted/50 text-foreground",
         className
       )}
     >

--- a/packages/studio/src/components/chart-type-selector.tsx
+++ b/packages/studio/src/components/chart-type-selector.tsx
@@ -5,10 +5,10 @@ import { UnfoldMoreIcon } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 import { useState } from "react";
 import { ChartTypeIcon } from "@/components/chart-type-icons";
-import { studioInputSurfaceClass } from "@/components/controls/control-field-helpers";
 import { studioChartList } from "@/lib/registry";
 import type { ChartSlug } from "@/lib/types";
 import { Popover, PopoverContent, PopoverTrigger } from "@/ui/popover";
+import { studioSurfaceClasses } from "@/ui/toggle";
 
 export function ChartTypeSelector({
   value,
@@ -23,10 +23,10 @@ export function ChartTypeSelector({
   return (
     <Popover onOpenChange={setOpen} open={open}>
       <PopoverTrigger
+        aria-expanded={open}
         className={cn(
-          "flex h-10 w-full items-center gap-2.5 rounded-lg px-2.5 text-left text-xs outline-none transition-colors",
-          studioInputSurfaceClass,
-          "hover:bg-[var(--studio-input-background)] focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50"
+          "flex h-8 w-full items-center gap-2.5 px-2.5 text-left font-medium text-xs outline-none transition-[color,box-shadow] focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50",
+          studioSurfaceClasses
         )}
         id="studio-chart"
         type="button"
@@ -44,7 +44,7 @@ export function ChartTypeSelector({
       <PopoverContent
         align="start"
         className="w-max min-w-[var(--radix-popover-trigger-width)] p-2"
-        side="bottom"
+        side="right"
         // sideOffset={5}
       >
         <p className="px-2 py-1.5 font-medium text-[11px] text-muted-foreground uppercase tracking-wide">
@@ -58,7 +58,7 @@ export function ChartTypeSelector({
                 className={cn(
                   "flex items-center gap-2 rounded-lg px-2 py-2 text-left transition-colors",
                   selected
-                    ? "bg-accent/10 text-foreground ring-1 ring-accent/25"
+                    ? "bg-accent/50 text-foreground ring-1 ring-accent/25"
                     : "text-muted-foreground hover:bg-muted/60 hover:text-foreground"
                 )}
                 key={item.slug}

--- a/packages/studio/src/components/controls/curve-picker.tsx
+++ b/packages/studio/src/components/controls/curve-picker.tsx
@@ -1,8 +1,10 @@
 "use client";
 
-import { StudioSingleToggleGroup } from "@/components/controls/studio-toggle-group";
+import {
+  StudioTab,
+  StudioTabs,
+} from "@/components/controls/studio-toggle-group";
 import { CURVE_OPTIONS, type CurveId } from "@/lib/curves";
-import { ToggleGroupItem } from "@/ui/toggle-group";
 import { CurvePreviewIcon } from "../curve-preview-icons";
 
 export function CurvePicker({
@@ -13,16 +15,9 @@ export function CurvePicker({
   onChange: (v: CurveId) => void;
 }) {
   return (
-    <StudioSingleToggleGroup
-      className="grid w-full grid-cols-3 gap-1.5"
-      onValueChange={onChange}
-      size="card"
-      spacing={2}
-      value={value}
-      variant="studio"
-    >
+    <StudioTabs layout="cards-3" onValueChange={onChange} value={value}>
       {CURVE_OPTIONS.map((opt) => (
-        <ToggleGroupItem
+        <StudioTab
           aria-label={opt.label}
           key={opt.value}
           title={opt.label}
@@ -30,8 +25,8 @@ export function CurvePicker({
         >
           <CurvePreviewIcon className="text-current" curveId={opt.value} />
           <span className="text-center leading-tight">{opt.label}</span>
-        </ToggleGroupItem>
+        </StudioTab>
       ))}
-    </StudioSingleToggleGroup>
+    </StudioTabs>
   );
 }

--- a/packages/studio/src/components/controls/fade-edges-picker.tsx
+++ b/packages/studio/src/components/controls/fade-edges-picker.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { IconToggleGroup } from "@/components/controls/icon-toggle-group";
-import { ToggleGroupItem } from "@/ui/toggle-group";
+import { StudioTab } from "@/components/controls/studio-toggle-group";
 
 export type FadeEdgesOption = "both" | "none" | "left" | "right";
 
@@ -10,25 +10,53 @@ interface FadeIconProps {
   stops: [number, number];
 }
 
-/** Pill-shaped preview of how the fade will paint horizontally. */
+/** Diamond preview of how the fade will paint horizontally. */
 function FadeIcon({ stops }: FadeIconProps) {
+  const gradientId = `fade-icon-${stops.join("-")}`;
+  const fadeBoth = stops[0] === 0 && stops[1] === 0;
+
   return (
-    <svg aria-hidden={true} className="h-3 w-7" viewBox="0 0 28 12">
+    <svg aria-hidden className="size-5" viewBox="0 0 20 20">
       <title>Fade preview</title>
       <defs>
-        <linearGradient id={`fade-icon-${stops.join("-")}`} x1="0" x2="1">
-          <stop offset="0%" stopColor="currentColor" stopOpacity={stops[0]} />
-          <stop offset="15%" stopColor="currentColor" stopOpacity={1} />
-          <stop offset="85%" stopColor="currentColor" stopOpacity={1} />
-          <stop offset="100%" stopColor="currentColor" stopOpacity={stops[1]} />
+        <linearGradient
+          gradientTransform="rotate(-45 10 10)"
+          gradientUnits="userSpaceOnUse"
+          id={gradientId}
+          x1="5"
+          x2="15"
+          y1="10"
+          y2="10"
+        >
+          {fadeBoth ? (
+            <>
+              <stop offset="0%" stopColor="currentColor" stopOpacity={0} />
+              <stop offset="50%" stopColor="currentColor" stopOpacity={1} />
+              <stop offset="100%" stopColor="currentColor" stopOpacity={0} />
+            </>
+          ) : (
+            <>
+              <stop
+                offset="0%"
+                stopColor="currentColor"
+                stopOpacity={stops[0]}
+              />
+              <stop
+                offset="100%"
+                stopColor="currentColor"
+                stopOpacity={stops[1]}
+              />
+            </>
+          )}
         </linearGradient>
       </defs>
       <rect
-        fill={`url(#fade-icon-${stops.join("-")})`}
-        height="3"
-        rx="1.5"
-        width="28"
-        y="4.5"
+        fill={`url(#${gradientId})`}
+        height="12"
+        transform="rotate(45 10 10)"
+        width="12"
+        x="4"
+        y="4"
       />
     </svg>
   );
@@ -55,14 +83,14 @@ export function FadeEdgesPicker({
   return (
     <IconToggleGroup onValueChange={onChange} value={value}>
       {OPTIONS.map((opt) => (
-        <ToggleGroupItem
+        <StudioTab
           aria-label={opt.label}
           key={opt.value}
           title={opt.label}
           value={opt.value}
         >
           <FadeIcon stops={opt.stops} />
-        </ToggleGroupItem>
+        </StudioTab>
       ))}
     </IconToggleGroup>
   );

--- a/packages/studio/src/components/controls/fill-picker.tsx
+++ b/packages/studio/src/components/controls/fill-picker.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { cn } from "@bklitui/ui/lib/utils";
-import { Grid3x3Icon, SquareIcon } from "lucide-react";
 import { useMemo, useState } from "react";
 import {
   studioFieldLabelClass,
@@ -13,7 +12,10 @@ import {
 } from "@/components/controls/pattern-picker";
 import { PresetSwatch } from "@/components/controls/preset-select";
 import { StudioColorPicker } from "@/components/controls/studio-color-picker";
-import { StudioSingleToggleGroup } from "@/components/controls/studio-toggle-group";
+import {
+  StudioTab,
+  StudioTabs,
+} from "@/components/controls/studio-toggle-group";
 import {
   parseColorMix,
   parseOpacityFromColor,
@@ -28,11 +30,31 @@ import {
 } from "@/lib/studio-color-picker-value";
 import type { SeriesFillMode } from "@/lib/studio-series-design";
 import { Popover, PopoverContent, PopoverTrigger } from "@/ui/popover";
-import { ToggleGroupItem } from "@/ui/toggle-group";
 
 function formatTriggerLabel(color: string): string {
   const body = studioColorToOklchField(color);
   return body ? `oklch(${body})` : color;
+}
+
+function FillSwatch({
+  fillMode,
+  pattern,
+  previewColor,
+}: {
+  fillMode: SeriesFillMode;
+  pattern: PatternPresetId;
+  previewColor: string;
+}) {
+  if (fillMode === "pattern" && pattern !== "none") {
+    return <PatternSwatch preset={pattern} />;
+  }
+
+  return (
+    <span
+      className="block size-full rounded-[3px] ring-1 ring-border ring-inset"
+      style={{ background: previewColor }}
+    />
+  );
 }
 
 export function FillPicker({
@@ -58,7 +80,7 @@ export function FillPicker({
   onFillModeChange: (mode: SeriesFillMode) => void;
   onPatternChange: (pattern: PatternPresetId) => void;
 }) {
-  const [open, setOpen] = useState(false);
+  const [colorOpen, setColorOpen] = useState(false);
 
   const previewColor = useMemo(() => {
     const trimmed = color.trim();
@@ -75,90 +97,69 @@ export function FillPicker({
     return parseOpacityFromColor(color);
   }, [color]);
 
-  const triggerPreview =
-    fillMode === "pattern" && pattern !== "none" ? (
-      <span className="size-4 shrink-0 overflow-hidden rounded-[4px] ring-1 ring-border">
-        <PatternSwatch preset={pattern} />
-      </span>
-    ) : (
-      <span
-        className="size-4 shrink-0 rounded-[4px] ring-1 ring-border"
-        style={{ background: previewColor }}
-      />
-    );
-
-  const triggerLabel =
-    fillMode === "pattern" ? pattern : formatTriggerLabel(color);
+  const triggerLabel = formatTriggerLabel(color);
 
   return (
-    <div className="flex flex-col gap-1.5">
+    <div className="flex flex-col gap-2">
       {label ? <p className={studioFieldLabelClass}>{label}</p> : null}
-      <Popover onOpenChange={setOpen} open={open}>
-        <PopoverTrigger
-          className={cn(
-            "flex h-9 w-full items-center gap-2 rounded-lg px-2 text-left outline-none transition-colors",
-            studioInputSurfaceClass,
-            "hover:bg-[var(--studio-input-background)] focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50",
-            disabled && "pointer-events-none opacity-50"
-          )}
-          disabled={disabled}
-          type="button"
-        >
-          {triggerPreview}
-          <span className="min-w-0 flex-1 truncate font-mono text-foreground text-xs capitalize">
-            {triggerLabel}
-          </span>
-          {fillMode === "solid" ? (
-            <span className="shrink-0 border-border border-l pl-2 font-mono text-muted-foreground text-xs tabular-nums">
-              {opacity}%
-            </span>
-          ) : null}
-        </PopoverTrigger>
 
-        <PopoverContent
-          align="center"
-          className="w-[min(calc(100vw-2rem),18rem)] gap-3 p-3"
-          side="bottom"
-          sideOffset={8}
+      {supportsPattern ? (
+        <StudioTabs
+          layout="segmented"
+          onValueChange={onFillModeChange}
+          value={fillMode}
         >
-          {supportsPattern ? (
-            <StudioSingleToggleGroup
-              className="rounded-md border border-input bg-muted/20 p-1"
-              onValueChange={onFillModeChange}
-              size="sm"
-              spacing={2}
-              value={fillMode}
-              variant="studio"
-            >
-              <ToggleGroupItem
-                aria-label="Solid fill"
-                className="size-8 min-h-8 flex-1"
-                value="solid"
-              >
-                <SquareIcon className="size-3.5 fill-current" strokeWidth={0} />
-              </ToggleGroupItem>
-              <ToggleGroupItem
-                aria-label="Pattern fill"
-                className="size-8 min-h-8 flex-1"
-                value="pattern"
-              >
-                <Grid3x3Icon className="size-3.5" strokeWidth={1.75} />
-              </ToggleGroupItem>
-            </StudioSingleToggleGroup>
-          ) : null}
+          <StudioTab value="solid">Solid</StudioTab>
+          <StudioTab value="pattern">Pattern</StudioTab>
+        </StudioTabs>
+      ) : null}
 
-          {fillMode === "pattern" && supportsPattern ? (
-            <PatternPicker onChange={onPatternChange} value={pattern} />
-          ) : (
+      <div
+        className={cn(
+          "flex h-9 w-full min-w-0 items-center gap-2 rounded-lg px-2",
+          studioInputSurfaceClass,
+          disabled && "pointer-events-none opacity-50"
+        )}
+      >
+        <Popover onOpenChange={setColorOpen} open={colorOpen}>
+          <PopoverTrigger
+            className="flex size-4 shrink-0 items-center justify-center overflow-hidden rounded-[4px] outline-none transition-opacity hover:opacity-80 focus-visible:ring-[3px] focus-visible:ring-ring/50"
+            disabled={disabled}
+            type="button"
+          >
+            <FillSwatch
+              fillMode={fillMode}
+              pattern={pattern}
+              previewColor={previewColor}
+            />
+          </PopoverTrigger>
+
+          <PopoverContent
+            align="start"
+            className="w-[min(calc(100vw-2rem),18rem)] gap-3 p-3"
+            side="left"
+            sideOffset={8}
+          >
             <StudioColorPicker
               color={color}
               disabled={disabled}
               onChange={onColorChange}
               onPreview={onColorPreview}
             />
-          )}
-        </PopoverContent>
-      </Popover>
+          </PopoverContent>
+        </Popover>
+
+        <span className="min-w-0 flex-1 truncate font-mono text-foreground text-xs lowercase">
+          {triggerLabel}
+        </span>
+        <span className="shrink-0 border-border border-l pl-2 font-mono text-muted-foreground text-xs tabular-nums">
+          {opacity}%
+        </span>
+      </div>
+
+      {fillMode === "pattern" && supportsPattern ? (
+        <PatternPicker onChange={onPatternChange} value={pattern} />
+      ) : null}
     </div>
   );
 }
@@ -179,27 +180,25 @@ export function ThemePresetList({
     seriesColors.split("|").some((part) => part.trim());
 
   return (
-    <div className="flex flex-col gap-0.5">
-      <p className="px-0.5 font-medium text-[10px] text-muted-foreground uppercase tracking-wide">
-        Palette
-      </p>
-      <div className="grid grid-cols-1 gap-0.5">
+    <div className="flex flex-col gap-2">
+      <p className={studioFieldLabelClass}>Palette</p>
+      <div className="flex flex-wrap items-center gap-2">
         {COLOR_PRESETS.map((item) => {
           const selected = item.id === preset && !hasCustomColors;
           return (
             <button
+              aria-label={item.label}
+              aria-pressed={selected}
               className={cn(
-                "flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left text-xs transition-colors",
-                selected
-                  ? "bg-accent/10 text-foreground ring-1 ring-accent/25"
-                  : "text-muted-foreground hover:bg-muted/60 hover:text-foreground"
+                "flex size-3.5 shrink-0 items-center justify-center rounded-full ring-2 ring-transparent ring-offset-1 ring-offset-background transition-[box-shadow]",
+                selected ? "ring-white" : "hover:ring-accent"
               )}
               key={item.id}
               onClick={() => onPresetChange(item.id)}
+              title={item.label}
               type="button"
             >
-              <PresetSwatch className="size-3.5" id={item.id} />
-              <span className="truncate">{item.label}</span>
+              <PresetSwatch className="size-full ring-0" id={item.id} />
             </button>
           );
         })}

--- a/packages/studio/src/components/controls/funnel-edges-picker.tsx
+++ b/packages/studio/src/components/controls/funnel-edges-picker.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { IconToggleGroup } from "@/components/controls/icon-toggle-group";
-import { ToggleGroupItem } from "@/ui/toggle-group";
+import { StudioTab } from "@/components/controls/studio-toggle-group";
 
 function FunnelStraightIcon() {
   return (
@@ -32,20 +32,16 @@ export function FunnelEdgesPicker({
 }) {
   return (
     <IconToggleGroup onValueChange={onChange} value={value}>
-      <ToggleGroupItem
-        aria-label="Curved edges"
-        title="Curved edges"
-        value="curved"
-      >
+      <StudioTab aria-label="Curved edges" title="Curved edges" value="curved">
         <FunnelCurvedIcon />
-      </ToggleGroupItem>
-      <ToggleGroupItem
+      </StudioTab>
+      <StudioTab
         aria-label="Straight edges"
         title="Straight edges"
         value="straight"
       >
         <FunnelStraightIcon />
-      </ToggleGroupItem>
+      </StudioTab>
     </IconToggleGroup>
   );
 }

--- a/packages/studio/src/components/controls/icon-toggle-group.tsx
+++ b/packages/studio/src/components/controls/icon-toggle-group.tsx
@@ -3,30 +3,24 @@
 import type { IconSvgElement } from "@hugeicons/react";
 import { HugeiconsIcon } from "@hugeicons/react";
 import type { ReactNode } from "react";
-import { StudioSingleToggleGroup } from "@/components/controls/studio-toggle-group";
-import { ToggleGroupItem } from "@/ui/toggle-group";
+import {
+  StudioTab,
+  StudioTabs,
+} from "@/components/controls/studio-toggle-group";
 
 export function IconToggleGroup<T extends string>({
   value,
   onValueChange,
-  className,
   children,
 }: {
   value: T;
   onValueChange: (value: T) => void;
-  className?: string;
   children: ReactNode;
 }) {
   return (
-    <StudioSingleToggleGroup
-      className={className}
-      onValueChange={onValueChange}
-      size="icon"
-      value={value}
-      variant="studio"
-    >
+    <StudioTabs layout="icons" onValueChange={onValueChange} value={value}>
       {children}
-    </StudioSingleToggleGroup>
+    </StudioTabs>
   );
 }
 
@@ -35,25 +29,18 @@ export function IconToggleButton({
   label,
   icon,
   children,
-  className,
 }: {
   value: string;
   label: string;
   icon?: IconSvgElement;
   children?: ReactNode;
-  className?: string;
 }) {
   return (
-    <ToggleGroupItem
-      aria-label={label}
-      className={className}
-      title={label}
-      value={value}
-    >
+    <StudioTab aria-label={label} title={label} value={value}>
       {children ??
         (icon ? (
           <HugeiconsIcon className="size-5" icon={icon} strokeWidth={1.75} />
         ) : null)}
-    </ToggleGroupItem>
+    </StudioTab>
   );
 }

--- a/packages/studio/src/components/controls/legend-position-picker.tsx
+++ b/packages/studio/src/components/controls/legend-position-picker.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import { cn } from "@bklitui/ui/lib/utils";
 import { motion, useReducedMotion } from "motion/react";
 import {
   type RefObject,
@@ -11,13 +10,16 @@ import {
 } from "react";
 import { studioFieldLabelClass } from "@/components/controls/control-field-helpers";
 import {
+  StudioTab,
+  StudioTabs,
+} from "@/components/controls/studio-toggle-group";
+import {
   type LegendPositionId,
   legendPositionId,
   parseLegendPositionId,
 } from "@/lib/legend-position";
 import type { StudioUrlState } from "@/lib/studio-parsers";
 import { Label } from "@/ui/label";
-import { ToggleGroup, ToggleGroupItem } from "@/ui/toggle-group";
 
 const POSITIONS: {
   id: LegendPositionId;
@@ -58,18 +60,15 @@ function LegendPositionToggle({
   label: string;
 }) {
   return (
-    <ToggleGroupItem
+    <StudioTab
       aria-label={label}
-      className={cn(
-        "legend-position-picker__toggle h-11 min-h-11 w-full",
-        `legend-position-picker__toggle--${id}`
-      )}
+      className={`legend-position-picker__toggle--${id}`}
       data-position={id}
       title={label}
       value={id}
     >
       <LegendToggleRing />
-    </ToggleGroupItem>
+    </StudioTab>
   );
 }
 
@@ -152,24 +151,18 @@ export function LegendPositionPicker({
             }
           />
         ) : null}
-        <ToggleGroup
-          className="legend-position-picker__grid w-full"
-          onValueChange={(values) => {
-            const next = values.at(-1) ?? values[0];
-            if (next == null) {
-              return;
-            }
+        <StudioTabs
+          layout="legend"
+          onValueChange={(next) => {
             const parsed = parseLegendPositionId(next as LegendPositionId);
             onChange(parsed.placement, parsed.align);
           }}
-          spacing={0}
-          value={[active]}
-          variant="studio"
+          value={active}
         >
           {POSITIONS.map((pos) => (
             <LegendPositionToggle id={pos.id} key={pos.id} label={pos.label} />
           ))}
-        </ToggleGroup>
+        </StudioTabs>
       </div>
     </div>
   );

--- a/packages/studio/src/components/controls/motion-control.tsx
+++ b/packages/studio/src/components/controls/motion-control.tsx
@@ -2,11 +2,13 @@
 
 import { MotionEasePresetGrid } from "@/components/controls/motion-ease-preset-grid";
 import { SliderInputGroup } from "@/components/controls/slider-input-group";
-import { StudioSingleToggleGroup } from "@/components/controls/studio-toggle-group";
+import {
+  StudioTab,
+  StudioTabs,
+} from "@/components/controls/studio-toggle-group";
 import { motionDurationToAnimationMs } from "@/lib/chart-animation";
 import { MOTION_EASE_PRESETS, type MotionType } from "@/lib/motion-config";
 import type { StudioUrlState } from "@/lib/studio-parsers";
-import { ToggleGroupItem } from "@/ui/toggle-group";
 import { MotionCurveEditor } from "./motion-curve-editor";
 
 function MotionTypeToggle({
@@ -17,20 +19,13 @@ function MotionTypeToggle({
   onChange: (v: MotionType) => void;
 }) {
   return (
-    <StudioSingleToggleGroup
-      className="rounded-lg border border-border bg-muted/30 p-1"
-      onValueChange={onChange}
-      size="sm"
-      spacing={0}
-      value={value}
-      variant="outline"
-    >
+    <StudioTabs layout="segmented" onValueChange={onChange} value={value}>
       {(["ease", "spring"] as const).map((type) => (
-        <ToggleGroupItem className="flex-1 capitalize" key={type} value={type}>
+        <StudioTab key={type} value={type}>
           {type}
-        </ToggleGroupItem>
+        </StudioTab>
       ))}
-    </StudioSingleToggleGroup>
+    </StudioTabs>
   );
 }
 

--- a/packages/studio/src/components/controls/motion-curve-editor.tsx
+++ b/packages/studio/src/components/controls/motion-curve-editor.tsx
@@ -415,28 +415,32 @@ export function MotionCurveEditor({
           studioInputSurfaceClass
         )}
       >
-        {isEase ? (
-          <Input
-            className="h-8 min-w-0 flex-1 rounded-none border-0 bg-transparent px-2.5 font-mono text-xs shadow-none focus-visible:ring-0"
-            id="motion-bezier-input"
-            onChange={(e) => {
-              const parsed = parseMotionBezier(e.target.value);
-              onPreview("motionBezier", e.target.value);
-              if (parsed) {
-                const clamped = clampEaseBezierControl(parsed);
-                setDragBezier(null);
-                onPreview("motionEase", "custom");
-                onCommit("motionBezier", formatMotionBezier(clamped));
-                onCommit("motionEase", "custom");
-              }
-            }}
-            placeholder="0.85, 0, 0.15, 1"
-            spellCheck={false}
-            value={state.motionBezier}
-          />
-        ) : (
-          <div aria-hidden className="min-w-0 flex-1" />
-        )}
+        <Input
+          className={cn(
+            "h-8 min-w-0 flex-1 rounded-none border-0 bg-transparent px-2.5 font-mono text-xs shadow-none focus-visible:ring-0",
+            !isEase && "cursor-default text-muted-foreground"
+          )}
+          id="motion-bezier-input"
+          onChange={
+            isEase
+              ? (e) => {
+                  const parsed = parseMotionBezier(e.target.value);
+                  onPreview("motionBezier", e.target.value);
+                  if (parsed) {
+                    const clamped = clampEaseBezierControl(parsed);
+                    setDragBezier(null);
+                    onPreview("motionEase", "custom");
+                    onCommit("motionBezier", formatMotionBezier(clamped));
+                    onCommit("motionEase", "custom");
+                  }
+                }
+              : undefined
+          }
+          placeholder="0.85, 0, 0.15, 1"
+          readOnly={!isEase}
+          spellCheck={false}
+          value={state.motionBezier}
+        />
         <button
           aria-label={isPlaying ? "Stop motion preview" : "Play motion preview"}
           className="flex w-9 shrink-0 items-center justify-center border-border border-l text-muted-foreground transition-colors hover:bg-muted/40 hover:text-foreground"

--- a/packages/studio/src/components/controls/motion-ease-preset-grid.tsx
+++ b/packages/studio/src/components/controls/motion-ease-preset-grid.tsx
@@ -1,14 +1,16 @@
 "use client";
 
 import { studioFieldLabelClass } from "@/components/controls/control-field-helpers";
-import { StudioSingleToggleGroup } from "@/components/controls/studio-toggle-group";
+import {
+  StudioTab,
+  StudioTabs,
+} from "@/components/controls/studio-toggle-group";
 import { MotionEasePreviewIcon } from "@/components/motion-ease-preview-icons";
 import {
   MOTION_EASE_IDS,
   MOTION_EASE_PRESETS,
   type MotionEaseId,
 } from "@/lib/motion-config";
-import { ToggleGroupItem } from "@/ui/toggle-group";
 
 export function MotionEasePresetGrid({
   value,
@@ -22,23 +24,20 @@ export function MotionEasePresetGrid({
   return (
     <div className="flex flex-col gap-2">
       <span className={studioFieldLabelClass}>{label}</span>
-      <StudioSingleToggleGroup
-        className="grid w-full grid-cols-2 gap-1.5"
+      <StudioTabs
+        layout="cards-2"
         onValueChange={(id) => onSelect(id as Exclude<MotionEaseId, "custom">)}
-        size="card"
-        spacing={2}
         value={value}
-        variant="studio"
       >
         {MOTION_EASE_IDS.filter((id) => id !== "custom").map((id) => (
-          <ToggleGroupItem key={id} value={id}>
+          <StudioTab key={id} value={id}>
             <MotionEasePreviewIcon className="text-current" easeId={id} />
             <span className="text-center leading-tight">
               {MOTION_EASE_PRESETS[id].label}
             </span>
-          </ToggleGroupItem>
+          </StudioTab>
         ))}
-      </StudioSingleToggleGroup>
+      </StudioTabs>
     </div>
   );
 }

--- a/packages/studio/src/components/controls/orientation-picker.tsx
+++ b/packages/studio/src/components/controls/orientation-picker.tsx
@@ -2,9 +2,11 @@
 
 import { ArrowRightLeft, ArrowUpDown } from "lucide-react";
 import { studioFieldLabelClass } from "@/components/controls/control-field-helpers";
-import { StudioSingleToggleGroup } from "@/components/controls/studio-toggle-group";
+import {
+  StudioTab,
+  StudioTabs,
+} from "@/components/controls/studio-toggle-group";
 import { Label } from "@/ui/label";
-import { ToggleGroupItem } from "@/ui/toggle-group";
 
 export function OrientationPicker({
   value,
@@ -18,27 +20,18 @@ export function OrientationPicker({
   return (
     <div className="space-y-2">
       <Label className={studioFieldLabelClass}>{label}</Label>
-      <StudioSingleToggleGroup
-        onValueChange={onChange}
-        size="icon"
-        value={value}
-        variant="studio"
-      >
-        <ToggleGroupItem
-          aria-label="Vertical"
-          title="Vertical"
-          value="vertical"
-        >
+      <StudioTabs layout="icons" onValueChange={onChange} value={value}>
+        <StudioTab aria-label="Vertical" title="Vertical" value="vertical">
           <ArrowUpDown className="size-5" strokeWidth={1.75} />
-        </ToggleGroupItem>
-        <ToggleGroupItem
+        </StudioTab>
+        <StudioTab
           aria-label="Horizontal"
           title="Horizontal"
           value="horizontal"
         >
           <ArrowRightLeft className="size-5" strokeWidth={1.75} />
-        </ToggleGroupItem>
-      </StudioSingleToggleGroup>
+        </StudioTab>
+      </StudioTabs>
     </div>
   );
 }

--- a/packages/studio/src/components/controls/pattern-picker.tsx
+++ b/packages/studio/src/components/controls/pattern-picker.tsx
@@ -2,6 +2,7 @@
 
 import { PatternLines } from "@bklitui/ui/charts";
 import { cn } from "@bklitui/ui/lib/utils";
+import { useId } from "react";
 import { PATTERN_PRESETS, type PatternPresetId } from "@/lib/patterns";
 
 function patternStroke(preset: PatternPresetId): string {
@@ -34,34 +35,58 @@ function patternOrientation(
   }
 }
 
-export function PatternSwatch({ preset }: { preset: PatternPresetId }) {
+export function PatternSwatch({
+  preset,
+  className,
+}: {
+  preset: PatternPresetId;
+  className?: string;
+}) {
+  const uid = useId();
+  const patternId = `${uid}-${preset}`;
+
   if (preset === "none") {
     return (
-      <span className="block size-full rounded-sm bg-[var(--chart-1)] opacity-80" />
+      <span
+        className={cn(
+          "block size-full rounded-[3px] bg-[var(--chart-1)]",
+          className
+        )}
+      />
     );
   }
 
-  const id = `swatch-${preset}`;
   const stroke = patternStroke(preset);
   const orientation = patternOrientation(preset);
 
   return (
-    <svg aria-hidden className="size-full rounded-sm" viewBox="0 0 24 24">
+    <svg
+      aria-hidden
+      className={cn(
+        "block size-full shrink-0 overflow-hidden rounded-[3px]",
+        className
+      )}
+      viewBox="0 0 24 24"
+    >
       <title>{preset}</title>
       <defs>
         <PatternLines
           height={preset === "dots" ? 4 : 6}
-          id={id}
+          id={patternId}
           orientation={orientation}
           stroke={stroke}
           strokeWidth={preset === "dots" ? 2 : 1}
           width={preset === "dots" ? 4 : 6}
         />
       </defs>
-      <rect fill={`url(#${id})`} height={24} width={24} />
+      <rect fill={`url(#${patternId})`} height={24} width={24} />
     </svg>
   );
 }
+
+const PATTERN_FILL_PRESETS = PATTERN_PRESETS.filter(
+  (preset) => preset.id !== "none"
+);
 
 export function PatternPicker({
   value,
@@ -72,11 +97,11 @@ export function PatternPicker({
 }) {
   return (
     <div className="flex flex-wrap gap-1.5">
-      {PATTERN_PRESETS.map((preset) => (
+      {PATTERN_FILL_PRESETS.map((preset) => (
         <button
           className={cn(
-            "size-8 shrink-0 overflow-hidden rounded-md ring-1 ring-foreground/10 ring-inset transition-[box-shadow,ring-color]",
-            value === preset.id && "ring-2 ring-foreground ring-inset"
+            "size-6 shrink-0 overflow-hidden rounded-[4px] bg-muted/20 ring-1 ring-border transition-[box-shadow,ring-color]",
+            value === preset.id && "ring-2 ring-foreground"
           )}
           key={preset.id}
           onClick={() => onChange(preset.id)}

--- a/packages/studio/src/components/controls/pie-fill-picker.tsx
+++ b/packages/studio/src/components/controls/pie-fill-picker.tsx
@@ -1,8 +1,10 @@
 "use client";
 
 import { PatternLines } from "@bklitui/ui/charts";
-import { StudioSingleToggleGroup } from "@/components/controls/studio-toggle-group";
-import { ToggleGroupItem } from "@/ui/toggle-group";
+import {
+  StudioTab,
+  StudioTabs,
+} from "@/components/controls/studio-toggle-group";
 
 export type PieFillMode = "solid" | "lines";
 
@@ -47,26 +49,15 @@ export function PieFillPicker({
     ];
 
   return (
-    <StudioSingleToggleGroup
-      className="grid w-full grid-cols-2 gap-2"
-      onValueChange={onChange}
-      size="default"
-      spacing={2}
-      value={value}
-      variant="studio"
-    >
+    <StudioTabs layout="swatch" onValueChange={onChange} value={value}>
       {options.map((opt) => (
-        <ToggleGroupItem
-          className="h-9 min-h-9 flex-row justify-start gap-2 px-2.5 font-normal text-xs"
-          key={opt.id}
-          value={opt.id}
-        >
+        <StudioTab key={opt.id} value={opt.id}>
           <span className="size-5 shrink-0 overflow-hidden rounded ring-1 ring-border">
             {opt.swatch}
           </span>
           {opt.label}
-        </ToggleGroupItem>
+        </StudioTab>
       ))}
-    </StudioSingleToggleGroup>
+    </StudioTabs>
   );
 }

--- a/packages/studio/src/components/controls/preset-select.tsx
+++ b/packages/studio/src/components/controls/preset-select.tsx
@@ -7,7 +7,7 @@ import { useState } from "react";
 import {
   COLOR_PRESETS,
   type ColorPresetId,
-  presetSwatchColor,
+  presetSwatchGradient,
 } from "@/lib/color-presets";
 import { Button } from "@/ui/button";
 import { Popover, PopoverContent, PopoverTrigger } from "@/ui/popover";
@@ -22,10 +22,10 @@ export function PresetSwatch({
   return (
     <span
       className={cn(
-        "size-3 shrink-0 rounded-full ring-1 ring-border",
+        "block shrink-0 rounded-full ring-1 ring-border",
         className
       )}
-      style={{ background: presetSwatchColor(id) }}
+      style={{ background: presetSwatchGradient(id) }}
     />
   );
 }

--- a/packages/studio/src/components/controls/scrub-number-field.tsx
+++ b/packages/studio/src/components/controls/scrub-number-field.tsx
@@ -66,12 +66,12 @@ export function ScrubNumberField({
     >
       <NumberFieldGroup
         className={cn(
-          "flex h-8 w-full min-w-0 items-center overflow-hidden rounded-md focus-within:border-ring focus-within:ring-3 focus-within:ring-ring/50",
+          "flex h-8 w-full min-w-0 items-center overflow-hidden rounded-sm focus-within:border-ring focus-within:ring-3 focus-within:ring-ring/50",
           studioInputSurfaceClass
         )}
       >
         <NumberFieldScrubArea
-          className="flex shrink-0 cursor-ew-resize select-none items-center self-stretch border-border border-r px-1.5 text-muted-foreground hover:text-foreground data-[scrubbing]:text-foreground"
+          className="flex shrink-0 cursor-ew-resize select-none items-center self-stretch px-1.5 text-muted-foreground hover:text-foreground data-[scrubbing]:text-foreground"
           direction="horizontal"
         >
           {scrubIcon ?? (

--- a/packages/studio/src/components/controls/studio-toggle-group.tsx
+++ b/packages/studio/src/components/controls/studio-toggle-group.tsx
@@ -2,13 +2,134 @@
 
 import { cn } from "@bklitui/ui/lib/utils";
 import type { VariantProps } from "class-variance-authority";
-import type { ReactNode } from "react";
+import {
+  type ComponentProps,
+  createContext,
+  type ReactNode,
+  useContext,
+} from "react";
 import type { toggleVariants } from "@/ui/toggle";
-import { ToggleGroup } from "@/ui/toggle-group";
+import { ToggleGroup, ToggleGroupItem } from "@/ui/toggle-group";
 
-type ToggleVariant = VariantProps<typeof toggleVariants>["variant"];
-type ToggleSize = VariantProps<typeof toggleVariants>["size"];
+/** Studio sidebar tab layouts — single source of truth for all segmented controls. */
+export type StudioTabsLayout =
+  | "segmented"
+  | "icons"
+  | "cards-2"
+  | "cards-3"
+  | "swatch"
+  | "legend";
 
+interface LayoutConfig {
+  groupClassName: string;
+  itemClassName?: string;
+  size: NonNullable<VariantProps<typeof toggleVariants>["size"]>;
+  spacing: number;
+  variant: NonNullable<VariantProps<typeof toggleVariants>["variant"]>;
+}
+
+export const STUDIO_TABS_LAYOUTS: Record<StudioTabsLayout, LayoutConfig> = {
+  /** Small text tabs in a pill (Fill mode, motion type, etc.). */
+  segmented: {
+    groupClassName:
+      "grid w-full grid-cols-[repeat(auto-fit,minmax(0,1fr))] gap-0",
+    itemClassName: "flex-1",
+    size: "segmented",
+    spacing: 0,
+    variant: "studio",
+  },
+  /** Equal-width icon row (orientation, fade edges, line cap, …). */
+  icons: {
+    groupClassName: "w-full",
+    size: "icon",
+    spacing: 2,
+    variant: "studio",
+  },
+  /** Two-column preview cards (motion ease presets). */
+  "cards-2": {
+    groupClassName: "grid w-full grid-cols-2 gap-1.5",
+    size: "card",
+    spacing: 2,
+    variant: "studio",
+  },
+  /** Three-column preview cards (curve type). */
+  "cards-3": {
+    groupClassName: "grid w-full grid-cols-3 gap-1.5",
+    size: "card",
+    spacing: 2,
+    variant: "studio",
+  },
+  /** Swatch + label rows (pie fill). */
+  swatch: {
+    groupClassName: "grid w-full grid-cols-2 gap-2",
+    size: "swatch",
+    spacing: 2,
+    variant: "studio",
+  },
+  /** 3×2 placement grid — pair with legend BEM classes on items. */
+  legend: {
+    groupClassName: "legend-position-picker__grid w-full",
+    itemClassName: "legend-position-picker__toggle h-11 min-h-11 w-full",
+    size: "icon",
+    spacing: 0,
+    variant: "studio",
+  },
+};
+
+const StudioTabsLayoutContext = createContext<StudioTabsLayout>("segmented");
+
+export function StudioTabs<T extends string>({
+  layout = "segmented",
+  value,
+  onValueChange,
+  className,
+  children,
+}: {
+  layout?: StudioTabsLayout;
+  value: T;
+  onValueChange: (value: T) => void;
+  className?: string;
+  children: ReactNode;
+}) {
+  const config = STUDIO_TABS_LAYOUTS[layout];
+
+  return (
+    <StudioTabsLayoutContext.Provider value={layout}>
+      <ToggleGroup
+        className={cn(config.groupClassName, className)}
+        onValueChange={(values) => {
+          const next = values.at(-1) ?? values[0];
+          if (next != null) {
+            onValueChange(next as T);
+          }
+        }}
+        size={config.size}
+        spacing={config.spacing}
+        value={[value]}
+        variant={config.variant}
+      >
+        {children}
+      </ToggleGroup>
+    </StudioTabsLayoutContext.Provider>
+  );
+}
+
+export function StudioTab({
+  className,
+  children,
+  ...props
+}: ComponentProps<typeof ToggleGroupItem>) {
+  const layout = useContext(StudioTabsLayoutContext);
+  const config = STUDIO_TABS_LAYOUTS[layout];
+
+  return (
+    <ToggleGroupItem className={cn(config.itemClassName, className)} {...props}>
+      {children}
+    </ToggleGroupItem>
+  );
+}
+
+/** @deprecated Use `StudioTabs` with an explicit `layout`. */
 export function StudioSingleToggleGroup<T extends string>({
   value,
   onValueChange,
@@ -22,8 +143,8 @@ export function StudioSingleToggleGroup<T extends string>({
   onValueChange: (value: T) => void;
   className?: string;
   spacing?: number;
-  variant?: ToggleVariant;
-  size?: ToggleSize;
+  variant?: VariantProps<typeof toggleVariants>["variant"];
+  size?: VariantProps<typeof toggleVariants>["size"];
   children: ReactNode;
 }) {
   return (

--- a/packages/studio/src/components/studio-scramble-data-button.tsx
+++ b/packages/studio/src/components/studio-scramble-data-button.tsx
@@ -1,9 +1,7 @@
 "use client";
 
-import { ShuffleIcon } from "@hugeicons/core-free-icons";
-import { HugeiconsIcon } from "@hugeicons/react";
-import { cn } from "@/lib/utils";
-import { Button } from "@/ui/button";
+import { cn } from "@bklitui/ui/lib/utils";
+import { studioSurfaceClasses } from "@/ui/toggle";
 
 export function StudioScrambleDataButton({
   className,
@@ -15,17 +13,17 @@ export function StudioScrambleDataButton({
   onScramble: () => void;
 }) {
   return (
-    <Button
-      aria-label="Scramble data"
-      className={cn("h-8 w-full justify-start gap-2 px-2 text-xs", className)}
+    <button
+      className={cn(
+        "flex h-8 w-full items-center justify-center px-2.5 text-center font-medium text-xs outline-none transition-[color,box-shadow] focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:pointer-events-none disabled:opacity-50",
+        studioSurfaceClasses,
+        className
+      )}
       disabled={disabled}
       onClick={onScramble}
-      size="sm"
       type="button"
-      variant="outline"
     >
-      <HugeiconsIcon icon={ShuffleIcon} size={14} strokeWidth={1.5} />
       Scramble data
-    </Button>
+    </button>
   );
 }

--- a/packages/studio/src/lib/color-presets.ts
+++ b/packages/studio/src/lib/color-presets.ts
@@ -94,3 +94,11 @@ export function presetSwatchColor(id: ColorPresetId): string {
   const preset = COLOR_PRESETS.find((p) => p.id === id);
   return preset?.vars["--chart-1"] ?? "var(--chart-1)";
 }
+
+/** Radial preview from chart-1 (top-left) to chart-5 for palette circles. */
+export function presetSwatchGradient(id: ColorPresetId): string {
+  const preset = COLOR_PRESETS.find((p) => p.id === id);
+  const chart1 = preset?.vars["--chart-1"] ?? "var(--chart-1)";
+  const chart5 = preset?.vars["--chart-5"] ?? "var(--chart-5)";
+  return `radial-gradient(circle at 0% 0%, ${chart1}, ${chart5})`;
+}

--- a/packages/studio/src/ui/toggle-group.tsx
+++ b/packages/studio/src/ui/toggle-group.tsx
@@ -12,6 +12,12 @@ import {
 } from "react";
 import { toggleVariants } from "@/ui/toggle";
 
+/**
+ * Low-level toggle group primitive for Studio.
+ * Prefer `StudioTabs` / `StudioTab` from `studio-toggle-group.tsx` in sidebar controls —
+ * that file owns layout presets; this file owns spacing, segmented join behavior, and item chrome.
+ */
+
 const ToggleGroupContext = createContext<
   VariantProps<typeof toggleVariants> & {
     spacing?: number;
@@ -41,7 +47,7 @@ function ToggleGroup({
   return (
     <ToggleGroupPrimitive
       className={cn(
-        "group/toggle-group flex w-fit flex-row items-center gap-[--spacing(var(--gap))] rounded-md data-[spacing=0]:data-[variant=outline]:shadow-xs data-vertical:flex-col data-vertical:items-stretch",
+        "group/toggle-group flex w-fit flex-row items-center gap-[--spacing(var(--gap))] rounded-sm data-[spacing=0]:data-[variant=outline]:shadow-xs data-vertical:flex-col data-vertical:items-stretch",
         className
       )}
       data-orientation={orientation}
@@ -73,7 +79,7 @@ function ToggleGroupItem({
   return (
     <TogglePrimitive
       className={cn(
-        "shrink-0 focus:z-10 focus-visible:z-10 group-data-[spacing=0]/toggle-group:rounded-none group-data-vertical/toggle-group:data-[spacing=0]:data-[variant=outline]:border-t-0 group-data-horizontal/toggle-group:data-[spacing=0]:data-[variant=outline]:border-l-0 group-data-[spacing=0]/toggle-group:px-2 group-data-[spacing=0]/toggle-group:shadow-none group-data-[spacing=0]/toggle-group:has-data-[icon=inline-end]:pr-1.5 group-data-[spacing=0]/toggle-group:has-data-[icon=inline-start]:pl-1.5 group-data-horizontal/toggle-group:data-[spacing=0]:last:rounded-r-md group-data-vertical/toggle-group:data-[spacing=0]:last:rounded-b-md group-data-vertical/toggle-group:data-[spacing=0]:data-[variant=outline]:first:border-t group-data-horizontal/toggle-group:data-[spacing=0]:data-[variant=outline]:first:border-l group-data-vertical/toggle-group:data-[spacing=0]:first:rounded-t-md group-data-horizontal/toggle-group:data-[spacing=0]:first:rounded-l-md",
+        "shrink-0 focus:z-10 focus-visible:z-10 group-data-[spacing=0]/toggle-group:rounded-none group-data-vertical/toggle-group:data-[spacing=0]:data-[variant=outline]:border-t-0 group-data-horizontal/toggle-group:data-[spacing=0]:data-[variant=outline]:border-l-0 group-data-[spacing=0]/toggle-group:px-2 group-data-[spacing=0]/toggle-group:shadow-none group-data-[spacing=0]/toggle-group:has-data-[icon=inline-end]:pr-1.5 group-data-[spacing=0]/toggle-group:has-data-[icon=inline-start]:pl-1.5 group-data-horizontal/toggle-group:data-[spacing=0]:last:rounded-r-sm group-data-vertical/toggle-group:data-[spacing=0]:last:rounded-b-sm group-data-vertical/toggle-group:data-[spacing=0]:data-[variant=outline]:first:border-t group-data-horizontal/toggle-group:data-[spacing=0]:data-[variant=outline]:first:border-l group-data-vertical/toggle-group:data-[spacing=0]:first:rounded-t-sm group-data-horizontal/toggle-group:data-[spacing=0]:first:rounded-l-sm",
         toggleVariants({
           variant: variant ?? context.variant,
           size: size ?? context.size,

--- a/packages/studio/src/ui/toggle.tsx
+++ b/packages/studio/src/ui/toggle.tsx
@@ -4,21 +4,27 @@ import { Toggle as TogglePrimitive } from "@base-ui/react/toggle";
 import { cn } from "@bklitui/ui/lib/utils";
 import { cva, type VariantProps } from "class-variance-authority";
 
+/** Shared studio control surface — tabs, dropdown triggers, etc. */
+export const studioSurfaceClasses =
+  "rounded-sm border-x-0 bg-linear-to-b from-accent/50 to-accent/10 text-muted-foreground hover:text-foreground aria-pressed:bg-accent/10 aria-pressed:text-foreground data-pressed:bg-accent/30 data-pressed:text-foreground aria-expanded:bg-accent/30 aria-expanded:text-foreground";
+
 const toggleVariants = cva(
-  "group/toggle inline-flex shrink-0 items-center justify-center gap-1 whitespace-nowrap rounded-md font-medium text-sm outline-none transition-[color,box-shadow] hover:text-foreground focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 disabled:pointer-events-none disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 [&_svg:not([class*='size-'])]:size-4 [&_svg]:pointer-events-none [&_svg]:shrink-0",
+  "group/toggle inline-flex shrink-0 items-center justify-center gap-1 whitespace-nowrap rounded-sm font-medium text-sm outline-none transition-[color,box-shadow] hover:text-foreground focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 disabled:pointer-events-none disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 [&_svg:not([class*='size-'])]:size-4 [&_svg]:pointer-events-none [&_svg]:shrink-0",
   {
     variants: {
       variant: {
         default: "bg-transparent hover:bg-muted",
         outline:
           "border border-input bg-[var(--studio-input-background)] shadow-xs hover:bg-muted",
-        studio:
-          "border border-input bg-[var(--studio-input-background)] text-muted-foreground shadow-xs hover:text-foreground aria-pressed:border-accent aria-pressed:bg-accent/10 aria-pressed:text-foreground data-pressed:border-accent data-pressed:bg-accent/10 data-pressed:text-foreground",
+        studio: studioSurfaceClasses,
       },
       size: {
         default:
           "h-9 min-w-9 px-2.5 has-data-[icon=inline-end]:pr-2 has-data-[icon=inline-start]:pl-2",
         sm: "h-8 min-w-8 px-2.5 has-data-[icon=inline-end]:pr-1.5 has-data-[icon=inline-start]:pl-1.5",
+        segmented: "h-6 min-h-6 min-w-0 px-2 font-normal text-[11px]",
+        swatch:
+          "h-9 min-h-9 w-full min-w-0 flex-row justify-start gap-2 px-2.5 font-normal text-xs",
         lg: "h-10 min-w-10 px-2.5 has-data-[icon=inline-end]:pr-2 has-data-[icon=inline-start]:pl-2",
         icon: "h-11 min-h-11 min-w-0 flex-1 px-0",
         card: "h-auto min-h-0 flex-col gap-1 px-1.5 py-2 font-normal text-[10px] leading-tight",


### PR DESCRIPTION
## Summary

- Centralize Studio segmented controls on `StudioTabs` with shared layout presets (`segmented`, `icons`, `cards`, `swatch`, `legend`) and extract `studioSurfaceClasses` for consistent sidebar chrome.
- Refresh fill/palette UX: compact Solid/Pattern tabs, left-aligned color popover, radial preset swatches, inline pattern grid, and lowercase oklch values.
- Polish related controls: fade-edges diamond icons, motion curve spring read-only bezier, chart selector/scramble surface alignment, and `--input` token tweak.

## Test plan

- [x] `pnpm lint` passes at repo root
- [x] `pnpm build` succeeds
- [x] `pnpm registry:build` succeeds (no registry output changes)
- [ ] Studio right pane: palette swatches, fill Solid/Pattern tabs, pattern grid
- [ ] Chart type selector and scramble button match updated surface styling
- [ ] Fade edges picker icons render correctly in all modes