### PR TITLE
feat(studio): Studio 2 onboarding dialog

### DIFF
--- a/apps/studio-desktop/index.html
+++ b/apps/studio-desktop/index.html
@@ -7,7 +7,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link
-      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&display=swap"
+      href="https://fonts.googleapis.com/css2?family=Geist:wght@100..900&family=Geist+Mono:wght@100..900&family=Source+Serif+4:ital,wght@0,200..900;1,200..900&display=swap"
       rel="stylesheet"
     >
   </head>

--- a/apps/studio-desktop/src/index.css
+++ b/apps/studio-desktop/src/index.css
@@ -12,6 +12,7 @@
   --color-foreground: var(--foreground);
   --font-sans: var(--font-sans);
   --font-mono: var(--font-mono);
+  --font-serif: var(--font-serif);
   --color-sidebar-ring: var(--sidebar-ring);
   --color-sidebar-border: var(--sidebar-border);
   --color-sidebar-accent-foreground: var(--sidebar-accent-foreground);
@@ -60,11 +61,16 @@
   --radius-3xl: calc(var(--radius) + 12px);
   --radius-4xl: calc(var(--radius) + 16px);
   --font-heading: var(--font-sans);
+  --font-geist-sans: var(--font-sans);
+  --font-geist-mono: var(--font-mono);
 }
 
 :root {
-  --font-sans: "Inter", ui-sans-serif, system-ui, sans-serif;
-  --font-mono: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  --font-sans: "Geist", ui-sans-serif, system-ui, sans-serif;
+  --font-mono:
+    "Geist Mono", ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas,
+    monospace;
+  --font-serif: "Source Serif 4", ui-serif, Georgia, serif;
   --card: oklch(1 0 0);
   --card-foreground: oklch(0.148 0.004 228.8);
   --popover: oklch(1 0 0);

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -16,8 +16,9 @@
 @theme inline {
   --color-background: var(--background);
   --color-foreground: var(--foreground);
-  --font-sans: var(--font-sans);
-  --font-mono: var(--font-mono);
+  --font-sans: var(--font-geist-sans);
+  --font-mono: var(--font-geist-mono);
+  --font-serif: var(--font-serif);
   --color-sidebar-ring: var(--sidebar-ring);
   --color-sidebar-border: var(--sidebar-border);
   --color-sidebar-accent-foreground: var(--sidebar-accent-foreground);
@@ -65,7 +66,7 @@
   --radius-2xl: calc(var(--radius) + 8px);
   --radius-3xl: calc(var(--radius) + 12px);
   --radius-4xl: calc(var(--radius) + 16px);
-  --font-heading: var(--font-sans);
+  --font-heading: var(--font-geist-sans);
   --color-fd-input: var(--input);
 }
 

--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -3,24 +3,20 @@ import "./globals.css";
 import { BklitComponent } from "@bklit/sdk/nextjs";
 import { OpenPanelComponent } from "@openpanel/nextjs";
 import { RootProvider } from "fumadocs-ui/provider";
+import { GeistMono } from "geist/font/mono";
+import { GeistSans } from "geist/font/sans";
 import type { Metadata } from "next";
-import { Geist, Geist_Mono, Inter } from "next/font/google";
+import { Source_Serif_4 } from "next/font/google";
 import type { ReactNode } from "react";
 import { DocsSearchDialog } from "@/components/docs/docs-search-dialog";
 import { getOpenPanelClientId } from "@/lib/openpanel-env";
 import { SITE_URL } from "@/lib/site-url";
 import { cn } from "@/lib/utils";
 
-const inter = Inter({ subsets: ["latin"], variable: "--font-sans" });
-
-const geistMono = Geist_Mono({
+/** Paired serif until `geist/font/serif` ships in the geist package. */
+const geistSerif = Source_Serif_4({
   subsets: ["latin"],
-  variable: "--font-mono",
-});
-
-const geistHeading = Geist({
-  subsets: ["latin"],
-  variable: "--font-heading",
+  variable: "--font-serif",
 });
 
 export const metadata: Metadata = {
@@ -52,10 +48,10 @@ export default function RootLayout({ children }: { children: ReactNode }) {
   return (
     <html
       className={cn(
-        inter.variable,
-        geistMono.variable,
-        geistHeading.variable,
-        "font-sans"
+        GeistSans.variable,
+        GeistMono.variable,
+        geistSerif.variable,
+        GeistSans.className
       )}
       lang="en"
       suppressHydrationWarning

--- a/apps/web/next.config.mjs
+++ b/apps/web/next.config.mjs
@@ -5,7 +5,7 @@ const withMDX = createMDX();
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   reactStrictMode: true,
-  transpilePackages: ["@bklitui/ui", "@bklitui/studio"],
+  transpilePackages: ["@bklitui/ui", "@bklitui/studio", "geist"],
   experimental: {
     // Keeps dev/prod from pulling the entire charts package per MDX page.
     optimizePackageImports: ["@bklitui/ui", "@bklitui/ui/charts"],

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -37,6 +37,7 @@
     "fumadocs-core": "^15.2.9",
     "fumadocs-mdx": "^11.6.5",
     "fumadocs-ui": "^15.2.9",
+    "geist": "^1.7.2",
     "lucide-react": "^0.562.0",
     "mediabunny": "1.45.0",
     "modern-screenshot": "^4.7.0",

--- a/packages/studio/src/components/onboarding/particle-badge.tsx
+++ b/packages/studio/src/components/onboarding/particle-badge.tsx
@@ -1,0 +1,423 @@
+"use client";
+
+import { cn } from "@bklitui/ui/lib/utils";
+import {
+  type ComponentProps,
+  type ReactNode,
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+} from "react";
+
+interface Particle {
+  x: number;
+  y: number;
+  vx: number;
+  vy: number;
+  life: number;
+  maxLife: number;
+  size: number;
+  color: { r: number; g: number; b: number };
+}
+
+export type ParticleBadgeProps = ComponentProps<"div"> & {
+  children: ReactNode;
+  /** Extra canvas bleed around the badge for particles. */
+  bleed?: number;
+};
+
+function compileShader(
+  gl: WebGLRenderingContext,
+  type: number,
+  source: string
+) {
+  const shader = gl.createShader(type);
+  if (!shader) {
+    return null;
+  }
+
+  gl.shaderSource(shader, source);
+  gl.compileShader(shader);
+
+  if (!gl.getShaderParameter(shader, gl.COMPILE_STATUS)) {
+    gl.deleteShader(shader);
+    return null;
+  }
+
+  return shader;
+}
+
+export function ParticleBadge({
+  children,
+  className,
+  bleed = 64,
+  ...props
+}: ParticleBadgeProps) {
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+  const containerRef = useRef<HTMLDivElement>(null);
+  const targetRef = useRef<HTMLDivElement>(null);
+  const particlesRef = useRef<Particle[]>([]);
+  const animationFrameRef = useRef<number | undefined>(undefined);
+  const emitIntervalRef = useRef<ReturnType<typeof setInterval> | undefined>(
+    undefined
+  );
+  const glRef = useRef<WebGLRenderingContext | null>(null);
+  const programRef = useRef<WebGLProgram | null>(null);
+  const [isHovering, setIsHovering] = useState(false);
+
+  const getColors = useCallback((bright = false) => {
+    if (bright) {
+      return [
+        { r: 150, g: 240, b: 255 },
+        { r: 180, g: 250, b: 255 },
+        { r: 200, g: 255, b: 255 },
+      ];
+    }
+
+    return [
+      { r: 119, g: 222, b: 232 },
+      { r: 100, g: 200, b: 220 },
+      { r: 80, g: 180, b: 200 },
+    ];
+  }, []);
+
+  const initWebGL = useCallback(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) {
+      return false;
+    }
+
+    const gl = canvas.getContext("webgl", {
+      alpha: true,
+      premultipliedAlpha: false,
+      antialias: true,
+    });
+
+    if (!gl) {
+      return false;
+    }
+
+    const vertexShader = compileShader(
+      gl,
+      gl.VERTEX_SHADER,
+      `
+      attribute vec2 a_position;
+      attribute float a_size;
+      attribute vec4 a_color;
+      varying vec4 v_color;
+      uniform vec2 u_resolution;
+
+      void main() {
+        vec2 clipSpace = (a_position / u_resolution) * 2.0 - 1.0;
+        gl_Position = vec4(clipSpace * vec2(1, -1), 0, 1);
+        gl_PointSize = a_size;
+        v_color = a_color;
+      }
+    `
+    );
+
+    const fragmentShader = compileShader(
+      gl,
+      gl.FRAGMENT_SHADER,
+      `
+      precision mediump float;
+      varying vec4 v_color;
+
+      void main() {
+        vec2 center = gl_PointCoord - vec2(0.5);
+        float dist = length(center);
+
+        float alpha = 1.0 - smoothstep(0.0, 0.5, dist);
+        alpha *= v_color.a;
+
+        float glow = exp(-dist * 4.0) * 0.6;
+
+        gl_FragColor = vec4(v_color.rgb, alpha + glow * v_color.a);
+      }
+    `
+    );
+
+    if (!(vertexShader && fragmentShader)) {
+      return false;
+    }
+
+    const program = gl.createProgram();
+    if (!program) {
+      return false;
+    }
+
+    gl.attachShader(program, vertexShader);
+    gl.attachShader(program, fragmentShader);
+    gl.linkProgram(program);
+
+    if (!gl.getProgramParameter(program, gl.LINK_STATUS)) {
+      return false;
+    }
+
+    // biome-ignore lint/correctness/useHookAtTopLevel: WebGL API, not a React hook
+    gl.useProgram(program);
+    gl.enable(gl.BLEND);
+    gl.blendFunc(gl.SRC_ALPHA, gl.ONE);
+
+    glRef.current = gl;
+    programRef.current = program;
+
+    return true;
+  }, []);
+
+  const createParticle = useCallback(
+    (x: number, y: number, bright = false): Particle => {
+      const colors = getColors(bright);
+      const color = colors[Math.floor(Math.random() * colors.length)] ?? {
+        r: 119,
+        g: 222,
+        b: 232,
+      };
+      const angle = Math.random() * Math.PI * 2;
+      const speed = bright ? 0.8 + Math.random() * 2 : 0.2 + Math.random() * 1;
+      const maxLife = bright
+        ? 50 + Math.random() * 50
+        : 70 + Math.random() * 80;
+
+      return {
+        x,
+        y,
+        vx: Math.cos(angle) * speed,
+        vy: Math.sin(angle) * speed - (bright ? 1 : 0.2),
+        life: maxLife,
+        maxLife,
+        size: bright ? 2 + Math.random() * 5 : 1 + Math.random() * 3,
+        color,
+      };
+    },
+    [getColors]
+  );
+
+  const emitFromEdges = useCallback(
+    (aggressive = false) => {
+      const target = targetRef.current;
+      const container = containerRef.current;
+      if (!(target && container)) {
+        return;
+      }
+
+      const containerRect = container.getBoundingClientRect();
+      const targetRect = target.getBoundingClientRect();
+      const offsetX = targetRect.left - containerRect.left;
+      const offsetY = targetRect.top - containerRect.top;
+      const targetWidth = targetRect.width;
+      const targetHeight = targetRect.height;
+      const particleCount = aggressive ? 4 : 2;
+
+      for (let index = 0; index < particleCount; index++) {
+        const edge = Math.floor(Math.random() * 4);
+        let x = offsetX;
+        let y = offsetY;
+
+        switch (edge) {
+          case 0:
+            x = offsetX + Math.random() * targetWidth;
+            y = offsetY;
+            break;
+          case 1:
+            x = offsetX + targetWidth;
+            y = offsetY + Math.random() * targetHeight;
+            break;
+          case 2:
+            x = offsetX + Math.random() * targetWidth;
+            y = offsetY + targetHeight;
+            break;
+          default:
+            x = offsetX;
+            y = offsetY + Math.random() * targetHeight;
+            break;
+        }
+
+        particlesRef.current.push(createParticle(x, y, aggressive));
+      }
+
+      if (particlesRef.current.length > 400) {
+        particlesRef.current = particlesRef.current.slice(-400);
+      }
+    },
+    [createParticle]
+  );
+
+  const render = useCallback(() => {
+    const gl = glRef.current;
+    const program = programRef.current;
+    const canvas = canvasRef.current;
+
+    if (!(gl && program && canvas)) {
+      animationFrameRef.current = requestAnimationFrame(render);
+      return;
+    }
+
+    gl.clearColor(0, 0, 0, 0);
+    gl.clear(gl.COLOR_BUFFER_BIT);
+
+    particlesRef.current = particlesRef.current.filter((particle) => {
+      particle.x += particle.vx;
+      particle.y += particle.vy;
+      particle.vy += 0.015;
+      particle.vx *= 0.995;
+      particle.life--;
+      return particle.life > 0;
+    });
+
+    if (particlesRef.current.length > 0) {
+      const dpr = window.devicePixelRatio || 1;
+      const positions: number[] = [];
+      const sizes: number[] = [];
+      const colors: number[] = [];
+
+      for (const particle of particlesRef.current) {
+        const alpha = (particle.life / particle.maxLife) * 0.9;
+        positions.push(particle.x * dpr, particle.y * dpr);
+        sizes.push(
+          particle.size * dpr * (particle.life / particle.maxLife + 0.5)
+        );
+        colors.push(
+          particle.color.r / 255,
+          particle.color.g / 255,
+          particle.color.b / 255,
+          alpha
+        );
+      }
+
+      const resolutionLocation = gl.getUniformLocation(program, "u_resolution");
+      gl.uniform2f(resolutionLocation, canvas.width, canvas.height);
+
+      const positionBuffer = gl.createBuffer();
+      gl.bindBuffer(gl.ARRAY_BUFFER, positionBuffer);
+      gl.bufferData(
+        gl.ARRAY_BUFFER,
+        new Float32Array(positions),
+        gl.STATIC_DRAW
+      );
+      const positionLocation = gl.getAttribLocation(program, "a_position");
+      gl.enableVertexAttribArray(positionLocation);
+      gl.vertexAttribPointer(positionLocation, 2, gl.FLOAT, false, 0, 0);
+
+      const sizeBuffer = gl.createBuffer();
+      gl.bindBuffer(gl.ARRAY_BUFFER, sizeBuffer);
+      gl.bufferData(gl.ARRAY_BUFFER, new Float32Array(sizes), gl.STATIC_DRAW);
+      const sizeLocation = gl.getAttribLocation(program, "a_size");
+      gl.enableVertexAttribArray(sizeLocation);
+      gl.vertexAttribPointer(sizeLocation, 1, gl.FLOAT, false, 0, 0);
+
+      const colorBuffer = gl.createBuffer();
+      gl.bindBuffer(gl.ARRAY_BUFFER, colorBuffer);
+      gl.bufferData(gl.ARRAY_BUFFER, new Float32Array(colors), gl.STATIC_DRAW);
+      const colorLocation = gl.getAttribLocation(program, "a_color");
+      gl.enableVertexAttribArray(colorLocation);
+      gl.vertexAttribPointer(colorLocation, 4, gl.FLOAT, false, 0, 0);
+
+      gl.drawArrays(gl.POINTS, 0, particlesRef.current.length);
+
+      gl.deleteBuffer(positionBuffer);
+      gl.deleteBuffer(sizeBuffer);
+      gl.deleteBuffer(colorBuffer);
+    }
+
+    animationFrameRef.current = requestAnimationFrame(render);
+  }, []);
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    const container = containerRef.current;
+    if (!(canvas && container)) {
+      return;
+    }
+
+    const resizeCanvas = () => {
+      const rect = container.getBoundingClientRect();
+      const dpr = window.devicePixelRatio || 1;
+
+      canvas.width = rect.width * dpr;
+      canvas.height = rect.height * dpr;
+      canvas.style.width = `${rect.width}px`;
+      canvas.style.height = `${rect.height}px`;
+
+      if (glRef.current) {
+        glRef.current.viewport(0, 0, canvas.width, canvas.height);
+      }
+    };
+
+    resizeCanvas();
+    initWebGL();
+
+    const resizeObserver = new ResizeObserver(resizeCanvas);
+    resizeObserver.observe(container);
+    animationFrameRef.current = requestAnimationFrame(render);
+
+    return () => {
+      resizeObserver.disconnect();
+      if (animationFrameRef.current) {
+        cancelAnimationFrame(animationFrameRef.current);
+      }
+    };
+  }, [initWebGL, render]);
+
+  useEffect(() => {
+    emitIntervalRef.current = setInterval(
+      () => {
+        emitFromEdges(isHovering);
+      },
+      isHovering ? 30 : 60
+    );
+
+    return () => {
+      if (emitIntervalRef.current) {
+        clearInterval(emitIntervalRef.current);
+      }
+    };
+  }, [emitFromEdges, isHovering]);
+
+  useEffect(() => {
+    const target = targetRef.current;
+    if (!target) {
+      return;
+    }
+
+    const onEnter = () => setIsHovering(true);
+    const onLeave = () => setIsHovering(false);
+
+    target.addEventListener("mouseenter", onEnter);
+    target.addEventListener("mouseleave", onLeave);
+
+    return () => {
+      target.removeEventListener("mouseenter", onEnter);
+      target.removeEventListener("mouseleave", onLeave);
+    };
+  }, []);
+
+  return (
+    <div
+      className={cn(
+        "relative isolate inline-flex items-center justify-center",
+        className
+      )}
+      {...props}
+    >
+      <div
+        aria-hidden
+        className="pointer-events-none absolute top-1/2 left-1/2 z-0 -translate-x-1/2 -translate-y-1/2 overflow-hidden"
+        ref={containerRef}
+        style={{
+          width: `calc(100% + ${bleed * 2}px)`,
+          height: `calc(100% + ${bleed * 2}px)`,
+        }}
+      >
+        <canvas
+          className="pointer-events-none absolute inset-0"
+          ref={canvasRef}
+        />
+      </div>
+      <div className="relative z-10 inline-flex items-center" ref={targetRef}>
+        {children}
+      </div>
+    </div>
+  );
+}

--- a/packages/studio/src/components/onboarding/shimmering-text.tsx
+++ b/packages/studio/src/components/onboarding/shimmering-text.tsx
@@ -1,0 +1,84 @@
+"use client";
+
+import { cn } from "@bklitui/ui/lib/utils";
+import { motion, useReducedMotion, type Variants } from "motion/react";
+import { type ComponentProps, useCallback } from "react";
+
+export type ShimmeringTextProps = Omit<
+  ComponentProps<typeof motion.span>,
+  "children"
+> & {
+  /** The text to render with the shimmering effect. */
+  text: string;
+  /**
+   * Duration in seconds for one shimmer cycle.
+   * @defaultValue 1
+   */
+  duration?: number;
+  /**
+   * Whether the shimmer animation is paused.
+   * @defaultValue false
+   */
+  isStopped?: boolean;
+};
+
+export function ShimmeringText({
+  text,
+  duration = 1,
+  isStopped = false,
+  className,
+  ...props
+}: ShimmeringTextProps) {
+  const reducedMotion = useReducedMotion();
+  const stopped = isStopped || reducedMotion === true;
+
+  const createCharVariants = useCallback(
+    (charIndex: number): Variants => ({
+      running: {
+        color: ["var(--color)", "var(--shimmering-color)", "var(--color)"],
+        transition: {
+          duration,
+          repeat: Number.POSITIVE_INFINITY,
+          repeatType: "loop",
+          repeatDelay: text.length * 0.05,
+          delay: (charIndex * duration) / text.length,
+          ease: "easeInOut",
+        },
+      },
+      stopped: {
+        color: "var(--color)",
+        transition: {
+          duration: duration * 0.5,
+          ease: "easeOut",
+        },
+      },
+    }),
+    [duration, text.length]
+  );
+
+  return (
+    <motion.span
+      className={cn(
+        "inline-flex select-none items-center leading-none",
+        "[--color:var(--muted-foreground)] [--shimmering-color:var(--foreground)]",
+        className
+      )}
+      {...props}
+    >
+      {text.split("").map((char, index) => (
+        <motion.span
+          animate={stopped ? "stopped" : "running"}
+          aria-hidden
+          className="inline-block whitespace-pre leading-none"
+          initial="stopped"
+          // biome-ignore lint/suspicious/noArrayIndexKey: static label text, order never changes
+          key={index}
+          variants={createCharVariants(index)}
+        >
+          {char}
+        </motion.span>
+      ))}
+      <span className="sr-only">{text}</span>
+    </motion.span>
+  );
+}

--- a/packages/studio/src/components/onboarding/studio-version-pill.tsx
+++ b/packages/studio/src/components/onboarding/studio-version-pill.tsx
@@ -1,0 +1,43 @@
+"use client";
+
+import { ArrowRightIcon } from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
+import { Button } from "@/ui/button";
+import { ParticleBadge } from "./particle-badge";
+import { ShimmeringText } from "./shimmering-text";
+
+export function StudioVersionPill({
+  showChevron = true,
+  tabIndex,
+}: {
+  showChevron?: boolean;
+  tabIndex?: number;
+}) {
+  return (
+    <ParticleBadge>
+      <Button
+        aria-label="Studio Version 2"
+        className="relative isolate inline-flex h-auto cursor-default items-center gap-0 rounded-full bg-background px-0.5 py-0.5 text-xs"
+        tabIndex={tabIndex}
+        type="button"
+        variant="outline"
+      >
+        <span className="flex h-6 items-center rounded-full bg-muted px-2.5 text-xs leading-none">
+          Studio
+        </span>
+        <span
+          className={
+            showChevron
+              ? "flex h-6 items-center gap-1 px-2.5 text-xs leading-none"
+              : "flex h-6 items-center px-2.5 text-xs leading-none"
+          }
+        >
+          <ShimmeringText className="leading-none" text="Version 2" />
+          {showChevron ? (
+            <HugeiconsIcon className="size-3.5" icon={ArrowRightIcon} />
+          ) : null}
+        </span>
+      </Button>
+    </ParticleBadge>
+  );
+}

--- a/packages/studio/src/components/studio-onboarding-dialog.tsx
+++ b/packages/studio/src/components/studio-onboarding-dialog.tsx
@@ -1,0 +1,103 @@
+"use client";
+
+import { cn } from "@bklitui/ui/lib/utils";
+import { useCallback, useEffect, useState } from "react";
+import { ShimmeringText } from "@/components/onboarding/shimmering-text";
+import { StudioVersionPill } from "@/components/onboarding/studio-version-pill";
+import {
+  dismissStudioOnboarding,
+  isStudioOnboardingDismissed,
+} from "@/lib/studio-onboarding-cookie";
+import { Avatar, AvatarFallback, AvatarImage } from "@/ui/avatar";
+import { Button } from "@/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/ui/dialog";
+
+const MAT_AVATAR_URL = "https://github.com/uixmat.png";
+
+export function StudioOnboardingDialog() {
+  const [open, setOpen] = useState(false);
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => {
+    setMounted(true);
+    if (!isStudioOnboardingDismissed()) {
+      setOpen(true);
+    }
+  }, []);
+
+  const dismiss = useCallback(() => {
+    dismissStudioOnboarding();
+    setOpen(false);
+  }, []);
+
+  const handleOpenChange = useCallback(
+    (nextOpen: boolean) => {
+      if (!nextOpen) {
+        dismiss();
+        return;
+      }
+      setOpen(true);
+    },
+    [dismiss]
+  );
+
+  if (!mounted) {
+    return null;
+  }
+
+  return (
+    <Dialog onOpenChange={handleOpenChange} open={open}>
+      <DialogContent
+        className={cn(
+          "gap-6 px-8 py-8",
+          "[&_[data-slot=dialog-close]]:top-8 [&_[data-slot=dialog-close]]:right-8"
+        )}
+        initialFocus={false}
+      >
+        <DialogHeader className="gap-5">
+          <div className="flex justify-center">
+            <StudioVersionPill showChevron={false} tabIndex={-1} />
+          </div>
+          <DialogTitle className="flex justify-center">
+            <ShimmeringText
+              className="font-light text-4xl tracking-tight"
+              text="Welcome"
+            />
+          </DialogTitle>
+        </DialogHeader>
+
+        <figure className="flex flex-col items-center gap-4 text-center">
+          <blockquote className="max-w-sm text-balance font-light font-serif text-lg text-muted-foreground italic leading-relaxed">
+            Thank you for using Studio 2 — it means a lot. Everything here is
+            still experimental and in beta, and your feedback is what helps us
+            make it great.
+          </blockquote>
+          <figcaption className="flex items-center justify-center gap-2 font-light text-muted-foreground text-sm">
+            <Avatar size="sm">
+              <AvatarImage alt="Matt" src={MAT_AVATAR_URL} />
+              <AvatarFallback>Ma</AvatarFallback>
+            </Avatar>
+            <span>Matt</span>
+          </figcaption>
+        </figure>
+
+        <DialogFooter>
+          <Button
+            className={cn("min-w-36")}
+            onClick={dismiss}
+            size="default"
+            type="button"
+          >
+            Let&apos;s go!
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/packages/studio/src/components/studio-shell.tsx
+++ b/packages/studio/src/components/studio-shell.tsx
@@ -5,6 +5,7 @@ import type { StudioUrlState } from "@/lib/studio-parsers";
 import type { StudioAnalytics } from "@/providers/studio-analytics-context";
 import { StudioAnalyticsProvider } from "@/providers/studio-analytics-context";
 import { StudioEditorLayout } from "./studio-editor-layout";
+import { StudioOnboardingDialog } from "./studio-onboarding-dialog";
 import { StudioStateProvider } from "./studio-state-provider";
 
 export function StudioShell({
@@ -18,6 +19,7 @@ export function StudioShell({
     <StudioAnalyticsProvider value={analytics ?? {}}>
       <StudioStateProvider>
         <div className="relative flex h-full min-h-0 flex-1 flex-col overflow-hidden">
+          <StudioOnboardingDialog />
           <StudioEditorLayout renderCodeSheet={renderCodeSheet} />
         </div>
       </StudioStateProvider>

--- a/packages/studio/src/lib/studio-onboarding-cookie.ts
+++ b/packages/studio/src/lib/studio-onboarding-cookie.ts
@@ -1,0 +1,31 @@
+const COOKIE_NAME = "bklit_studio_v2_onboarding_dismissed";
+const MAX_AGE_SECONDS = 60 * 60 * 24 * 365;
+
+function readCookie(name: string): string | undefined {
+  if (typeof document === "undefined") {
+    return undefined;
+  }
+
+  const match = document.cookie.match(
+    new RegExp(`(?:^|; )${name.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}=([^;]*)`)
+  );
+  return match?.[1];
+}
+
+export function isStudioOnboardingDismissed(): boolean {
+  return readCookie(COOKIE_NAME) === "1";
+}
+
+export function dismissStudioOnboarding(): void {
+  if (typeof document === "undefined") {
+    return;
+  }
+
+  const secure =
+    typeof window !== "undefined" && window.location.protocol === "https:"
+      ? "; Secure"
+      : "";
+
+  // biome-ignore lint/suspicious/noDocumentCookie: simple dismiss flag; Cookie Store API is unnecessary here
+  document.cookie = `${COOKIE_NAME}=1; path=/; max-age=${MAX_AGE_SECONDS}; SameSite=Lax${secure}`;
+}

--- a/packages/studio/src/ui/avatar.tsx
+++ b/packages/studio/src/ui/avatar.tsx
@@ -1,0 +1,108 @@
+"use client";
+
+import { Avatar as AvatarPrimitive } from "@base-ui/react/avatar";
+import { cn } from "@bklitui/ui/lib/utils";
+import type * as React from "react";
+
+function Avatar({
+  className,
+  size = "default",
+  ...props
+}: AvatarPrimitive.Root.Props & {
+  size?: "default" | "sm" | "lg";
+}) {
+  return (
+    <AvatarPrimitive.Root
+      className={cn(
+        "group/avatar relative flex size-8 shrink-0 select-none rounded-full after:absolute after:inset-0 after:rounded-full after:border after:border-border after:mix-blend-darken data-[size=lg]:size-10 data-[size=sm]:size-6 dark:after:mix-blend-lighten",
+        className
+      )}
+      data-size={size}
+      data-slot="avatar"
+      {...props}
+    />
+  );
+}
+
+function AvatarImage({ className, ...props }: AvatarPrimitive.Image.Props) {
+  return (
+    <AvatarPrimitive.Image
+      className={cn(
+        "aspect-square size-full rounded-full object-cover",
+        className
+      )}
+      data-slot="avatar-image"
+      {...props}
+    />
+  );
+}
+
+function AvatarFallback({
+  className,
+  ...props
+}: AvatarPrimitive.Fallback.Props) {
+  return (
+    <AvatarPrimitive.Fallback
+      className={cn(
+        "flex size-full items-center justify-center rounded-full bg-muted text-muted-foreground text-sm group-data-[size=sm]/avatar:text-xs",
+        className
+      )}
+      data-slot="avatar-fallback"
+      {...props}
+    />
+  );
+}
+
+function AvatarBadge({ className, ...props }: React.ComponentProps<"span">) {
+  return (
+    <span
+      className={cn(
+        "absolute right-0 bottom-0 z-10 inline-flex select-none items-center justify-center rounded-full bg-primary text-primary-foreground bg-blend-color ring-2 ring-background",
+        "group-data-[size=sm]/avatar:size-2 group-data-[size=sm]/avatar:[&>svg]:hidden",
+        "group-data-[size=default]/avatar:size-2.5 group-data-[size=default]/avatar:[&>svg]:size-2",
+        "group-data-[size=lg]/avatar:size-3 group-data-[size=lg]/avatar:[&>svg]:size-2",
+        className
+      )}
+      data-slot="avatar-badge"
+      {...props}
+    />
+  );
+}
+
+function AvatarGroup({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      className={cn(
+        "group/avatar-group flex -space-x-2 *:data-[slot=avatar]:ring-2 *:data-[slot=avatar]:ring-background",
+        className
+      )}
+      data-slot="avatar-group"
+      {...props}
+    />
+  );
+}
+
+function AvatarGroupCount({
+  className,
+  ...props
+}: React.ComponentProps<"div">) {
+  return (
+    <div
+      className={cn(
+        "relative flex size-8 shrink-0 items-center justify-center rounded-full bg-muted text-muted-foreground text-sm ring-2 ring-background group-has-data-[size=lg]/avatar-group:size-10 group-has-data-[size=sm]/avatar-group:size-6 [&>svg]:size-4 group-has-data-[size=lg]/avatar-group:[&>svg]:size-5 group-has-data-[size=sm]/avatar-group:[&>svg]:size-3",
+        className
+      )}
+      data-slot="avatar-group-count"
+      {...props}
+    />
+  );
+}
+
+export {
+  Avatar,
+  AvatarBadge,
+  AvatarFallback,
+  AvatarGroup,
+  AvatarGroupCount,
+  AvatarImage,
+};

--- a/packages/studio/src/ui/dialog.tsx
+++ b/packages/studio/src/ui/dialog.tsx
@@ -1,0 +1,134 @@
+"use client";
+
+import { Dialog as DialogPrimitive } from "@base-ui/react/dialog";
+import { cn } from "@bklitui/ui/lib/utils";
+import { Cancel01Icon } from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
+import type * as React from "react";
+import { Button } from "@/ui/button";
+
+function Dialog({ ...props }: DialogPrimitive.Root.Props) {
+  return <DialogPrimitive.Root data-slot="dialog" {...props} />;
+}
+
+function DialogPortal({ ...props }: DialogPrimitive.Portal.Props) {
+  return <DialogPrimitive.Portal data-slot="dialog-portal" {...props} />;
+}
+
+function DialogOverlay({
+  className,
+  ...props
+}: DialogPrimitive.Backdrop.Props) {
+  return (
+    <DialogPrimitive.Backdrop
+      className={cn(
+        "fixed inset-0 z-50 bg-black/20 transition-opacity duration-150 data-ending-style:opacity-0 data-starting-style:opacity-0 supports-backdrop-filter:backdrop-blur-xs",
+        className
+      )}
+      data-slot="dialog-overlay"
+      {...props}
+    />
+  );
+}
+
+function DialogContent({
+  className,
+  children,
+  showCloseButton = true,
+  initialFocus,
+  finalFocus,
+  ...props
+}: DialogPrimitive.Popup.Props & {
+  showCloseButton?: boolean;
+}) {
+  return (
+    <DialogPortal>
+      <DialogOverlay />
+      <DialogPrimitive.Popup
+        className={cn(
+          "fixed top-1/2 left-1/2 z-50 flex w-[calc(100%-2rem)] max-w-md -translate-x-1/2 -translate-y-1/2 flex-col gap-4 rounded-xl border border-border bg-popover p-6 text-popover-foreground shadow-lg transition duration-200 ease-in-out data-ending-style:scale-95 data-starting-style:scale-95 data-ending-style:opacity-0 data-starting-style:opacity-0",
+          className
+        )}
+        data-slot="dialog-content"
+        finalFocus={finalFocus}
+        initialFocus={initialFocus}
+        {...props}
+      >
+        {children}
+        {showCloseButton ? (
+          <DialogPrimitive.Close
+            data-slot="dialog-close"
+            render={
+              <Button
+                className="absolute top-4 right-4"
+                size="icon-sm"
+                variant="ghost"
+              />
+            }
+          >
+            <HugeiconsIcon icon={Cancel01Icon} strokeWidth={2} />
+            <span className="sr-only">Close</span>
+          </DialogPrimitive.Close>
+        ) : null}
+      </DialogPrimitive.Popup>
+    </DialogPortal>
+  );
+}
+
+function DialogHeader({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      className={cn("flex flex-col gap-2 text-center", className)}
+      data-slot="dialog-header"
+      {...props}
+    />
+  );
+}
+
+function DialogFooter({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      className={cn("flex flex-col items-center gap-2", className)}
+      data-slot="dialog-footer"
+      {...props}
+    />
+  );
+}
+
+function DialogTitle({ className, ...props }: DialogPrimitive.Title.Props) {
+  return (
+    <DialogPrimitive.Title
+      className={cn(
+        "font-light text-4xl text-foreground tracking-tight",
+        className
+      )}
+      data-slot="dialog-title"
+      {...props}
+    />
+  );
+}
+
+function DialogDescription({
+  className,
+  ...props
+}: DialogPrimitive.Description.Props) {
+  return (
+    <DialogPrimitive.Description
+      className={cn(
+        "text-balance font-light text-muted-foreground text-sm leading-relaxed",
+        className
+      )}
+      data-slot="dialog-description"
+      {...props}
+    />
+  );
+}
+
+export {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+};

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -94,7 +94,7 @@ importers:
         version: 0.4.6(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       nuqs:
         specifier: ^2.8.9
-        version: 2.8.9(next@15.5.9(@babel/core@7.29.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0)
+        version: 2.8.9(next@15.5.9(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0)
       react:
         specifier: ^19.2.0
         version: 19.2.0
@@ -234,6 +234,9 @@ importers:
       fumadocs-ui:
         specifier: ^15.2.9
         version: 15.8.5(@types/react-dom@19.2.2(@types/react@19.2.2))(@types/react@19.2.2)(lucide-react@0.562.0(react@19.2.0))(next@15.5.9(@babel/core@7.29.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(tailwindcss@4.1.18)
+      geist:
+        specifier: ^1.7.2
+        version: 1.7.2(next@15.5.9(@babel/core@7.29.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))
       lucide-react:
         specifier: ^0.562.0
         version: 0.562.0(react@19.2.0)
@@ -254,7 +257,7 @@ importers:
         version: 0.4.6(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       nuqs:
         specifier: ^2.8.9
-        version: 2.8.9(next@15.5.9(@babel/core@7.29.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0)
+        version: 2.8.9(next@15.5.9(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0)
       react:
         specifier: ^19.2.0
         version: 19.2.0
@@ -417,7 +420,7 @@ importers:
         version: 0.4.6(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       nuqs:
         specifier: ^2.8.9
-        version: 2.8.9(next@15.5.9(@babel/core@7.29.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0)
+        version: 2.8.9(next@15.5.9(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0)
       react:
         specifier: ^19.2.0
         version: 19.2.0
@@ -3786,6 +3789,11 @@ packages:
 
   fuzzysort@3.1.0:
     resolution: {integrity: sha512-sR9BNCjBg6LNgwvxlBd0sBABvQitkLzoVY9MYYROQVX/FvfJ4Mai9LsGhDgd8qYdds0bY77VzYd5iuB+v5rwQQ==}
+
+  geist@1.7.2:
+    resolution: {integrity: sha512-Gu5lDFa3pLRyoBlBPf0QIFHVdWAnpco7fS1bJm41jyLPFoguBgiubseUN2oLXMgqZ7uxAxDoXcHMhCY/fOTTgg==}
+    peerDependencies:
+      next: '>=13.2.0'
 
   gensync@1.0.0-beta.2:
     resolution: {integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==}
@@ -9243,6 +9251,10 @@ snapshots:
 
   fuzzysort@3.1.0: {}
 
+  geist@1.7.2(next@15.5.9(@babel/core@7.29.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)):
+    dependencies:
+      next: 15.5.9(@babel/core@7.29.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+
   gensync@1.0.0-beta.2: {}
 
   get-caller-file@2.0.5: {}
@@ -10469,7 +10481,7 @@ snapshots:
     dependencies:
       esm-env: esm-env-runtime@0.1.1
 
-  nuqs@2.8.9(next@15.5.9(@babel/core@7.29.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0):
+  nuqs@2.8.9(next@15.5.9(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0):
     dependencies:
       '@standard-schema/spec': 1.0.0
       react: 19.2.0


### PR DESCRIPTION
## Summary

- Adds a first-visit onboarding modal in `@bklitui/studio` (`StudioShell`) with Studio Version 2 pill, shimmering Welcome title, Matt’s quote/avatar, and a dismiss cookie so it does not show again.
- Introduces studio `Dialog` and `Avatar` primitives, particle-badge layering for the pill, and Geist sans/mono via the `geist` package plus `font-serif` (Source Serif 4 until Geist Serif ships).
- Aligns studio-desktop font tokens with web.

## Test plan

- [x] `pnpm lint` passes at repo root
- [x] `pnpm check-types` passes
- [x] `pnpm build` succeeds
- [x] `pnpm registry:build` (no registry output changes)
- [ ] Clear `bklit_studio_v2_onboarding_dismissed` cookie and open `/studio` — modal appears once
- [ ] Dismiss via X, backdrop, or “Let’s go!” — cookie set, modal does not reappear on reload
- [ ] Pill has no focus ring on open; chevron hidden in modal only