### PR TITLE
fix(web): resolve Chromium bin path for Studio OG on Vercel

### DIFF
--- a/apps/web/lib/studio-og-chromium.ts
+++ b/apps/web/lib/studio-og-chromium.ts
@@ -1,3 +1,5 @@
+import { existsSync } from "node:fs";
+import { join } from "node:path";
 import chromium from "@sparticuz/chromium";
 import puppeteer, { type Browser } from "puppeteer-core";
 
@@ -27,6 +29,21 @@ function shouldUseLocalChrome(): boolean {
   return process.env.NODE_ENV === "development" || process.env.VERCEL !== "1";
 }
 
+const SERVERLESS_CHROMIUM_BIN_CANDIDATES = [
+  join(process.cwd(), "node_modules/@sparticuz/chromium/bin"),
+  join(process.cwd(), "apps/web/node_modules/@sparticuz/chromium/bin"),
+];
+
+async function resolveServerlessChromiumPath(): Promise<string> {
+  for (const binPath of SERVERLESS_CHROMIUM_BIN_CANDIDATES) {
+    if (existsSync(binPath)) {
+      return await chromium.executablePath(binPath);
+    }
+  }
+
+  return await chromium.executablePath();
+}
+
 export async function launchStudioOgBrowser(): Promise<Browser> {
   const localChrome = shouldUseLocalChrome();
 
@@ -47,7 +64,7 @@ export async function launchStudioOgBrowser(): Promise<Browser> {
     },
     executablePath: localChrome
       ? await resolveLocalChromePath()
-      : await chromium.executablePath(),
+      : await resolveServerlessChromiumPath(),
     headless: true,
   });
 }

--- a/apps/web/vercel.json
+++ b/apps/web/vercel.json
@@ -1,11 +1,10 @@
 {
+  "$schema": "https://openapi.vercel.sh/vercel.json",
   "functions": {
     "app/api/og/studio/chart/route.ts": {
-      "memory": 3008,
       "maxDuration": 60
     },
     "app/api/og/studio/route.tsx": {
-      "memory": 1024,
       "maxDuration": 60
     }
   }


### PR DESCRIPTION
## Summary

- Remove ignored `memory` keys from `vercel.json` (Fluid compute uses dashboard CPU/memory tier instead) and keep `maxDuration: 60` for Puppeteer screenshots.
- Fix production Chromium launch by explicitly resolving `@sparticuz/chromium/bin` from `process.cwd()` before falling back to the package default path.

OG routes already cache responses for 1 year (`immutable`), so repeat social crawls of the same `?s=…` URL are CDN hits. This setup targets ~20k unique OG generations/month (~$20 compute on Pro) with most traffic served from cache after first generation.

## Deploy notes

If chart screenshots still OOM on complex charts, bump the project default function size to **Performance (4 GB / 2 vCPU)** in Vercel → Settings → Functions. That cannot be set in `vercel.json` on Fluid compute.

## Test plan

- [x] `pnpm lint` passes at repo root
- [x] `pnpm registry:build` run; no registry output changes
- [x] `apps/web` production build succeeds
- [ ] After deploy: `curl -sI https://ui.bklit.com/api/og/studio/chart?s=v1.NoXSA` returns 200 `image/png`
- [ ] After deploy: `curl -sI https://ui.bklit.com/api/og/studio?s=v1.NoXSA` returns 200 `image/png`
- [ ] opengraph.xyz preview for a serialized Studio URL shows the OG card