### PR TITLE
fix(web): stop ParticleBadge bleed from affecting hero layout

### DIFF
--- a/apps/studio-desktop/package.json
+++ b/apps/studio-desktop/package.json
@@ -12,7 +12,8 @@
     "tauri": "tauri",
     "icon:generate": "tauri icon app-icon.png",
     "tauri:dev": "tauri dev",
-    "tauri:build": "tauri build"
+    "tauri:build": "tauri build",
+    "publish:mac-beta": "pnpm tauri:build && cp \"src-tauri/target/release/bundle/dmg/Bklit Studio_0.1.0_aarch64.dmg\" ../../apps/web/public/downloads/bklit-studio-beta.dmg"
   },
   "dependencies": {
     "@base-ui/react": "^1.1.0",

--- a/apps/studio-desktop/src-tauri/tauri.conf.json
+++ b/apps/studio-desktop/src-tauri/tauri.conf.json
@@ -29,6 +29,9 @@
   "bundle": {
     "active": true,
     "targets": "all",
+    "macOS": {
+      "signingIdentity": "-"
+    },
     "icon": [
       "icons/32x32.png",
       "icons/128x128.png",

--- a/apps/web/components/particle-badge.tsx
+++ b/apps/web/components/particle-badge.tsx
@@ -396,17 +396,25 @@ export function ParticleBadge({
   return (
     <div
       className={cn(
-        "relative isolate inline-flex items-center justify-center overflow-visible",
+        "relative isolate inline-flex items-center justify-center",
         className
       )}
-      ref={containerRef}
-      style={{ padding: bleed }}
       {...props}
     >
-      <canvas
-        className="pointer-events-none absolute inset-0 z-0"
-        ref={canvasRef}
-      />
+      <div
+        aria-hidden
+        className="pointer-events-none absolute top-1/2 left-1/2 z-0 -translate-x-1/2 -translate-y-1/2 overflow-hidden"
+        ref={containerRef}
+        style={{
+          width: `calc(100% + ${bleed * 2}px)`,
+          height: `calc(100% + ${bleed * 2}px)`,
+        }}
+      >
+        <canvas
+          className="pointer-events-none absolute inset-0"
+          ref={canvasRef}
+        />
+      </div>
       <div className="relative z-10 inline-flex items-center" ref={targetRef}>
         {children}
       </div>


### PR DESCRIPTION
## Summary

- Match Studio onboarding `ParticleBadge` layout: absolutely position the particle canvas with bleed sizing instead of padding, so heroes and badges keep correct spacing.
- Add ad-hoc macOS code signing (`signingIdentity: "-"`) and a `publish:mac-beta` script for future desktop beta builds.

## Test plan

- [x] `pnpm lint` passes at repo root
- [x] `pnpm registry:build` (no output changes)
- [x] `apps/web` production build succeeds
- [ ] Hero / homepage Studio pill: particles render without extra vertical gap
- [ ] Studio onboarding pill spacing unchanged