### PR TITLE
fix(studio): restore canvas pan and crisp frame resize

### DIFF
--- a/packages/studio/src/components/studio-chart-frame.tsx
+++ b/packages/studio/src/components/studio-chart-frame.tsx
@@ -219,6 +219,7 @@ export const StudioChartFrame = forwardRef<
         return;
       }
       event.preventDefault();
+      event.stopPropagation();
       const handle = event.currentTarget;
       handle.setPointerCapture(event.pointerId);
       draggingRef.current = true;

--- a/packages/studio/src/components/studio-chart-frame.tsx
+++ b/packages/studio/src/components/studio-chart-frame.tsx
@@ -26,8 +26,6 @@ export const STUDIO_EXPORT_ROOT_ATTR = "data-studio-export-root";
 const MIN_WIDTH = 1;
 const MIN_HEIGHT = 1;
 
-const frameSpring = { type: "spring" as const, stiffness: 420, damping: 36 };
-
 type ResizeEdge = "right" | "bottom" | "corner";
 
 interface FrameSize {
@@ -306,9 +304,6 @@ export const StudioChartFrame = forwardRef<
       ref={wrapRef}
     >
       <motion.div
-        animate={
-          resizable ? { width: size.width, height: size.height } : undefined
-        }
         className={cn(
           "relative overflow-visible border-2 bg-card",
           isRecording
@@ -324,16 +319,7 @@ export const StudioChartFrame = forwardRef<
         data-studio-export-root=""
         layout={false}
         ref={captureRef}
-        style={
-          resizable
-            ? style
-            : { ...style, width: size.width, height: size.height }
-        }
-        transition={
-          isDragging || reducedMotion || isRecording || !resizable
-            ? { duration: 0 }
-            : { ...frameSpring, layout: frameSpring }
-        }
+        style={{ ...style, width: size.width, height: size.height }}
       >
         {frameContent}
         {isRecording || !resizable ? null : (

--- a/packages/studio/src/editor/editor-camera.ts
+++ b/packages/studio/src/editor/editor-camera.ts
@@ -128,6 +128,39 @@ export function computeCenterCamera({
   };
 }
 
+/** Keep the same world anchor when the artboard grows from a fixed origin. */
+export function adjustCameraForContentBoundsChange(
+  camera: EditorCamera,
+  prev: {
+    x: number;
+    y: number;
+    width: number;
+    height: number;
+  },
+  next: {
+    x: number;
+    y: number;
+    width: number;
+    height: number;
+  }
+): EditorCamera {
+  if (prev.x !== next.x || prev.y !== next.y) {
+    return camera;
+  }
+  if (prev.width === next.width && prev.height === next.height) {
+    return camera;
+  }
+
+  const dw = next.width - prev.width;
+  const dh = next.height - prev.height;
+
+  return {
+    ...camera,
+    x: camera.x - (dw * camera.zoom) / 2,
+    y: camera.y - (dh * camera.zoom) / 2,
+  };
+}
+
 export function zoomCameraAtPoint({
   camera,
   pointX,

--- a/packages/studio/src/editor/use-editor-canvas-view.ts
+++ b/packages/studio/src/editor/use-editor-canvas-view.ts
@@ -8,7 +8,6 @@ import {
   useState,
 } from "react";
 import {
-  adjustCameraForContentBoundsChange,
   clampCameraZoom,
   compute100PercentCamera,
   computeFitCamera,
@@ -250,46 +249,18 @@ export function useEditorCamera({
     userAdjustedCameraRef.current = false;
   }, [enabled]);
 
-  // biome-ignore lint/correctness/useExhaustiveDependencies: react to artboard bounds changes
+  // biome-ignore lint/correctness/useExhaustiveDependencies: initial center only — artboard move/resize keeps camera fixed
   useEffect(() => {
     const bounds = getContentBoundsRef.current();
     const prev = prevContentBoundsRef.current;
     prevContentBoundsRef.current = bounds;
 
-    if (!prev) {
-      applyDefaultCamera();
-      return;
-    }
-
-    if (
-      prev.x === bounds.x &&
-      prev.y === bounds.y &&
-      prev.width === bounds.width &&
-      prev.height === bounds.height
-    ) {
-      return;
-    }
-
-    const positionChanged = prev.x !== bounds.x || prev.y !== bounds.y;
-    const sizeChanged =
-      prev.width !== bounds.width || prev.height !== bounds.height;
-
-    // Dragging the frame label moves artboard x/y — camera must stay fixed.
-    if (positionChanged && !sizeChanged) {
-      return;
-    }
-
-    if (userAdjustedCameraRef.current) {
-      if (sizeChanged) {
-        applyCamera(
-          adjustCameraForContentBoundsChange(cameraRef.current, prev, bounds)
-        );
-      }
+    if (prev) {
       return;
     }
 
     applyDefaultCamera();
-  }, [applyCamera, applyDefaultCamera, getContentBounds]);
+  }, [applyDefaultCamera, getContentBounds]);
 
   useEffect(() => {
     if (!enabled) {

--- a/packages/studio/src/editor/use-editor-canvas-view.ts
+++ b/packages/studio/src/editor/use-editor-canvas-view.ts
@@ -8,6 +8,7 @@ import {
   useState,
 } from "react";
 import {
+  adjustCameraForContentBoundsChange,
   clampCameraZoom,
   compute100PercentCamera,
   computeFitCamera,
@@ -41,6 +42,22 @@ function isEditableTarget(target: EventTarget | null) {
     tag === "TEXTAREA" ||
     tag === "SELECT" ||
     tag === "BUTTON"
+  );
+}
+
+function isChartFrameResizeTarget(target: EventTarget | null) {
+  if (!(target instanceof Element)) {
+    return false;
+  }
+  const control = target.closest("button");
+  if (!control) {
+    return false;
+  }
+  const label = control.getAttribute("aria-label");
+  return (
+    label === "Resize width" ||
+    label === "Resize height" ||
+    label === "Resize width and height"
   );
 }
 
@@ -81,6 +98,7 @@ export function useEditorCamera({
   cameraRef.current = camera;
   const getContentBoundsRef = useRef(getContentBounds);
   getContentBoundsRef.current = getContentBounds;
+  const prevContentBoundsRef = useRef<EditorContentBounds | null>(null);
   const userAdjustedCameraRef = useRef(false);
 
   const getViewportSize = useCallback(() => {
@@ -232,10 +250,35 @@ export function useEditorCamera({
     userAdjustedCameraRef.current = false;
   }, [enabled]);
 
-  // biome-ignore lint/correctness/useExhaustiveDependencies: re-center when artboard bounds change
+  // biome-ignore lint/correctness/useExhaustiveDependencies: react to artboard bounds changes
   useEffect(() => {
+    const bounds = getContentBoundsRef.current();
+    const prev = prevContentBoundsRef.current;
+    prevContentBoundsRef.current = bounds;
+
+    if (!prev) {
+      applyDefaultCamera();
+      return;
+    }
+
+    if (
+      prev.x === bounds.x &&
+      prev.y === bounds.y &&
+      prev.width === bounds.width &&
+      prev.height === bounds.height
+    ) {
+      return;
+    }
+
+    if (userAdjustedCameraRef.current) {
+      applyCamera(
+        adjustCameraForContentBoundsChange(cameraRef.current, prev, bounds)
+      );
+      return;
+    }
+
     applyDefaultCamera();
-  }, [applyDefaultCamera, getContentBounds]);
+  }, [applyCamera, applyDefaultCamera, getContentBounds]);
 
   useEffect(() => {
     if (!enabled) {
@@ -378,6 +421,26 @@ export function useEditorCamera({
     };
   }, [applyCamera, enabled, panBy, viewportRef]);
 
+  useEffect(() => {
+    if (!enabled) {
+      return;
+    }
+
+    const element = viewportRef.current;
+    if (!element) {
+      return;
+    }
+
+    const onLostPointerCapture = () => {
+      panSessionRef.current = null;
+    };
+
+    element.addEventListener("lostpointercapture", onLostPointerCapture);
+    return () => {
+      element.removeEventListener("lostpointercapture", onLostPointerCapture);
+    };
+  }, [enabled, viewportRef]);
+
   const onPointerDown = useCallback(
     (event: React.PointerEvent<HTMLDivElement>) => {
       if (!enabled) {
@@ -390,6 +453,10 @@ export function useEditorCamera({
       }
 
       if (viewport.dataset.pinchActive === "true") {
+        return;
+      }
+
+      if (isChartFrameResizeTarget(event.target)) {
         return;
       }
 

--- a/packages/studio/src/editor/use-editor-canvas-view.ts
+++ b/packages/studio/src/editor/use-editor-canvas-view.ts
@@ -270,10 +270,21 @@ export function useEditorCamera({
       return;
     }
 
+    const positionChanged = prev.x !== bounds.x || prev.y !== bounds.y;
+    const sizeChanged =
+      prev.width !== bounds.width || prev.height !== bounds.height;
+
+    // Dragging the frame label moves artboard x/y — camera must stay fixed.
+    if (positionChanged && !sizeChanged) {
+      return;
+    }
+
     if (userAdjustedCameraRef.current) {
-      applyCamera(
-        adjustCameraForContentBoundsChange(cameraRef.current, prev, bounds)
-      );
+      if (sizeChanged) {
+        applyCamera(
+          adjustCameraForContentBoundsChange(cameraRef.current, prev, bounds)
+        );
+      }
       return;
     }
 

--- a/packages/studio/src/lib/__tests__/editor-camera.test.ts
+++ b/packages/studio/src/lib/__tests__/editor-camera.test.ts
@@ -1,0 +1,26 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { adjustCameraForContentBoundsChange } from "@/editor/editor-camera";
+
+test("adjustCameraForContentBoundsChange shifts pan when artboard grows from origin", () => {
+  const camera = { x: 100, y: 50, zoom: 2 };
+  const prev = { x: 0, y: 0, width: 400, height: 300 };
+  const next = { x: 0, y: 0, width: 600, height: 500 };
+
+  assert.deepEqual(adjustCameraForContentBoundsChange(camera, prev, next), {
+    x: 100 - 200,
+    y: 50 - 200,
+    zoom: 2,
+  });
+});
+
+test("adjustCameraForContentBoundsChange is unchanged when artboard moves", () => {
+  const camera = { x: 10, y: 20, zoom: 1 };
+  const prev = { x: 0, y: 0, width: 400, height: 300 };
+  const next = { x: 40, y: 0, width: 400, height: 300 };
+
+  assert.deepEqual(
+    adjustCameraForContentBoundsChange(camera, prev, next),
+    camera
+  );
+});


### PR DESCRIPTION
## Summary

- Fixes bklit/bklit-ui#136: resize handles no longer bubble pointer events to the canvas (which left a stuck pan session and broke panning after resize).
- Keeps the viewport camera fixed while dragging the artboard label or resizing the frame — rulers stay put and the chart grows from its origin (Figma-style), instead of re-centering or spring-animating on release.
- Clears stale pan sessions on `lostpointercapture` as a safety net; adds unit tests for artboard bounds camera math.

## Test plan

- [x] `pnpm lint` passes at repo root
- [x] `pnpm registry:build` (no output diff)
- [x] `pnpm build` succeeds
- [x] `pnpm --filter @bklitui/studio test` (85 tests)
- [x] Manual: resize chart → pan (trackpad, Space+drag, middle-click) still works
- [x] Manual: drag chart by title label moves frame; rulers/camera do not drift
- [x] Manual: resize is crisp (no ruler jump, no spring on release)
- [x] Manual: Space + resize handle does not pan the canvas