### PR TITLE
feat(studio): unify sidebar control surface styling

### DIFF
--- a/packages/studio/src/components/chart-type-selector.tsx
+++ b/packages/studio/src/components/chart-type-selector.tsx
@@ -8,7 +8,7 @@ import { ChartTypeIcon } from "@/components/chart-type-icons";
 import { studioChartList } from "@/lib/registry";
 import type { ChartSlug } from "@/lib/types";
 import { Popover, PopoverContent, PopoverTrigger } from "@/ui/popover";
-import { studioSurfaceClasses } from "@/ui/toggle";
+import { StudioControlSurface } from "@/ui/studio-control-surface";
 
 export function ChartTypeSelector({
   value,
@@ -24,12 +24,14 @@ export function ChartTypeSelector({
     <Popover onOpenChange={setOpen} open={open}>
       <PopoverTrigger
         aria-expanded={open}
-        className={cn(
-          "flex h-8 w-full items-center gap-2.5 px-2.5 text-left font-medium text-xs outline-none transition-[color,box-shadow] focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50",
-          studioSurfaceClasses
-        )}
         id="studio-chart"
-        type="button"
+        render={
+          <StudioControlSurface
+            align="start"
+            aria-expanded={open}
+            type="button"
+          />
+        }
       >
         <ChartTypeIcon slug={value} variant="plain" />
         <span className="min-w-0 flex-1 truncate font-medium">

--- a/packages/studio/src/components/controls/control-field-helpers.tsx
+++ b/packages/studio/src/components/controls/control-field-helpers.tsx
@@ -20,7 +20,10 @@ export const studioControlRowClass = "flex min-w-0 items-center gap-2.5";
 /** Compact font size for sidebar inputs — overrides the Input default `text-sm`. */
 export const studioControlInputClass = "text-xs";
 
-/** Shared surface for sidebar inputs/triggers — tune via `--studio-input-background`. */
+/**
+ * Bordered field row (scrub inputs, fill color row) — tune via `--studio-input-background`.
+ * Accent triggers / segmented tabs use `.studio-control-surface` in `styles/studio.css`.
+ */
 export const studioInputSurfaceClass =
   "border border-input bg-[var(--studio-input-background)] shadow-xs";
 

--- a/packages/studio/src/components/controls/motion-control.tsx
+++ b/packages/studio/src/components/controls/motion-control.tsx
@@ -9,6 +9,12 @@ import {
 import { motionDurationToAnimationMs } from "@/lib/chart-animation";
 import { MOTION_EASE_PRESETS, type MotionType } from "@/lib/motion-config";
 import type { StudioUrlState } from "@/lib/studio-parsers";
+
+const MOTION_TYPE_LABELS: Record<MotionType, string> = {
+  ease: "Ease",
+  spring: "Spring",
+};
+
 import { MotionCurveEditor } from "./motion-curve-editor";
 
 function MotionTypeToggle({
@@ -22,7 +28,7 @@ function MotionTypeToggle({
     <StudioTabs layout="segmented" onValueChange={onChange} value={value}>
       {(["ease", "spring"] as const).map((type) => (
         <StudioTab key={type} value={type}>
-          {type}
+          {MOTION_TYPE_LABELS[type]}
         </StudioTab>
       ))}
     </StudioTabs>

--- a/packages/studio/src/components/controls/motion-curve-editor.tsx
+++ b/packages/studio/src/components/controls/motion-curve-editor.tsx
@@ -1,7 +1,11 @@
 "use client";
 
 import { cn } from "@bklitui/ui/lib/utils";
-import { PlayIcon, StopIcon } from "@hugeicons/core-free-icons";
+import {
+  EaseCurveControlPointsIcon,
+  PlayIcon,
+  StopIcon,
+} from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 import { animate, motion, type Transition } from "motion/react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
@@ -411,13 +415,23 @@ export function MotionCurveEditor({
 
       <div
         className={cn(
-          "flex h-8 items-stretch overflow-hidden rounded-b-lg border-border border-t",
+          "flex h-9 items-stretch overflow-hidden rounded-b-lg border-border border-t",
           studioInputSurfaceClass
         )}
       >
+        <div
+          aria-hidden
+          className="flex w-9 shrink-0 items-center justify-center border-border border-r text-muted-foreground"
+        >
+          <HugeiconsIcon
+            icon={EaseCurveControlPointsIcon}
+            size={16}
+            strokeWidth={1.75}
+          />
+        </div>
         <Input
           className={cn(
-            "h-8 min-w-0 flex-1 rounded-none border-0 bg-transparent px-2.5 font-mono text-xs shadow-none focus-visible:ring-0",
+            "h-9 min-w-0 flex-1 rounded-none border-0 bg-transparent px-2.5 font-mono text-xs shadow-none focus-visible:ring-0",
             !isEase && "cursor-default text-muted-foreground"
           )}
           id="motion-bezier-input"

--- a/packages/studio/src/components/controls/studio-toggle-group.tsx
+++ b/packages/studio/src/components/controls/studio-toggle-group.tsx
@@ -45,11 +45,13 @@ export const STUDIO_TABS_LAYOUTS: Record<StudioTabsLayout, LayoutConfig> = {
     spacing: 2,
     variant: "studio",
   },
-  /** Two-column preview cards (motion ease presets). */
+  /** Two-column preview cards (motion ease presets) — joined surface group like Ease/Spring. */
   "cards-2": {
-    groupClassName: "grid w-full grid-cols-2 gap-1.5",
+    groupClassName:
+      "studio-control-surface-group--2col grid w-full grid-cols-2 gap-0",
+    itemClassName: "w-full",
     size: "card",
-    spacing: 2,
+    spacing: 0,
     variant: "studio",
   },
   /** Three-column preview cards (curve type). */

--- a/packages/studio/src/components/studio-scramble-data-button.tsx
+++ b/packages/studio/src/components/studio-scramble-data-button.tsx
@@ -1,7 +1,6 @@
 "use client";
 
-import { cn } from "@bklitui/ui/lib/utils";
-import { studioSurfaceClasses } from "@/ui/toggle";
+import { StudioControlSurface } from "@/ui/studio-control-surface";
 
 export function StudioScrambleDataButton({
   className,
@@ -13,17 +12,13 @@ export function StudioScrambleDataButton({
   onScramble: () => void;
 }) {
   return (
-    <button
-      className={cn(
-        "flex h-8 w-full items-center justify-center px-2.5 text-center font-medium text-xs outline-none transition-[color,box-shadow] focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:pointer-events-none disabled:opacity-50",
-        studioSurfaceClasses,
-        className
-      )}
+    <StudioControlSurface
+      className={className}
       disabled={disabled}
       onClick={onScramble}
       type="button"
     >
       Scramble data
-    </button>
+    </StudioControlSurface>
   );
 }

--- a/packages/studio/src/styles/studio.css
+++ b/packages/studio/src/styles/studio.css
@@ -7,6 +7,8 @@
  *     --studio-label: oklch(0.72 0.014 214.4);
  *     --studio-section-label: oklch(0.65 0.014 214.4);
  *     --studio-input-background: oklch(0.12 0.004 263);
+ *     --studio-control-surface-top: oklch(0.28 0.02 290 / 0.5);
+ *     --studio-control-surface-bottom: oklch(0.28 0.02 290 / 0.1);
  *   }
  */
 @layer base {
@@ -15,6 +17,24 @@
     --studio-section-label: var(--muted-foreground);
     /** Sidebar control surfaces (Fill trigger, scrub inputs, selects). */
     --studio-input-background: var(--background);
+    /** Accent gradient triggers, segmented tabs, toggle items — `.studio-control-surface`. */
+    --studio-control-surface-top: var(--accent);
+    --studio-control-surface-bottom: color-mix(
+      in oklch,
+      var(--accent) 10%,
+      transparent
+    );
+    --studio-control-surface-pressed: color-mix(
+      in oklch,
+      var(--input) 40%,
+      transparent
+    );
+    --studio-control-surface-pressed-shadow:
+      inset 0 0 0 1px var(--input), inset 0 -2px 2px 0 var(--background),
+      inset 0 1px 1px 0 var(--input);
+    /** Pressed cells on the bottom row of a grid (no top bevel). */
+    --studio-control-surface-pressed-shadow-grid-bottom:
+      inset 0 0 0 1px var(--input), inset 0 -2px 2px 0 var(--background);
     --studio-scrollbar-width: 8px;
     --studio-scrollbar-thumb: color-mix(
       in oklch,
@@ -54,6 +74,162 @@
 }
 
 @layer components {
+  /**
+   * Shared chrome for chart selector, scramble data, StudioTabs / toggle `variant="studio"`.
+   * Override the `--studio-control-surface-*` tokens above to theme every control at once.
+   */
+  .studio-control-surface {
+    border-left-width: 0;
+    border-right-width: 0;
+    border-radius: var(--radius-sm);
+    background-image: linear-gradient(
+      to bottom,
+      var(--studio-control-surface-top),
+      var(--studio-control-surface-bottom)
+    );
+    color: var(--muted-foreground);
+    box-shadow:
+      inset 0 0 0 1px var(--input),
+      inset 0 -2px 2px 0 var(--background),
+      inset 0 1px 1px 0 var(--input);
+  }
+
+  .studio-control-surface:hover {
+    color: var(--foreground);
+  }
+
+  /** Selected / pressed — tabs, icon toggles, triggers (same tokens everywhere). */
+  .studio-control-surface-pressed,
+  .studio-control-surface[data-pressed],
+  .studio-control-surface[aria-pressed="true"],
+  .studio-control-surface[aria-expanded="true"] {
+    background-color: var(--studio-control-surface-pressed);
+    background-image: none;
+    box-shadow: var(--studio-control-surface-pressed-shadow);
+    color: var(--foreground);
+  }
+
+  /**
+   * Segmented tabs (Ease / Spring), placement grid — one outer bevel, flat segments.
+   */
+  .studio-control-surface-group {
+    overflow: hidden;
+    border-radius: var(--radius-sm);
+    background-image: linear-gradient(
+      to bottom,
+      var(--studio-control-surface-top),
+      var(--studio-control-surface-bottom)
+    );
+    box-shadow:
+      inset 0 0 0 1px var(--input),
+      inset 0 -2px 2px 0 var(--background),
+      inset 0 1px 1px 0 var(--input);
+  }
+
+  .studio-control-surface-group > .studio-control-surface {
+    border-radius: 0;
+    background-color: transparent;
+    background-image: none;
+    box-shadow: none;
+    color: var(--muted-foreground);
+  }
+
+  .studio-control-surface-group > .studio-control-surface:hover {
+    color: var(--foreground);
+  }
+
+  .studio-control-surface-group
+    > .studio-control-surface
+    + .studio-control-surface {
+    border-left: 1px solid var(--input);
+  }
+
+  .studio-control-surface-group > .studio-control-surface-pressed,
+  .studio-control-surface-group > .studio-control-surface[data-pressed],
+  .studio-control-surface-group > .studio-control-surface[aria-pressed="true"] {
+    background-color: var(--studio-control-surface-pressed);
+    background-image: none;
+    box-shadow: var(--studio-control-surface-pressed-shadow);
+    color: var(--foreground);
+  }
+
+  /* 2×2 preset grid — joined layout, gradient + bevel on each cell (not the group). */
+  .studio-control-surface-group--2col {
+    background-image: none;
+    background-color: transparent;
+    box-shadow: none;
+  }
+
+  .studio-control-surface-group--2col > .studio-control-surface {
+    border-radius: 0 !important;
+    background-image: linear-gradient(
+      to bottom,
+      var(--studio-control-surface-top),
+      var(--studio-control-surface-bottom)
+    );
+    background-color: transparent;
+    box-shadow:
+      inset 0 0 0 1px var(--input),
+      inset 0 -2px 2px 0 var(--background),
+      inset 0 1px 1px 0 var(--input);
+    color: var(--muted-foreground);
+  }
+
+  .studio-control-surface-group--2col > .studio-control-surface:hover {
+    color: var(--foreground);
+  }
+
+  .studio-control-surface-group--2col > .studio-control-surface-pressed,
+  .studio-control-surface-group--2col > .studio-control-surface[data-pressed],
+  .studio-control-surface-group--2col
+    > .studio-control-surface[aria-pressed="true"] {
+    background-color: var(--studio-control-surface-pressed);
+    background-image: none;
+    box-shadow: var(--studio-control-surface-pressed-shadow);
+    color: var(--foreground);
+  }
+
+  .studio-control-surface-group--2col
+    > .studio-control-surface
+    + .studio-control-surface {
+    border-left: 0;
+  }
+
+  .studio-control-surface-group--2col
+    > .studio-control-surface:not(:nth-child(2n)) {
+    border-right: 1px solid var(--input);
+  }
+
+  .studio-control-surface-group--2col
+    > .studio-control-surface:nth-child(-n + 2) {
+    border-bottom: 1px solid var(--input);
+  }
+
+  .studio-control-surface-group--2col > .studio-control-surface:nth-child(1) {
+    border-top-left-radius: var(--radius-sm) !important;
+  }
+
+  .studio-control-surface-group--2col > .studio-control-surface:nth-child(2) {
+    border-top-right-radius: var(--radius-sm) !important;
+  }
+
+  .studio-control-surface-group--2col > .studio-control-surface:nth-child(3) {
+    border-bottom-left-radius: var(--radius-sm) !important;
+  }
+
+  .studio-control-surface-group--2col > .studio-control-surface:nth-child(4) {
+    border-bottom-right-radius: var(--radius-sm) !important;
+  }
+
+  .studio-control-surface-group--2col
+    > .studio-control-surface:nth-child(n + 3).studio-control-surface-pressed,
+  .studio-control-surface-group--2col
+    > .studio-control-surface:nth-child(n + 3)[data-pressed],
+  .studio-control-surface-group--2col
+    > .studio-control-surface:nth-child(n + 3)[aria-pressed="true"] {
+    box-shadow: var(--studio-control-surface-pressed-shadow-grid-bottom);
+  }
+
   .studio-label {
     color: var(--studio-label);
   }
@@ -125,10 +301,6 @@
     z-index: 1;
     display: grid !important;
     width: 100%;
-    overflow: hidden;
-    border: 1px solid var(--input);
-    border-radius: var(--radius-md);
-    background: var(--studio-input-background);
     grid-template-columns: repeat(3, minmax(0, 1fr));
     grid-template-rows: repeat(2, auto);
     gap: 0;
@@ -138,39 +310,49 @@
     display: grid !important;
   }
 
-  .legend-position-picker__toggle {
-    border: 0 !important;
+  /* Grid dividers — override single-row `border-left` from surface group. */
+  .legend-position-picker__grid > .studio-control-surface
+    + .studio-control-surface {
+    border-left: 0;
+  }
+
+  .legend-position-picker__grid > .studio-control-surface:not(:nth-child(3n)) {
+    border-right: 1px solid var(--input);
+  }
+
+  .legend-position-picker__grid > .studio-control-surface:nth-child(-n + 3) {
+    border-bottom: 1px solid var(--input);
+  }
+
+  /* Flat inner joints — only the group’s outer corners stay rounded. */
+  .legend-position-picker__grid > .studio-control-surface {
     border-radius: 0 !important;
-    box-shadow: none !important;
   }
 
-  .legend-position-picker__toggle:not(:nth-child(3n)) {
-    border-right: 1px solid var(--input) !important;
+  .legend-position-picker__grid > .legend-position-picker__toggle--top-start {
+    border-top-left-radius: var(--radius-sm) !important;
   }
 
-  .legend-position-picker__toggle:nth-child(-n + 3) {
-    border-bottom: 1px solid var(--input) !important;
+  .legend-position-picker__grid > .legend-position-picker__toggle--top-end {
+    border-top-right-radius: var(--radius-sm) !important;
   }
 
-  .legend-position-picker__toggle--top-start {
-    border-top-left-radius: calc(var(--radius-md) - 1px) !important;
+  .legend-position-picker__grid
+    > .legend-position-picker__toggle--bottom-start {
+    border-bottom-left-radius: var(--radius-sm) !important;
   }
 
-  .legend-position-picker__toggle--top-end {
-    border-top-right-radius: calc(var(--radius-md) - 1px) !important;
+  .legend-position-picker__grid > .legend-position-picker__toggle--bottom-end {
+    border-bottom-right-radius: var(--radius-sm) !important;
   }
 
-  .legend-position-picker__toggle--bottom-start {
-    border-bottom-left-radius: calc(var(--radius-md) - 1px) !important;
-  }
-
-  .legend-position-picker__toggle--bottom-end {
-    border-bottom-right-radius: calc(var(--radius-md) - 1px) !important;
-  }
-
-  .legend-position-picker__toggle[data-pressed] {
-    background: color-mix(in oklch, var(--accent) 12%, transparent) !important;
-    box-shadow: inset 0 0 0 1px var(--accent) !important;
+  .legend-position-picker__grid
+    > .studio-control-surface:nth-child(n + 4).studio-control-surface-pressed,
+  .legend-position-picker__grid
+    > .studio-control-surface:nth-child(n + 4)[data-pressed],
+  .legend-position-picker__grid
+    > .studio-control-surface:nth-child(n + 4)[aria-pressed="true"] {
+    box-shadow: var(--studio-control-surface-pressed-shadow-grid-bottom);
   }
 
   .legend-position-picker__toggle:active:not([data-pressed]) {

--- a/packages/studio/src/ui/studio-control-surface.tsx
+++ b/packages/studio/src/ui/studio-control-surface.tsx
@@ -1,0 +1,64 @@
+"use client";
+
+import { Button as ButtonPrimitive } from "@base-ui/react/button";
+import { cn } from "@bklitui/ui/lib/utils";
+import { cva, type VariantProps } from "class-variance-authority";
+
+/**
+ * Class applied to sidebar triggers, segmented tabs, and toggle items (`variant="studio"`).
+ * Visual tokens live in `styles/studio.css` (`.studio-control-surface`).
+ */
+export const studioControlSurfaceClass = "studio-control-surface";
+
+/** Segmented tabs / placement grid — one outer surface, flat segments inside. */
+export const studioControlSurfaceGroupClass = "studio-control-surface-group";
+
+/** Selected segment (also matches `[data-pressed]` in CSS). */
+export const studioControlSurfacePressedClass =
+  "studio-control-surface-pressed";
+
+/** @deprecated Use `studioControlSurfaceClass` or `studioControlSurfaceVariants`. */
+export const studioSurfaceClasses = studioControlSurfaceClass;
+
+const studioControlSurfaceVariants = cva(
+  [
+    "inline-flex shrink-0 items-center font-medium outline-none transition-[color,box-shadow]",
+    "focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50",
+    "disabled:pointer-events-none disabled:opacity-50",
+    studioControlSurfaceClass,
+  ],
+  {
+    variants: {
+      /** Layout for trigger content (chart selector vs centered actions). */
+      align: {
+        center: "justify-center text-center",
+        start: "justify-start gap-2.5 text-left",
+      },
+      size: {
+        /** Full-width sidebar triggers (chart type, scramble data, …). */
+        trigger: "h-8 w-full px-2.5 text-xs",
+      },
+    },
+    defaultVariants: {
+      align: "center",
+      size: "trigger",
+    },
+  }
+);
+
+function StudioControlSurface({
+  className,
+  size,
+  align,
+  ...props
+}: ButtonPrimitive.Props & VariantProps<typeof studioControlSurfaceVariants>) {
+  return (
+    <ButtonPrimitive
+      className={cn(studioControlSurfaceVariants({ size, align, className }))}
+      data-slot="studio-control-surface"
+      {...props}
+    />
+  );
+}
+
+export { StudioControlSurface, studioControlSurfaceVariants };

--- a/packages/studio/src/ui/toggle-group.tsx
+++ b/packages/studio/src/ui/toggle-group.tsx
@@ -10,6 +10,7 @@ import {
   type ReactNode,
   useContext,
 } from "react";
+import { studioControlSurfaceGroupClass } from "@/ui/studio-control-surface";
 import { toggleVariants } from "@/ui/toggle";
 
 /**
@@ -48,6 +49,7 @@ function ToggleGroup({
     <ToggleGroupPrimitive
       className={cn(
         "group/toggle-group flex w-fit flex-row items-center gap-[--spacing(var(--gap))] rounded-sm data-[spacing=0]:data-[variant=outline]:shadow-xs data-vertical:flex-col data-vertical:items-stretch",
+        variant === "studio" && spacing === 0 && studioControlSurfaceGroupClass,
         className
       )}
       data-orientation={orientation}
@@ -79,7 +81,7 @@ function ToggleGroupItem({
   return (
     <TogglePrimitive
       className={cn(
-        "shrink-0 focus:z-10 focus-visible:z-10 group-data-[spacing=0]/toggle-group:rounded-none group-data-vertical/toggle-group:data-[spacing=0]:data-[variant=outline]:border-t-0 group-data-horizontal/toggle-group:data-[spacing=0]:data-[variant=outline]:border-l-0 group-data-[spacing=0]/toggle-group:px-2 group-data-[spacing=0]/toggle-group:shadow-none group-data-[spacing=0]/toggle-group:has-data-[icon=inline-end]:pr-1.5 group-data-[spacing=0]/toggle-group:has-data-[icon=inline-start]:pl-1.5 group-data-horizontal/toggle-group:data-[spacing=0]:last:rounded-r-sm group-data-vertical/toggle-group:data-[spacing=0]:last:rounded-b-sm group-data-vertical/toggle-group:data-[spacing=0]:data-[variant=outline]:first:border-t group-data-horizontal/toggle-group:data-[spacing=0]:data-[variant=outline]:first:border-l group-data-vertical/toggle-group:data-[spacing=0]:first:rounded-t-sm group-data-horizontal/toggle-group:data-[spacing=0]:first:rounded-l-sm",
+        "shrink-0 focus:z-10 focus-visible:z-10 group-data-[spacing=0]/toggle-group:rounded-none group-data-vertical/toggle-group:data-[spacing=0]:data-[variant=outline]:border-t-0 group-data-horizontal/toggle-group:data-[spacing=0]:data-[variant=outline]:border-l-0 group-data-[spacing=0]/toggle-group:px-2 group-data-[spacing=0]/toggle-group:data-[variant=outline]:shadow-none group-data-[spacing=0]/toggle-group:has-data-[icon=inline-end]:pr-1.5 group-data-[spacing=0]/toggle-group:has-data-[icon=inline-start]:pl-1.5 group-data-horizontal/toggle-group:data-[spacing=0]:last:rounded-r-sm group-data-vertical/toggle-group:data-[spacing=0]:last:rounded-b-sm group-data-vertical/toggle-group:data-[spacing=0]:data-[variant=outline]:first:border-t group-data-horizontal/toggle-group:data-[spacing=0]:data-[variant=outline]:first:border-l group-data-vertical/toggle-group:data-[spacing=0]:first:rounded-t-sm group-data-horizontal/toggle-group:data-[spacing=0]:first:rounded-l-sm",
         toggleVariants({
           variant: variant ?? context.variant,
           size: size ?? context.size,

--- a/packages/studio/src/ui/toggle.tsx
+++ b/packages/studio/src/ui/toggle.tsx
@@ -3,10 +3,7 @@
 import { Toggle as TogglePrimitive } from "@base-ui/react/toggle";
 import { cn } from "@bklitui/ui/lib/utils";
 import { cva, type VariantProps } from "class-variance-authority";
-
-/** Shared studio control surface — tabs, dropdown triggers, etc. */
-export const studioSurfaceClasses =
-  "rounded-sm border-x-0 bg-linear-to-b from-accent/50 to-accent/10 text-muted-foreground hover:text-foreground aria-pressed:bg-accent/10 aria-pressed:text-foreground data-pressed:bg-accent/30 data-pressed:text-foreground aria-expanded:bg-accent/30 aria-expanded:text-foreground";
+import { studioControlSurfaceClass } from "@/ui/studio-control-surface";
 
 const toggleVariants = cva(
   "group/toggle inline-flex shrink-0 items-center justify-center gap-1 whitespace-nowrap rounded-sm font-medium text-sm outline-none transition-[color,box-shadow] hover:text-foreground focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 disabled:pointer-events-none disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 [&_svg:not([class*='size-'])]:size-4 [&_svg]:pointer-events-none [&_svg]:shrink-0",
@@ -16,13 +13,13 @@ const toggleVariants = cva(
         default: "bg-transparent hover:bg-muted",
         outline:
           "border border-input bg-[var(--studio-input-background)] shadow-xs hover:bg-muted",
-        studio: studioSurfaceClasses,
+        studio: studioControlSurfaceClass,
       },
       size: {
         default:
           "h-9 min-w-9 px-2.5 has-data-[icon=inline-end]:pr-2 has-data-[icon=inline-start]:pl-2",
         sm: "h-8 min-w-8 px-2.5 has-data-[icon=inline-end]:pr-1.5 has-data-[icon=inline-start]:pl-1.5",
-        segmented: "h-6 min-h-6 min-w-0 px-2 font-normal text-[11px]",
+        segmented: "h-8 min-h-8 min-w-0 px-2.5 font-medium text-xs",
         swatch:
           "h-9 min-h-9 w-full min-w-0 flex-row justify-start gap-2 px-2.5 font-normal text-xs",
         lg: "h-10 min-w-10 px-2.5 has-data-[icon=inline-end]:pr-2 has-data-[icon=inline-start]:pl-2",


### PR DESCRIPTION
## Summary

- Introduces `StudioControlSurface` and `.studio-control-surface` CSS tokens so chart selector, scramble data, segmented tabs, icon toggles, placement grid, and ease presets share one pressed/active look.
- Segmented controls (Ease/Spring) use a joined group bevel; preset cards use per-cell gradients in a 2×2 grid with flat inner corners.
- Motion bezier input gets a taller row and `EaseCurveControlPointsIcon` at the start.

## Test plan

- [x] `pnpm lint` passes at repo root
- [x] `pnpm check-types` passes
- [x] `pnpm build` succeeds
- [x] `pnpm registry:build` run (no registry output changes)
- [ ] `/studio` — Ease/Spring tabs, ease presets, legend placement, orientation toggles: pressed states match
- [ ] `/studio` — chart selector and scramble data match control surface chrome