### PR TITLE
fix(studio): align fill color popover with chart selector

### DIFF
--- a/packages/studio/src/components/chart-type-selector.tsx
+++ b/packages/studio/src/components/chart-type-selector.tsx
@@ -9,6 +9,10 @@ import { studioChartList } from "@/lib/registry";
 import type { ChartSlug } from "@/lib/types";
 import { Popover, PopoverContent, PopoverTrigger } from "@/ui/popover";
 import { StudioControlSurface } from "@/ui/studio-control-surface";
+import {
+  studioSidebarPopoverCollisionAvoidance,
+  studioSidebarPopoverSideOffset,
+} from "@/ui/studio-sidebar-popover";
 
 export function ChartTypeSelector({
   value,
@@ -46,8 +50,10 @@ export function ChartTypeSelector({
       <PopoverContent
         align="start"
         className="w-max min-w-[var(--radix-popover-trigger-width)] p-2"
+        collisionAvoidance={studioSidebarPopoverCollisionAvoidance}
+        positionMethod="fixed"
         side="right"
-        // sideOffset={5}
+        sideOffset={studioSidebarPopoverSideOffset}
       >
         <p className="px-2 py-1.5 font-medium text-[11px] text-muted-foreground uppercase tracking-wide">
           Chart type

--- a/packages/studio/src/components/controls/fill-picker.tsx
+++ b/packages/studio/src/components/controls/fill-picker.tsx
@@ -30,6 +30,10 @@ import {
 } from "@/lib/studio-color-picker-value";
 import type { SeriesFillMode } from "@/lib/studio-series-design";
 import { Popover, PopoverContent, PopoverTrigger } from "@/ui/popover";
+import {
+  studioSidebarPopoverCollisionAvoidance,
+  studioSidebarPopoverSideOffset,
+} from "@/ui/studio-sidebar-popover";
 
 function formatTriggerLabel(color: string): string {
   const body = studioColorToOklchField(color);
@@ -114,48 +118,54 @@ export function FillPicker({
         </StudioTabs>
       ) : null}
 
-      <div
-        className={cn(
-          "flex h-9 w-full min-w-0 items-center gap-2 rounded-lg px-2",
-          studioInputSurfaceClass,
-          disabled && "pointer-events-none opacity-50"
-        )}
-      >
-        <Popover onOpenChange={setColorOpen} open={colorOpen}>
-          <PopoverTrigger
-            className="flex size-4 shrink-0 items-center justify-center overflow-hidden rounded-[4px] outline-none transition-opacity hover:opacity-80 focus-visible:ring-[3px] focus-visible:ring-ring/50"
-            disabled={disabled}
-            type="button"
-          >
+      <Popover onOpenChange={setColorOpen} open={colorOpen}>
+        <PopoverTrigger
+          aria-expanded={colorOpen}
+          disabled={disabled}
+          render={
+            <button
+              aria-expanded={colorOpen}
+              className={cn(
+                "flex h-9 w-full min-w-0 items-center gap-2 rounded-lg px-2 text-left outline-none transition-opacity hover:opacity-90 focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50",
+                studioInputSurfaceClass,
+                disabled && "pointer-events-none opacity-50"
+              )}
+              type="button"
+            />
+          }
+        >
+          <span className="flex size-4 shrink-0 items-center justify-center overflow-hidden rounded-[4px]">
             <FillSwatch
               fillMode={fillMode}
               pattern={pattern}
               previewColor={previewColor}
             />
-          </PopoverTrigger>
+          </span>
 
-          <PopoverContent
-            align="start"
-            className="w-[min(calc(100vw-2rem),18rem)] gap-3 p-3"
-            side="left"
-            sideOffset={8}
-          >
-            <StudioColorPicker
-              color={color}
-              disabled={disabled}
-              onChange={onColorChange}
-              onPreview={onColorPreview}
-            />
-          </PopoverContent>
-        </Popover>
+          <span className="min-w-0 flex-1 truncate font-mono text-foreground text-xs lowercase">
+            {triggerLabel}
+          </span>
+          <span className="shrink-0 border-border border-l pl-2 font-mono text-muted-foreground text-xs tabular-nums">
+            {opacity}%
+          </span>
+        </PopoverTrigger>
 
-        <span className="min-w-0 flex-1 truncate font-mono text-foreground text-xs lowercase">
-          {triggerLabel}
-        </span>
-        <span className="shrink-0 border-border border-l pl-2 font-mono text-muted-foreground text-xs tabular-nums">
-          {opacity}%
-        </span>
-      </div>
+        <PopoverContent
+          align="start"
+          className="w-[min(calc(100vw-2rem),18rem)] gap-3 p-3"
+          collisionAvoidance={studioSidebarPopoverCollisionAvoidance}
+          positionMethod="fixed"
+          side="left"
+          sideOffset={studioSidebarPopoverSideOffset}
+        >
+          <StudioColorPicker
+            color={color}
+            disabled={disabled}
+            onChange={onColorChange}
+            onPreview={onColorPreview}
+          />
+        </PopoverContent>
+      </Popover>
 
       {fillMode === "pattern" && supportsPattern ? (
         <PatternPicker onChange={onPatternChange} value={pattern} />

--- a/packages/studio/src/ui/popover.tsx
+++ b/packages/studio/src/ui/popover.tsx
@@ -18,11 +18,22 @@ function PopoverContent({
   alignOffset = 0,
   side = "bottom",
   sideOffset = 4,
+  collisionAvoidance,
+  collisionBoundary,
+  collisionPadding,
+  positionMethod,
   ...props
 }: PopoverPrimitive.Popup.Props &
   Pick<
     PopoverPrimitive.Positioner.Props,
-    "align" | "alignOffset" | "side" | "sideOffset"
+    | "align"
+    | "alignOffset"
+    | "side"
+    | "sideOffset"
+    | "collisionAvoidance"
+    | "collisionBoundary"
+    | "collisionPadding"
+    | "positionMethod"
   >) {
   return (
     <PopoverPrimitive.Portal>
@@ -30,6 +41,10 @@ function PopoverContent({
         align={align}
         alignOffset={alignOffset}
         className="isolate z-50"
+        collisionAvoidance={collisionAvoidance}
+        collisionBoundary={collisionBoundary}
+        collisionPadding={collisionPadding}
+        positionMethod={positionMethod}
         side={side}
         sideOffset={sideOffset}
       >

--- a/packages/studio/src/ui/studio-sidebar-popover.ts
+++ b/packages/studio/src/ui/studio-sidebar-popover.ts
@@ -1,0 +1,10 @@
+import type { Popover as PopoverPrimitive } from "@base-ui/react/popover";
+
+/** Keep panel popovers on their canvas-facing side (shift, do not flip onto the pane). */
+export const studioSidebarPopoverCollisionAvoidance = {
+  side: "shift",
+  align: "shift",
+  fallbackAxisSide: "none",
+} satisfies PopoverPrimitive.Positioner.Props["collisionAvoidance"];
+
+export const studioSidebarPopoverSideOffset = 4;


### PR DESCRIPTION
## Summary

- Use the full fill color row as the popover trigger so `align="start"` lines up with the control, matching the chart type selector.
- Add shared sidebar popover positioning (`shift` collision, `fixed` anchoring, 4px offset) so the color picker opens into the canvas instead of flipping onto the Properties panel.
- Forward collision and `positionMethod` props through `PopoverContent` for reuse.

## Test plan

- [x] `pnpm lint` passes at repo root
- [x] `pnpm check-types` passes
- [x] `pnpm build` succeeds
- [ ] Open Studio Properties panel, click fill color row — popover sits left of the row with a gap (no overlap on sidebar)
- [ ] Chart type selector on Controls panel still opens right with the same offset feel