### PR TITLE
fix(web): bundle Chromium binaries for Studio OG images on Vercel

### DIFF
--- a/apps/web/app/api/og/studio/chart/route.ts
+++ b/apps/web/app/api/og/studio/chart/route.ts
@@ -13,6 +13,7 @@ import { launchStudioOgBrowser } from "@/lib/studio-og-chromium";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
+export const maxDuration = 60;
 
 const OG_READY_TIMEOUT_MS = 10_000;
 /** Retina capture multiplier — keep in sync with `OG_PREVIEW_MAX_WIDTH` in studio-og-preview */

--- a/apps/web/app/api/og/studio/route.tsx
+++ b/apps/web/app/api/og/studio/route.tsx
@@ -15,6 +15,7 @@ import {
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
+export const maxDuration = 60;
 
 const size = { width: 1200, height: 630 };
 const RIGHT_PADDING = 48;

--- a/apps/web/lib/studio-og-chromium.ts
+++ b/apps/web/lib/studio-og-chromium.ts
@@ -23,10 +23,18 @@ async function resolveLocalChromePath(): Promise<string> {
   );
 }
 
-export async function launchStudioOgBrowser(): Promise<Browser> {
-  const isDev = process.env.NODE_ENV === "development";
+function shouldUseLocalChrome(): boolean {
+  return process.env.NODE_ENV === "development" || process.env.VERCEL !== "1";
+}
 
-  const chromiumArgs: string[] = isDev
+export async function launchStudioOgBrowser(): Promise<Browser> {
+  const localChrome = shouldUseLocalChrome();
+
+  if (!localChrome) {
+    chromium.setGraphicsMode = false;
+  }
+
+  const chromiumArgs: string[] = localChrome
     ? await Promise.resolve(puppeteer.defaultArgs())
     : await Promise.resolve(chromium.args);
 
@@ -37,7 +45,7 @@ export async function launchStudioOgBrowser(): Promise<Browser> {
       height: 800,
       deviceScaleFactor: 2,
     },
-    executablePath: isDev
+    executablePath: localChrome
       ? await resolveLocalChromePath()
       : await chromium.executablePath(),
     headless: true,

--- a/apps/web/next.config.mjs
+++ b/apps/web/next.config.mjs
@@ -6,6 +6,14 @@ const withMDX = createMDX();
 const nextConfig = {
   reactStrictMode: true,
   transpilePackages: ["@bklitui/ui", "@bklitui/studio", "geist"],
+  serverExternalPackages: ["@sparticuz/chromium", "puppeteer-core"],
+  outputFileTracingIncludes: {
+    "/api/og/studio/chart": ["./node_modules/@sparticuz/chromium/bin/**"],
+    "/api/og/studio": [
+      "./node_modules/geist/dist/fonts/geist-sans/**",
+      "./node_modules/@sparticuz/chromium/bin/**",
+    ],
+  },
   experimental: {
     // Keeps dev/prod from pulling the entire charts package per MDX page.
     optimizePackageImports: ["@bklitui/ui", "@bklitui/ui/charts"],

--- a/apps/web/vercel.json
+++ b/apps/web/vercel.json
@@ -1,0 +1,12 @@
+{
+  "functions": {
+    "app/api/og/studio/chart/route.ts": {
+      "memory": 3008,
+      "maxDuration": 60
+    },
+    "app/api/og/studio/route.tsx": {
+      "memory": 1024,
+      "maxDuration": 60
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- Fix Studio OG image routes returning 500 in production by tracing `@sparticuz/chromium` bin assets and Geist fonts into the Vercel serverless bundle via `outputFileTracingIncludes`.
- Add `vercel.json` function config (3GB memory for Puppeteer chart screenshots, 60s timeout) and `maxDuration` exports on both OG routes.
- Use local Chrome outside Vercel so `next start` OG verification works on macOS.

## Test plan

- [x] `pnpm lint` passes at repo root
- [x] `pnpm registry:build` run; no registry output changes
- [x] `apps/web` production build succeeds
- [ ] After deploy: `curl -sI https://ui.bklit.com/api/og/studio/chart?s=v1.NoXSA` returns 200 `image/png`
- [ ] After deploy: `curl -sI https://ui.bklit.com/api/og/studio?s=v1.NoXSA` returns 200 `image/png`
- [ ] After deploy: opengraph.xyz preview for a serialized Studio URL shows the OG card image