### PR TITLE
Add Intellipickz to showcase

### DIFF
--- a/apps/web/lib/showcase/projects.ts
+++ b/apps/web/lib/showcase/projects.ts
@@ -19,4 +19,11 @@ export const showcaseProjects: ShowcaseProject[] = [
       "https://github.com/user-attachments/assets/b4fdc21a-2b8f-465b-9eb4-11f03f3a9fd0",
     imageAlt: "Chánh Đại portfolio",
   },
+  {
+    title: "Intellipickz",
+    url: "https://intellipickz.com/",
+    image:
+      "https://github.com/user-attachments/assets/3081b652-52c0-45fe-8dad-4a1b06ca08e5",
+    imageAlt: "Intellipickz sports analytics platform",
+  },
 ];


### PR DESCRIPTION
## Summary

- Add Intellipickz (https://intellipickz.com/) to the showcase grid from discussion #82
- Uses the screenshot submitted in the discussion comment

## Test plan

- [x] `pnpm lint` passes at repo root
- [x] `pnpm registry:build` run; no registry output changes
- [x] `apps/web` production build succeeds
- [ ] Verify `/showcase` shows Intellipickz card with screenshot and link