### PR TITLE
feat(studio): share link, export panel, and canvas toolbar

### DIFF
--- a/packages/studio/package.json
+++ b/packages/studio/package.json
@@ -58,6 +58,7 @@
     "react": "^19.2.0",
     "react-dom": "^19.2.0",
     "remotion": "4.0.462",
+    "sonner": "^2.0.7",
     "tailwind-merge": "^2.6.0",
     "topojson-client": "3.1.0"
   }

--- a/packages/studio/src/components/studio-editor-layout.tsx
+++ b/packages/studio/src/components/studio-editor-layout.tsx
@@ -21,6 +21,7 @@ import {
   useStudioDisplayState,
   useStudioShellState,
 } from "@/components/use-studio-state";
+import { useReplayKeyboardShortcut } from "@/editor/editor-replay-button";
 import { EditorShell } from "@/editor/editor-shell";
 import { StudioComponentSelectionProvider } from "@/editor/studio-component-selection";
 import { StudioPatternDefs, studioPatternFill } from "@/lib/patterns";
@@ -350,6 +351,8 @@ export function StudioEditorLayout({
     onReplay: replay,
   });
 
+  useReplayKeyboardShortcut(replay, !recording.controlsDisabled);
+
   const handleExportSvg = useCallback(async () => {
     const root = chartAreaRef.current?.querySelector<HTMLElement>(
       `[${STUDIO_EXPORT_ROOT_ATTR}]`
@@ -430,23 +433,19 @@ export function StudioEditorLayout({
             config={config}
             controlsDisabled={recording.controlsDisabled}
             frameTitle={config.label}
+            isRecording={recording.isRecording}
+            onExportSvg={handleExportSvg}
+            onReplay={replay}
             onScramble={scrambleData}
+            onStartRecording={recording.handleStartRecording}
+            onStopRecording={recording.stopRecording}
             propertiesHeaderActions={
               <StudioEditorSidebarActions
-                controlsDisabled={recording.controlsDisabled}
-                isRecording={recording.isRecording}
-                onExportSvg={handleExportSvg}
-                onRecordPopoverOpenChange={
-                  recording.handleRecordPopoverOpenChange
-                }
-                onReplay={replay}
-                onStartRecording={recording.handleStartRecording}
-                onStopRecording={recording.stopRecording}
-                recordingBlocked={recording.recordingBlocked}
                 renderCodeSheet={renderCodeSheet}
                 state={state}
               />
             }
+            recordingBlocked={recording.recordingBlocked}
             showMotionControls={Boolean(config.motionPanel)}
             size={{ width: state.frameW, height: state.frameH }}
           >

--- a/packages/studio/src/components/studio-editor-sidebar-actions.tsx
+++ b/packages/studio/src/components/studio-editor-sidebar-actions.tsx
@@ -1,114 +1,23 @@
 "use client";
 
 import type { ReactNode } from "react";
-import { useEffect } from "react";
 import { StudioCodeSheetTrigger } from "@/components/studio-code-sheet-trigger";
-import { StudioExportSvgButton } from "@/components/studio-export-svg-button";
-import { StudioRecordPopover } from "@/components/studio-record-popover";
-import { EditorReplayButton } from "@/editor/editor-replay-button";
 import type { StudioUrlState } from "@/lib/studio-parsers";
-import type {
-  StudioRecordingAspect,
-  StudioRecordingFormat,
-  StudioRecordingInteractionMs,
-} from "@/lib/studio-recording";
-import { supportsStudioExportFeatures } from "@/lib/studio-runtime";
-
-function isTypingTarget(target: EventTarget | null): boolean {
-  if (!(target instanceof HTMLElement)) {
-    return false;
-  }
-  const tag = target.tagName;
-  return (
-    target.isContentEditable ||
-    tag === "INPUT" ||
-    tag === "TEXTAREA" ||
-    tag === "SELECT"
-  );
-}
 
 export function StudioEditorSidebarActions({
   state,
-  controlsDisabled,
-  recordingBlocked,
-  isRecording,
-  onReplay,
-  onExportSvg,
-  onRecordPopoverOpenChange,
-  onStartRecording,
-  onStopRecording,
   renderCodeSheet,
 }: {
   state: StudioUrlState;
-  controlsDisabled: boolean;
-  recordingBlocked: boolean;
-  isRecording: boolean;
-  onReplay: () => void;
-  onExportSvg: () => void;
-  onRecordPopoverOpenChange: (open: boolean) => void;
-  onStartRecording: (
-    interactionMs: StudioRecordingInteractionMs,
-    aspect: StudioRecordingAspect,
-    format: StudioRecordingFormat
-  ) => void;
-  onStopRecording: () => void;
   renderCodeSheet?: (state: StudioUrlState) => ReactNode;
 }) {
-  useEffect(() => {
-    const onKeyDown = (event: KeyboardEvent) => {
-      if (event.key !== "r" && event.key !== "R") {
-        return;
-      }
-      if (event.metaKey || event.ctrlKey || event.altKey) {
-        return;
-      }
-      if (isTypingTarget(event.target)) {
-        return;
-      }
-      event.preventDefault();
-      onReplay();
-    };
-
-    window.addEventListener("keydown", onKeyDown);
-    return () => window.removeEventListener("keydown", onKeyDown);
-  }, [onReplay]);
-
-  const showExportFeatures = supportsStudioExportFeatures();
-
-  return (
-    <>
-      <EditorReplayButton disabled={controlsDisabled} onReplay={onReplay} />
-
-      {showExportFeatures ? (
-        <>
-          <StudioRecordPopover
-            disabled={recordingBlocked}
-            isRecording={isRecording}
-            onOpenChange={onRecordPopoverOpenChange}
-            onStart={onStartRecording}
-            onStop={onStopRecording}
-            size="icon-sm"
-            variant="ghost"
-          />
-
-          <StudioExportSvgButton
-            disabled={controlsDisabled}
-            onExport={onExportSvg}
-            size="icon-sm"
-            variant="ghost"
-          />
-        </>
-      ) : null}
-
-      {renderCodeSheet ? (
-        renderCodeSheet(state)
-      ) : (
-        <StudioCodeSheetTrigger
-          state={state}
-          triggerClassName="font-mono text-xs"
-          triggerSize="sm"
-        />
-      )}
-    </>
+  return renderCodeSheet ? (
+    renderCodeSheet(state)
+  ) : (
+    <StudioCodeSheetTrigger
+      state={state}
+      triggerClassName="font-mono text-xs"
+      triggerSize="sm"
+    />
   );
 }

--- a/packages/studio/src/components/studio-share-button.tsx
+++ b/packages/studio/src/components/studio-share-button.tsx
@@ -1,0 +1,69 @@
+"use client";
+
+import { Share03Icon } from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
+import { CheckIcon } from "lucide-react";
+import { useCallback, useState } from "react";
+import { toast } from "sonner";
+import { ParticleBadge } from "@/components/onboarding/particle-badge";
+import { cn } from "@/lib/utils";
+import { Button } from "@/ui/button";
+
+export function StudioShareButton({
+  className,
+  onCopiedChange,
+}: {
+  className?: string;
+  onCopiedChange?: (copied: boolean) => void;
+}) {
+  const [copied, setCopied] = useState(false);
+
+  const copyLink = useCallback(async () => {
+    if (copied) {
+      return;
+    }
+
+    await navigator.clipboard.writeText(window.location.href);
+    toast.success("Link copied to clipboard");
+    setCopied(true);
+    onCopiedChange?.(true);
+    window.setTimeout(() => {
+      setCopied(false);
+      onCopiedChange?.(false);
+    }, 2000);
+  }, [copied, onCopiedChange]);
+
+  return (
+    <ParticleBadge>
+      <Button
+        aria-label={copied ? "Copied" : "Share chart"}
+        className={cn("size-8", className)}
+        onClick={copyLink}
+        size="icon-sm"
+        type="button"
+        variant="ghost"
+      >
+        <span className="relative block size-4">
+          <HugeiconsIcon
+            className="absolute inset-0 transition-all duration-300 ease-out"
+            icon={Share03Icon}
+            strokeWidth={1.75}
+            style={{
+              filter: copied ? "blur(4px)" : "blur(0px)",
+              opacity: copied ? 0 : 1,
+              transform: copied ? "scale(0.8)" : "scale(1)",
+            }}
+          />
+          <CheckIcon
+            className="absolute inset-0 size-4 transition-all duration-300 ease-out"
+            style={{
+              filter: copied ? "blur(0px)" : "blur(4px)",
+              opacity: copied ? 1 : 0,
+              transform: copied ? "scale(1)" : "scale(0.8)",
+            }}
+          />
+        </span>
+      </Button>
+    </ParticleBadge>
+  );
+}

--- a/packages/studio/src/components/studio-shell.tsx
+++ b/packages/studio/src/components/studio-shell.tsx
@@ -4,6 +4,7 @@ import type { ReactNode } from "react";
 import type { StudioUrlState } from "@/lib/studio-parsers";
 import type { StudioAnalytics } from "@/providers/studio-analytics-context";
 import { StudioAnalyticsProvider } from "@/providers/studio-analytics-context";
+import { Toaster } from "@/ui/sonner";
 import { StudioEditorLayout } from "./studio-editor-layout";
 import { StudioOnboardingDialog } from "./studio-onboarding-dialog";
 import { StudioStateProvider } from "./studio-state-provider";
@@ -21,6 +22,7 @@ export function StudioShell({
         <div className="relative flex h-full min-h-0 flex-1 flex-col overflow-hidden">
           <StudioOnboardingDialog />
           <StudioEditorLayout renderCodeSheet={renderCodeSheet} />
+          <Toaster position="top-center" />
         </div>
       </StudioStateProvider>
     </StudioAnalyticsProvider>

--- a/packages/studio/src/components/studio-toolbar-tooltips.tsx
+++ b/packages/studio/src/components/studio-toolbar-tooltips.tsx
@@ -1,7 +1,17 @@
 "use client";
 
-import { createContext, type ReactNode, useContext } from "react";
-import { TooltipProvider } from "@/ui/tooltip";
+import {
+  createContext,
+  type ReactElement,
+  type ReactNode,
+  useContext,
+} from "react";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/ui/tooltip";
 
 type StudioToolbarTooltipSide = "top" | "bottom";
 
@@ -32,5 +42,24 @@ export function StudioToolbarTooltips({
         {children}
       </TooltipProvider>
     </StudioToolbarTooltipSideContext.Provider>
+  );
+}
+
+export function EditorMenuBarTooltipItem({
+  label,
+  children,
+}: {
+  label: ReactNode;
+  children: ReactElement;
+}) {
+  const side = useStudioToolbarTooltipSide();
+
+  return (
+    <Tooltip>
+      <TooltipTrigger render={<span className="inline-flex" />}>
+        {children}
+      </TooltipTrigger>
+      <TooltipContent side={side}>{label}</TooltipContent>
+    </Tooltip>
   );
 }

--- a/packages/studio/src/editor/editor-export-section.tsx
+++ b/packages/studio/src/editor/editor-export-section.tsx
@@ -1,0 +1,209 @@
+"use client";
+
+import { cn } from "@bklitui/ui/lib/utils";
+import { VideoCameraIcon } from "@heroicons/react/24/outline";
+import { Download01Icon } from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
+import { useState } from "react";
+import {
+  StudioTab,
+  StudioTabs,
+} from "@/components/controls/studio-toggle-group";
+import { StudioControlGroup } from "@/components/studio-control-group";
+import {
+  STUDIO_RECORDING_ASPECT_OPTIONS,
+  STUDIO_RECORDING_FORMAT_OPTIONS,
+  STUDIO_RECORDING_INTERACTION_OPTIONS,
+  type StudioRecordingAspect,
+  type StudioRecordingFormat,
+  type StudioRecordingInteractionMs,
+} from "@/lib/studio-recording";
+import { supportsStudioExportFeatures } from "@/lib/studio-runtime";
+import { Button } from "@/ui/button";
+import { Label } from "@/ui/label";
+import { RadioGroup, RadioGroupItem } from "@/ui/radio-group";
+
+type ExportMode = "svg" | "recording";
+
+export function EditorExportSection({
+  controlsDisabled = false,
+  recordingBlocked = false,
+  isRecording = false,
+  onExportSvg,
+  onStartRecording,
+  onStopRecording,
+}: {
+  controlsDisabled?: boolean;
+  recordingBlocked?: boolean;
+  isRecording?: boolean;
+  onExportSvg: () => void;
+  onStartRecording: (
+    interactionMs: StudioRecordingInteractionMs,
+    aspect: StudioRecordingAspect,
+    format: StudioRecordingFormat
+  ) => void;
+  onStopRecording: () => void;
+}) {
+  const [mode, setMode] = useState<ExportMode>("svg");
+  const [interactionMs, setInteractionMs] =
+    useState<StudioRecordingInteractionMs>(5000);
+  const [aspect, setAspect] = useState<StudioRecordingAspect>("16:9");
+  const [format, setFormat] = useState<StudioRecordingFormat>("webm");
+
+  if (!supportsStudioExportFeatures()) {
+    return null;
+  }
+
+  return (
+    <StudioControlGroup
+      className="shrink-0 border-border/60 border-t px-3 pb-3"
+      collapsible
+      defaultOpen
+      title="Export"
+    >
+      {isRecording ? (
+        <div className="flex flex-col gap-3">
+          <p className="text-muted-foreground text-xs leading-relaxed">
+            Recording in progress…
+          </p>
+          <Button
+            className="w-full"
+            onClick={onStopRecording}
+            type="button"
+            variant="destructive"
+          >
+            <span className="mr-2 size-2 rounded-sm bg-current" />
+            Stop recording
+          </Button>
+        </div>
+      ) : (
+        <div className="flex flex-col gap-3">
+          <StudioTabs
+            layout="segmented"
+            onValueChange={(value) => setMode(value as ExportMode)}
+            value={mode}
+          >
+            <StudioTab value="svg">SVG</StudioTab>
+            <StudioTab value="recording">Recording</StudioTab>
+          </StudioTabs>
+
+          {mode === "recording" ? (
+            <>
+              <div>
+                <p className="mb-2 font-medium text-[11px] text-muted-foreground uppercase tracking-wide">
+                  Aspect ratio
+                </p>
+                <div className="grid grid-cols-2 gap-1.5">
+                  {STUDIO_RECORDING_ASPECT_OPTIONS.map((opt) => {
+                    const selected = aspect === opt.value;
+                    return (
+                      <button
+                        className={cn(
+                          "rounded-md border px-2 py-2 text-left text-xs transition-colors",
+                          selected
+                            ? "border-primary/40 bg-primary/10 text-foreground"
+                            : "border-border bg-muted/30 text-muted-foreground hover:bg-muted/50 hover:text-foreground"
+                        )}
+                        key={opt.value}
+                        onClick={() => setAspect(opt.value)}
+                        type="button"
+                      >
+                        {opt.label}
+                      </button>
+                    );
+                  })}
+                </div>
+              </div>
+
+              <div>
+                <p className="mb-2 font-medium text-[11px] text-muted-foreground uppercase tracking-wide">
+                  Interaction time
+                </p>
+                <div className="grid grid-cols-2 gap-1.5">
+                  {STUDIO_RECORDING_INTERACTION_OPTIONS.map((opt) => {
+                    const selected = interactionMs === opt.value;
+                    return (
+                      <button
+                        className={cn(
+                          "rounded-md border px-2 py-2 text-left text-xs transition-colors",
+                          selected
+                            ? "border-primary/40 bg-primary/10 text-foreground"
+                            : "border-border bg-muted/30 text-muted-foreground hover:bg-muted/50 hover:text-foreground"
+                        )}
+                        key={opt.value}
+                        onClick={() => setInteractionMs(opt.value)}
+                        type="button"
+                      >
+                        {opt.label}
+                      </button>
+                    );
+                  })}
+                </div>
+              </div>
+
+              <div>
+                <p className="mb-2 font-medium text-[11px] text-muted-foreground uppercase tracking-wide">
+                  Export format
+                </p>
+                <RadioGroup
+                  className="flex flex-row items-center gap-4"
+                  onValueChange={(value) =>
+                    setFormat(value as StudioRecordingFormat)
+                  }
+                  value={format}
+                >
+                  {STUDIO_RECORDING_FORMAT_OPTIONS.map((opt) => (
+                    <div className="flex items-center gap-2" key={opt.value}>
+                      <RadioGroupItem
+                        id={`studio-export-format-${opt.value}`}
+                        value={opt.value}
+                      />
+                      <Label
+                        className="cursor-pointer font-normal text-xs"
+                        htmlFor={`studio-export-format-${opt.value}`}
+                      >
+                        {opt.label}
+                      </Label>
+                    </div>
+                  ))}
+                </RadioGroup>
+              </div>
+            </>
+          ) : null}
+
+          <Button
+            className="w-full"
+            disabled={
+              controlsDisabled || (mode === "recording" && recordingBlocked)
+            }
+            onClick={() => {
+              if (mode === "svg") {
+                onExportSvg();
+                return;
+              }
+              onStartRecording(interactionMs, aspect, format);
+            }}
+            type="button"
+          >
+            {mode === "svg" ? (
+              <>
+                <HugeiconsIcon
+                  className="mr-2"
+                  icon={Download01Icon}
+                  size={16}
+                  strokeWidth={1.5}
+                />
+                Export SVG
+              </>
+            ) : (
+              <>
+                <VideoCameraIcon aria-hidden className="mr-2 size-4" />
+                Start recording
+              </>
+            )}
+          </Button>
+        </div>
+      )}
+    </StudioControlGroup>
+  );
+}

--- a/packages/studio/src/editor/editor-main-pane.tsx
+++ b/packages/studio/src/editor/editor-main-pane.tsx
@@ -26,6 +26,8 @@ export function EditorMainPane({
   onLeftSheetOpen,
   onRightSheetOpen,
   showFpsCounter = false,
+  onReplay,
+  controlsDisabled = false,
   children,
 }: {
   className?: string;
@@ -38,6 +40,8 @@ export function EditorMainPane({
   onLeftSheetOpen?: () => void;
   onRightSheetOpen?: () => void;
   showFpsCounter?: boolean;
+  onReplay?: () => void;
+  controlsDisabled?: boolean;
   children: (ctx: {
     size: { width: number; height: number };
     boundsRef: RefObject<HTMLDivElement | null>;
@@ -196,8 +200,11 @@ export function EditorMainPane({
                 "pointer-events-auto absolute left-1/2 z-20 -translate-x-1/2",
                 mobileViewport ? "bottom-3" : "bottom-6"
               )}
+              controlsDisabled={controlsDisabled}
               height={frame.height}
+              onCenterOnContent={camera.centerOnContent}
               onFitView={camera.fitToContent}
+              onReplay={onReplay}
               onResetZoom={camera.resetTo100}
               onSidebarsOpenChange={onSidebarsOpenChange}
               onZoomIn={() => camera.zoomBy(1.12)}

--- a/packages/studio/src/editor/editor-menu-bar.tsx
+++ b/packages/studio/src/editor/editor-menu-bar.tsx
@@ -1,13 +1,19 @@
 "use client";
 
+import { ArrowsPointingInIcon } from "@heroicons/react/24/outline";
 import { Maximize2, Minus, Plus } from "lucide-react";
-import { StudioToolbarTooltips } from "@/components/studio-toolbar-tooltips";
+import { useState } from "react";
+import { StudioShareButton } from "@/components/studio-share-button";
+import {
+  EditorMenuBarTooltipItem,
+  StudioToolbarTooltips,
+} from "@/components/studio-toolbar-tooltips";
+import { EditorReplayButton } from "@/editor/editor-replay-button";
 import { EditorSidebarToggle } from "@/editor/editor-sidebar-toggle";
 import { EditorThemeToggle } from "@/editor/editor-theme-toggle";
 import { cn } from "@/lib/utils";
 import { Button } from "@/ui/button";
 import { Separator } from "@/ui/separator";
-import { Tooltip, TooltipContent, TooltipTrigger } from "@/ui/tooltip";
 
 export function EditorMenuBar({
   className,
@@ -22,6 +28,9 @@ export function EditorMenuBar({
   onZoomOut,
   onFitView,
   onResetZoom,
+  onCenterOnContent,
+  onReplay,
+  controlsDisabled = false,
 }: {
   className?: string;
   width: number;
@@ -35,7 +44,12 @@ export function EditorMenuBar({
   onZoomOut?: () => void;
   onFitView?: () => void;
   onResetZoom?: () => void;
+  onCenterOnContent?: () => void;
+  onReplay?: () => void;
+  controlsDisabled?: boolean;
 }) {
+  const [shareCopied, setShareCopied] = useState(false);
+
   return (
     <StudioToolbarTooltips>
       <div
@@ -46,36 +60,37 @@ export function EditorMenuBar({
       >
         {showSidebarToggle ? (
           <>
-            <EditorSidebarToggle
-              onToggle={() => onSidebarsOpenChange(!sidebarsOpen)}
-              open={sidebarsOpen}
-            />
+            <EditorMenuBarTooltipItem label="Toggle sidebars">
+              <EditorSidebarToggle
+                onToggle={() => onSidebarsOpenChange(!sidebarsOpen)}
+                open={sidebarsOpen}
+              />
+            </EditorMenuBarTooltipItem>
 
             <Separator className="mx-0.5 h-5" orientation="vertical" />
           </>
         ) : null}
 
-        <EditorThemeToggle />
+        <EditorMenuBarTooltipItem label="Toggle theme (D)">
+          <EditorThemeToggle />
+        </EditorMenuBarTooltipItem>
 
         {showZoomControls ? (
           <>
             <Separator className="mx-0.5 h-5 shrink-0" orientation="vertical" />
 
-            <Tooltip>
-              <TooltipTrigger render={<span className="inline-flex" />}>
-                <Button
-                  aria-label="Zoom out"
-                  className="size-8"
-                  onClick={onZoomOut}
-                  size="icon-sm"
-                  type="button"
-                  variant="ghost"
-                >
-                  <Minus />
-                </Button>
-              </TooltipTrigger>
-              <TooltipContent side="top">Zoom out</TooltipContent>
-            </Tooltip>
+            <EditorMenuBarTooltipItem label="Zoom out">
+              <Button
+                aria-label="Zoom out"
+                className="size-8"
+                onClick={onZoomOut}
+                size="icon-sm"
+                type="button"
+                variant="ghost"
+              >
+                <Minus />
+              </Button>
+            </EditorMenuBarTooltipItem>
 
             <button
               className="min-w-12 shrink-0 px-1 font-mono text-[11px] text-muted-foreground tabular-nums hover:text-foreground"
@@ -85,37 +100,62 @@ export function EditorMenuBar({
               {Math.round(canvasScale * 100)}%
             </button>
 
-            <Tooltip>
-              <TooltipTrigger render={<span className="inline-flex" />}>
-                <Button
-                  aria-label="Zoom in"
-                  className="size-8"
-                  onClick={onZoomIn}
-                  size="icon-sm"
-                  type="button"
-                  variant="ghost"
-                >
-                  <Plus />
-                </Button>
-              </TooltipTrigger>
-              <TooltipContent>Zoom in</TooltipContent>
-            </Tooltip>
+            <EditorMenuBarTooltipItem label="Zoom in">
+              <Button
+                aria-label="Zoom in"
+                className="size-8"
+                onClick={onZoomIn}
+                size="icon-sm"
+                type="button"
+                variant="ghost"
+              >
+                <Plus />
+              </Button>
+            </EditorMenuBarTooltipItem>
 
-            <Tooltip>
-              <TooltipTrigger render={<span className="inline-flex" />}>
+            <EditorMenuBarTooltipItem label="Zoom to fit (double-click canvas)">
+              <Button
+                aria-label="Zoom to fit"
+                className="size-8"
+                onClick={onFitView}
+                size="icon-sm"
+                type="button"
+                variant="ghost"
+              >
+                <Maximize2 />
+              </Button>
+            </EditorMenuBarTooltipItem>
+
+            {onCenterOnContent ? (
+              <EditorMenuBarTooltipItem label="Center chart on canvas">
                 <Button
-                  aria-label="Zoom to fit"
+                  aria-label="Center chart on canvas"
                   className="size-8"
-                  onClick={onFitView}
+                  onClick={onCenterOnContent}
                   size="icon-sm"
                   type="button"
                   variant="ghost"
                 >
-                  <Maximize2 />
+                  <ArrowsPointingInIcon aria-hidden className="size-4" />
                 </Button>
-              </TooltipTrigger>
-              <TooltipContent>Zoom to fit (double-click canvas)</TooltipContent>
-            </Tooltip>
+              </EditorMenuBarTooltipItem>
+            ) : null}
+
+            {onReplay ? (
+              <EditorMenuBarTooltipItem label="Replay animation (R)">
+                <EditorReplayButton
+                  disabled={controlsDisabled}
+                  onReplay={onReplay}
+                  size="icon-sm"
+                />
+              </EditorMenuBarTooltipItem>
+            ) : null}
+
+            <EditorMenuBarTooltipItem
+              label={shareCopied ? "Copied" : "Copy link"}
+            >
+              <StudioShareButton onCopiedChange={setShareCopied} />
+            </EditorMenuBarTooltipItem>
           </>
         ) : null}
 

--- a/packages/studio/src/editor/editor-mobile-panel-sheets.tsx
+++ b/packages/studio/src/editor/editor-mobile-panel-sheets.tsx
@@ -7,10 +7,16 @@ import { StudioPropertiesPanel } from "@/components/studio-properties-panel";
 import { StudioScrollArea } from "@/components/studio-scroll-area";
 import { EditorAnimationSection } from "@/editor/editor-animation-section";
 import { EditorDataSection } from "@/editor/editor-data-section";
+import { EditorExportSection } from "@/editor/editor-export-section";
 import { EditorPropertiesSidebarHeader } from "@/editor/editor-properties-sidebar-header";
 import { useStudioComponentSelection } from "@/editor/studio-component-selection";
 import { isCartesianLoadingMode } from "@/lib/line-chart-mode";
 import type { StudioUrlState } from "@/lib/studio-parsers";
+import type {
+  StudioRecordingAspect,
+  StudioRecordingFormat,
+  StudioRecordingInteractionMs,
+} from "@/lib/studio-recording";
 import type { StudioChartConfig } from "@/lib/types";
 import { cn } from "@/lib/utils";
 import { Button } from "@/ui/button";
@@ -86,6 +92,11 @@ export function EditorMobilePanelSheets({
   controlsDisabled = false,
   headerActions,
   onScramble,
+  isRecording = false,
+  recordingBlocked = false,
+  onExportSvg = () => undefined,
+  onStartRecording = () => undefined,
+  onStopRecording = () => undefined,
 }: {
   leftOpen: boolean;
   rightOpen: boolean;
@@ -113,6 +124,15 @@ export function EditorMobilePanelSheets({
   controlsDisabled?: boolean;
   headerActions?: ReactNode;
   onScramble: () => void;
+  isRecording?: boolean;
+  recordingBlocked?: boolean;
+  onExportSvg: () => void;
+  onStartRecording: (
+    interactionMs: StudioRecordingInteractionMs,
+    aspect: StudioRecordingAspect,
+    format: StudioRecordingFormat
+  ) => void;
+  onStopRecording: () => void;
 }) {
   const {
     components,
@@ -195,6 +215,14 @@ export function EditorMobilePanelSheets({
             onCommit={onCommit}
             onPreview={onPreview}
             state={state}
+          />
+          <EditorExportSection
+            controlsDisabled={controlsDisabled}
+            isRecording={isRecording}
+            onExportSvg={onExportSvg}
+            onStartRecording={onStartRecording}
+            onStopRecording={onStopRecording}
+            recordingBlocked={recordingBlocked}
           />
         </SheetContent>
       </Sheet>

--- a/packages/studio/src/editor/editor-properties-sidebar-header.tsx
+++ b/packages/studio/src/editor/editor-properties-sidebar-header.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import type { ReactNode } from "react";
-import { StudioToolbarTooltips } from "@/components/studio-toolbar-tooltips";
 import { cn } from "@/lib/utils";
 
 export function EditorPropertiesSidebarHeader({
@@ -22,7 +21,7 @@ export function EditorPropertiesSidebarHeader({
         className
       )}
     >
-      <StudioToolbarTooltips side="bottom">{actions}</StudioToolbarTooltips>
+      {actions}
     </div>
   );
 }

--- a/packages/studio/src/editor/editor-replay-button.tsx
+++ b/packages/studio/src/editor/editor-replay-button.tsx
@@ -2,14 +2,53 @@
 
 import { Refresh01Icon } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
-import { useCallback, useState } from "react";
-import { useStudioToolbarTooltipSide } from "@/components/studio-toolbar-tooltips";
+import { useCallback, useEffect, useState } from "react";
 import { cn } from "@/lib/utils";
 import { Button } from "@/ui/button";
 import { Spinner } from "@/ui/spinner";
-import { Tooltip, TooltipContent, TooltipTrigger } from "@/ui/tooltip";
 
 const REPLAY_BUSY_MS = 650;
+
+function isTypingTarget(target: EventTarget | null): boolean {
+  if (!(target instanceof HTMLElement)) {
+    return false;
+  }
+  const tag = target.tagName;
+  return (
+    target.isContentEditable ||
+    tag === "INPUT" ||
+    tag === "TEXTAREA" ||
+    tag === "SELECT"
+  );
+}
+
+export function useReplayKeyboardShortcut(
+  onReplay: () => void,
+  enabled = true
+) {
+  useEffect(() => {
+    if (!enabled) {
+      return;
+    }
+
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key !== "r" && event.key !== "R") {
+        return;
+      }
+      if (event.metaKey || event.ctrlKey || event.altKey) {
+        return;
+      }
+      if (isTypingTarget(event.target)) {
+        return;
+      }
+      event.preventDefault();
+      onReplay();
+    };
+
+    window.addEventListener("keydown", onKeyDown);
+    return () => window.removeEventListener("keydown", onKeyDown);
+  }, [enabled, onReplay]);
+}
 
 const iconSwapStyle = {
   transition:
@@ -40,52 +79,45 @@ export function EditorReplayButton({
     window.setTimeout(() => setBusy(false), REPLAY_BUSY_MS);
   }, [busy, disabled, onReplay]);
 
-  const tooltipSide = useStudioToolbarTooltipSide();
-
   return (
-    <Tooltip>
-      <TooltipTrigger render={<span className="inline-flex" />}>
-        <Button
-          aria-keyshortcuts="R"
-          aria-label="Replay animation"
-          className={cn(className)}
-          disabled={busy || disabled}
-          onClick={handleClick}
-          size={size}
-          type="button"
-          variant="ghost"
+    <Button
+      aria-keyshortcuts="R"
+      aria-label="Replay animation"
+      className={cn(className)}
+      disabled={busy || disabled}
+      onClick={handleClick}
+      size={size}
+      type="button"
+      variant="ghost"
+    >
+      <span className="relative block size-4">
+        <span
+          className="absolute inset-0 flex items-center justify-center"
+          style={{
+            ...iconSwapStyle,
+            opacity: busy ? 0 : 1,
+            filter: busy ? "blur(4px)" : "blur(0px)",
+            transform: busy ? "scale(0.85)" : "scale(1)",
+          }}
         >
-          <span className="relative block size-4">
-            <span
-              className="absolute inset-0 flex items-center justify-center"
-              style={{
-                ...iconSwapStyle,
-                opacity: busy ? 0 : 1,
-                filter: busy ? "blur(4px)" : "blur(0px)",
-                transform: busy ? "scale(0.85)" : "scale(1)",
-              }}
-            >
-              <HugeiconsIcon
-                icon={Refresh01Icon}
-                size={iconSize}
-                strokeWidth={1.75}
-              />
-            </span>
-            <span
-              className="absolute inset-0 flex items-center justify-center"
-              style={{
-                ...iconSwapStyle,
-                opacity: busy ? 1 : 0,
-                filter: busy ? "blur(0px)" : "blur(4px)",
-                transform: busy ? "scale(1)" : "scale(0.85)",
-              }}
-            >
-              <Spinner />
-            </span>
-          </span>
-        </Button>
-      </TooltipTrigger>
-      <TooltipContent side={tooltipSide}>Replay animation (R)</TooltipContent>
-    </Tooltip>
+          <HugeiconsIcon
+            icon={Refresh01Icon}
+            size={iconSize}
+            strokeWidth={1.75}
+          />
+        </span>
+        <span
+          className="absolute inset-0 flex items-center justify-center"
+          style={{
+            ...iconSwapStyle,
+            opacity: busy ? 1 : 0,
+            filter: busy ? "blur(0px)" : "blur(4px)",
+            transform: busy ? "scale(1)" : "scale(0.85)",
+          }}
+        >
+          <Spinner />
+        </span>
+      </span>
+    </Button>
   );
 }

--- a/packages/studio/src/editor/editor-right-panel.tsx
+++ b/packages/studio/src/editor/editor-right-panel.tsx
@@ -3,9 +3,15 @@
 import { memo, type ReactNode } from "react";
 import { StudioPropertiesPanel } from "@/components/studio-properties-panel";
 import { EditorCollapsiblePane } from "@/editor/editor-collapsible-pane";
+import { EditorExportSection } from "@/editor/editor-export-section";
 import { EditorPropertiesSidebarHeader } from "@/editor/editor-properties-sidebar-header";
 import { useStudioComponentSelection } from "@/editor/studio-component-selection";
 import type { StudioUrlState } from "@/lib/studio-parsers";
+import type {
+  StudioRecordingAspect,
+  StudioRecordingFormat,
+  StudioRecordingInteractionMs,
+} from "@/lib/studio-recording";
 import type { StudioChartConfig } from "@/lib/types";
 
 export const EditorRightPanel = memo(function EditorRightPanel({
@@ -18,6 +24,11 @@ export const EditorRightPanel = memo(function EditorRightPanel({
   onCommit,
   controlsDisabled = false,
   headerActions,
+  isRecording = false,
+  recordingBlocked = false,
+  onExportSvg = () => undefined,
+  onStartRecording = () => undefined,
+  onStopRecording = () => undefined,
 }: {
   state: StudioUrlState;
   config: StudioChartConfig;
@@ -37,23 +48,42 @@ export const EditorRightPanel = memo(function EditorRightPanel({
   ) => void;
   controlsDisabled?: boolean;
   headerActions?: ReactNode;
+  isRecording?: boolean;
+  recordingBlocked?: boolean;
+  onExportSvg?: () => void;
+  onStartRecording?: (
+    interactionMs: StudioRecordingInteractionMs,
+    aspect: StudioRecordingAspect,
+    format: StudioRecordingFormat
+  ) => void;
+  onStopRecording?: () => void;
 }) {
   const { selectedComponent } = useStudioComponentSelection();
 
   return (
     <EditorCollapsiblePane label="Properties" side="right">
-      <EditorPropertiesSidebarHeader actions={headerActions} />
-      <StudioPropertiesPanel
-        component={selectedComponent}
-        config={config}
-        disabled={controlsDisabled}
-        onBatchChange={onBatchChange}
-        onBatchPreview={onBatchPreview}
-        onChange={onChange}
-        onCommit={onCommit}
-        onPreview={onPreview}
-        state={state}
-      />
+      <div className="flex min-h-0 min-w-0 flex-1 flex-col">
+        <EditorPropertiesSidebarHeader actions={headerActions} />
+        <StudioPropertiesPanel
+          component={selectedComponent}
+          config={config}
+          disabled={controlsDisabled}
+          onBatchChange={onBatchChange}
+          onBatchPreview={onBatchPreview}
+          onChange={onChange}
+          onCommit={onCommit}
+          onPreview={onPreview}
+          state={state}
+        />
+        <EditorExportSection
+          controlsDisabled={controlsDisabled}
+          isRecording={isRecording}
+          onExportSvg={onExportSvg}
+          onStartRecording={onStartRecording}
+          onStopRecording={onStopRecording}
+          recordingBlocked={recordingBlocked}
+        />
+      </div>
     </EditorCollapsiblePane>
   );
 });

--- a/packages/studio/src/editor/editor-shell.tsx
+++ b/packages/studio/src/editor/editor-shell.tsx
@@ -9,6 +9,11 @@ import { EditorRightPanel } from "@/editor/editor-right-panel";
 import { useEditorCompactLayout } from "@/editor/use-editor-compact-layout";
 import { useEditorFixedViewport } from "@/editor/use-editor-fixed-viewport";
 import type { StudioUrlState } from "@/lib/studio-parsers";
+import type {
+  StudioRecordingAspect,
+  StudioRecordingFormat,
+  StudioRecordingInteractionMs,
+} from "@/lib/studio-recording";
 import type { StudioChartConfig } from "@/lib/types";
 import { cn } from "@/lib/utils";
 
@@ -44,6 +49,12 @@ export const EditorShell = memo(function EditorShell({
   showFpsCounter = false,
   controlsDisabled = false,
   onScramble,
+  onReplay = () => undefined,
+  isRecording = false,
+  recordingBlocked = false,
+  onExportSvg = () => undefined,
+  onStartRecording = () => undefined,
+  onStopRecording = () => undefined,
   children,
 }: {
   className?: string;
@@ -56,6 +67,16 @@ export const EditorShell = memo(function EditorShell({
   showFpsCounter?: boolean;
   controlsDisabled?: boolean;
   onScramble: () => void;
+  onReplay?: () => void;
+  isRecording?: boolean;
+  recordingBlocked?: boolean;
+  onExportSvg?: () => void;
+  onStartRecording?: (
+    interactionMs: StudioRecordingInteractionMs,
+    aspect: StudioRecordingAspect,
+    format: StudioRecordingFormat
+  ) => void;
+  onStopRecording?: () => void;
   chartState: StudioEditorChartState;
   children: (ctx: {
     size: { width: number; height: number };
@@ -108,9 +129,11 @@ export const EditorShell = memo(function EditorShell({
 
       <EditorMainPane
         className="min-h-0 min-w-0 flex-1"
+        controlsDisabled={controlsDisabled}
         frameTitle={frameTitle}
         mobileViewport={mobileShell}
         onLeftSheetOpen={() => setLeftSheetOpen(true)}
+        onReplay={onReplay}
         onRightSheetOpen={() => setRightSheetOpen(true)}
         onSidebarsOpenChange={setSidebarsOpen}
         showFpsCounter={showFpsCounter}
@@ -126,11 +149,16 @@ export const EditorShell = memo(function EditorShell({
           config={config}
           controlsDisabled={controlsDisabled}
           headerActions={propertiesHeaderActions}
+          isRecording={isRecording}
           onBatchChange={chartState.setStudioParams}
           onBatchPreview={chartState.setPreviewParams}
           onChange={chartState.setParam}
           onCommit={chartState.commitParam}
+          onExportSvg={onExportSvg}
           onPreview={chartState.setPreviewParam}
+          onStartRecording={onStartRecording}
+          onStopRecording={onStopRecording}
+          recordingBlocked={recordingBlocked}
           state={chartState.state}
         />
       ) : null}
@@ -141,16 +169,21 @@ export const EditorShell = memo(function EditorShell({
           config={config}
           controlsDisabled={controlsDisabled}
           headerActions={propertiesHeaderActions}
+          isRecording={isRecording}
           leftOpen={leftSheetOpen}
           onBatchChange={chartState.setStudioParams}
           onBatchPreview={chartState.setPreviewParams}
           onChange={chartState.setParam}
           onCommit={chartState.commitParam}
+          onExportSvg={onExportSvg}
           onLeftOpenChange={setLeftSheetOpen}
           onMotionCurveDragActiveChange={chartState.setMotionCurveDragging}
           onPreview={chartState.setPreviewParam}
           onRightOpenChange={setRightSheetOpen}
           onScramble={onScramble}
+          onStartRecording={onStartRecording}
+          onStopRecording={onStopRecording}
+          recordingBlocked={recordingBlocked}
           rightOpen={rightSheetOpen}
           showMotionControls={showMotionControls}
           state={chartState.state}

--- a/packages/studio/src/editor/editor-sidebar-toggle.tsx
+++ b/packages/studio/src/editor/editor-sidebar-toggle.tsx
@@ -1,10 +1,8 @@
 "use client";
 
 import { Columns3, PanelTopBottomDashed } from "lucide-react";
-import { useStudioToolbarTooltipSide } from "@/components/studio-toolbar-tooltips";
 import { cn } from "@/lib/utils";
 import { Button } from "@/ui/button";
-import { Tooltip, TooltipContent, TooltipTrigger } from "@/ui/tooltip";
 
 /** Lucide `columns-3` — three-column layout with side panes visible. */
 const Layout3ColumnIcon = Columns3;
@@ -19,28 +17,21 @@ export function EditorSidebarToggle({
   open: boolean;
   onToggle: () => void;
 }) {
-  const tooltipSide = useStudioToolbarTooltipSide();
-
   return (
-    <Tooltip>
-      <TooltipTrigger render={<span className="inline-flex" />}>
-        <Button
-          aria-label={open ? "Hide sidebars" : "Show sidebars"}
-          aria-pressed={open}
-          className={cn("size-8", className)}
-          onClick={onToggle}
-          size="icon-sm"
-          type="button"
-          variant="ghost"
-        >
-          {open ? (
-            <Layout3ColumnIcon />
-          ) : (
-            <PanelTopBottomDashedIcon className="rotate-90" />
-          )}
-        </Button>
-      </TooltipTrigger>
-      <TooltipContent side={tooltipSide}>Toggle sidebars</TooltipContent>
-    </Tooltip>
+    <Button
+      aria-label={open ? "Hide sidebars" : "Show sidebars"}
+      aria-pressed={open}
+      className={cn("size-8", className)}
+      onClick={onToggle}
+      size="icon-sm"
+      type="button"
+      variant="ghost"
+    >
+      {open ? (
+        <Layout3ColumnIcon />
+      ) : (
+        <PanelTopBottomDashedIcon className="rotate-90" />
+      )}
+    </Button>
   );
 }

--- a/packages/studio/src/editor/editor-theme-toggle.tsx
+++ b/packages/studio/src/editor/editor-theme-toggle.tsx
@@ -3,10 +3,8 @@
 import { MoonIcon, SunIcon } from "lucide-react";
 import { useTheme } from "next-themes";
 import { useCallback, useEffect, useState } from "react";
-import { useStudioToolbarTooltipSide } from "@/components/studio-toolbar-tooltips";
 import { cn } from "@/lib/utils";
 import { Button } from "@/ui/button";
-import { Tooltip, TooltipContent, TooltipTrigger } from "@/ui/tooltip";
 
 function isTypingTarget(target: EventTarget | null): boolean {
   if (!(target instanceof HTMLElement)) {
@@ -57,25 +55,19 @@ export function EditorThemeToggle({ className }: { className?: string }) {
   }, [mounted, toggleTheme]);
 
   const isDark = mounted && resolvedTheme === "dark";
-  const tooltipSide = useStudioToolbarTooltipSide();
 
   return (
-    <Tooltip>
-      <TooltipTrigger render={<span className="inline-flex" />}>
-        <Button
-          aria-keyshortcuts="D"
-          aria-label={isDark ? "Switch to light mode" : "Switch to dark mode"}
-          className={cn("size-8", className)}
-          disabled={!mounted}
-          onClick={toggleTheme}
-          size="icon-sm"
-          type="button"
-          variant="ghost"
-        >
-          {isDark ? <SunIcon /> : <MoonIcon />}
-        </Button>
-      </TooltipTrigger>
-      <TooltipContent side={tooltipSide}>Toggle theme (D)</TooltipContent>
-    </Tooltip>
+    <Button
+      aria-keyshortcuts="D"
+      aria-label={isDark ? "Switch to light mode" : "Switch to dark mode"}
+      className={cn("size-8", className)}
+      disabled={!mounted}
+      onClick={toggleTheme}
+      size="icon-sm"
+      type="button"
+      variant="ghost"
+    >
+      {isDark ? <SunIcon /> : <MoonIcon />}
+    </Button>
   );
 }

--- a/packages/studio/src/editor/use-editor-canvas-view.ts
+++ b/packages/studio/src/editor/use-editor-canvas-view.ts
@@ -10,6 +10,7 @@ import {
 import {
   clampCameraZoom,
   compute100PercentCamera,
+  computeCenterCamera,
   computeFitCamera,
   type EditorCamera,
   persistCamera,
@@ -165,6 +166,31 @@ export function useEditorCamera({
         worldWidth: bounds.width,
         worldHeight: bounds.height,
       }),
+      { userInitiated: true }
+    );
+  }, [applyCamera, getViewportSize]);
+
+  const centerOnContent = useCallback(() => {
+    const { width, height } = getViewportSize();
+    const bounds = getContentBoundsRef.current();
+    const currentZoom = cameraRef.current.zoom;
+    if (!(width && height && bounds.width && bounds.height)) {
+      return;
+    }
+
+    applyCamera(
+      {
+        zoom: currentZoom,
+        ...computeCenterCamera({
+          viewportWidth: width,
+          viewportHeight: height,
+          worldX: bounds.x,
+          worldY: bounds.y,
+          worldWidth: bounds.width,
+          worldHeight: bounds.height,
+          zoom: currentZoom,
+        }),
+      },
       { userInitiated: true }
     );
   }, [applyCamera, getViewportSize]);
@@ -615,6 +641,7 @@ export function useEditorCamera({
     fitToContent,
     /** @deprecated Use fitToContent */
     fitToView: fitToContent,
+    centerOnContent,
     resetTo100,
     zoomBy,
     panBy,

--- a/packages/studio/src/ui/item.tsx
+++ b/packages/studio/src/ui/item.tsx
@@ -1,0 +1,199 @@
+import { mergeProps } from "@base-ui/react/merge-props";
+import { useRender } from "@base-ui/react/use-render";
+import { cn } from "@bklitui/ui/lib/utils";
+import { cva, type VariantProps } from "class-variance-authority";
+import type * as React from "react";
+import { Separator } from "@/ui/separator";
+
+function ItemGroup({ className, ...props }: React.ComponentProps<"ul">) {
+  return (
+    <ul
+      className={cn(
+        "group/item-group flex w-full list-none flex-col gap-4 has-data-[size=sm]:gap-2.5 has-data-[size=xs]:gap-2",
+        className
+      )}
+      data-slot="item-group"
+      {...props}
+    />
+  );
+}
+
+function ItemSeparator({
+  className,
+  ...props
+}: React.ComponentProps<typeof Separator>) {
+  return (
+    <Separator
+      className={cn("my-2", className)}
+      data-slot="item-separator"
+      orientation="horizontal"
+      {...props}
+    />
+  );
+}
+
+const itemVariants = cva(
+  "group/item flex w-full flex-wrap items-center rounded-md border text-sm outline-none transition-colors duration-100 focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 [a]:transition-colors [a]:hover:bg-muted",
+  {
+    variants: {
+      variant: {
+        default: "border-transparent",
+        outline: "border-border",
+        muted: "border-transparent bg-muted/50",
+      },
+      size: {
+        default: "gap-3.5 px-4 py-3.5",
+        sm: "gap-2.5 px-3 py-2.5",
+        xs: "gap-2 in-data-[slot=dropdown-menu-content]:p-0 px-2.5 py-2",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+      size: "default",
+    },
+  }
+);
+
+function Item({
+  className,
+  variant = "default",
+  size = "default",
+  render,
+  ...props
+}: useRender.ComponentProps<"div"> & VariantProps<typeof itemVariants>) {
+  return useRender({
+    defaultTagName: "div",
+    props: mergeProps<"div">(
+      {
+        className: cn(itemVariants({ variant, size, className })),
+      },
+      props
+    ),
+    render,
+    state: {
+      slot: "item",
+      variant,
+      size,
+    },
+  });
+}
+
+const itemMediaVariants = cva(
+  "flex shrink-0 items-center justify-center gap-2 group-has-data-[slot=item-description]/item:translate-y-0.5 group-has-data-[slot=item-description]/item:self-start [&_svg]:pointer-events-none",
+  {
+    variants: {
+      variant: {
+        default: "bg-transparent",
+        icon: "[&_svg:not([class*='size-'])]:size-4",
+        image:
+          "size-10 overflow-hidden rounded-sm group-data-[size=sm]/item:size-8 group-data-[size=xs]/item:size-6 [&_img]:size-full [&_img]:object-cover",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+    },
+  }
+);
+
+function ItemMedia({
+  className,
+  variant = "default",
+  ...props
+}: React.ComponentProps<"div"> & VariantProps<typeof itemMediaVariants>) {
+  return (
+    <div
+      className={cn(itemMediaVariants({ variant, className }))}
+      data-slot="item-media"
+      data-variant={variant}
+      {...props}
+    />
+  );
+}
+
+function ItemContent({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      className={cn(
+        "flex flex-1 flex-col gap-1 group-data-[size=xs]/item:gap-0 [&+[data-slot=item-content]]:flex-none",
+        className
+      )}
+      data-slot="item-content"
+      {...props}
+    />
+  );
+}
+
+function ItemTitle({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      className={cn(
+        "line-clamp-1 flex w-fit items-center gap-2 font-medium text-sm leading-snug underline-offset-4",
+        className
+      )}
+      data-slot="item-title"
+      {...props}
+    />
+  );
+}
+
+function ItemDescription({ className, ...props }: React.ComponentProps<"p">) {
+  return (
+    <p
+      className={cn(
+        "line-clamp-2 text-left font-normal text-muted-foreground text-sm leading-normal group-data-[size=xs]/item:text-xs [&>a:hover]:text-primary [&>a]:underline [&>a]:underline-offset-4",
+        className
+      )}
+      data-slot="item-description"
+      {...props}
+    />
+  );
+}
+
+function ItemActions({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      className={cn("flex items-center gap-2", className)}
+      data-slot="item-actions"
+      {...props}
+    />
+  );
+}
+
+function ItemHeader({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      className={cn(
+        "flex basis-full items-center justify-between gap-2",
+        className
+      )}
+      data-slot="item-header"
+      {...props}
+    />
+  );
+}
+
+function ItemFooter({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      className={cn(
+        "flex basis-full items-center justify-between gap-2",
+        className
+      )}
+      data-slot="item-footer"
+      {...props}
+    />
+  );
+}
+
+export {
+  Item,
+  ItemActions,
+  ItemContent,
+  ItemDescription,
+  ItemFooter,
+  ItemGroup,
+  ItemHeader,
+  ItemMedia,
+  ItemSeparator,
+  ItemTitle,
+};

--- a/packages/studio/src/ui/sonner.tsx
+++ b/packages/studio/src/ui/sonner.tsx
@@ -1,0 +1,77 @@
+"use client";
+
+import {
+  Alert02Icon,
+  CheckmarkCircle02Icon,
+  InformationCircleIcon,
+  Loading03Icon,
+  MultiplicationSignCircleIcon,
+} from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
+import { useTheme } from "next-themes";
+import type * as React from "react";
+import { Toaster as Sonner, type ToasterProps } from "sonner";
+
+const Toaster = ({ ...props }: ToasterProps) => {
+  const { theme = "system" } = useTheme();
+
+  return (
+    <Sonner
+      className="toaster group"
+      icons={{
+        error: (
+          <HugeiconsIcon
+            className="size-4"
+            icon={MultiplicationSignCircleIcon}
+            strokeWidth={2}
+          />
+        ),
+        info: (
+          <HugeiconsIcon
+            className="size-4"
+            icon={InformationCircleIcon}
+            strokeWidth={2}
+          />
+        ),
+        loading: (
+          <HugeiconsIcon
+            className="size-4 animate-spin"
+            icon={Loading03Icon}
+            strokeWidth={2}
+          />
+        ),
+        success: (
+          <HugeiconsIcon
+            className="size-4"
+            icon={CheckmarkCircle02Icon}
+            strokeWidth={2}
+          />
+        ),
+        warning: (
+          <HugeiconsIcon
+            className="size-4"
+            icon={Alert02Icon}
+            strokeWidth={2}
+          />
+        ),
+      }}
+      style={
+        {
+          "--border-radius": "var(--radius)",
+          "--normal-bg": "var(--popover)",
+          "--normal-border": "var(--border)",
+          "--normal-text": "var(--popover-foreground)",
+        } as React.CSSProperties
+      }
+      theme={theme as ToasterProps["theme"]}
+      toastOptions={{
+        classNames: {
+          toast: "cn-toast",
+        },
+      }}
+      {...props}
+    />
+  );
+};
+
+export { Toaster };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -282,6 +282,9 @@ importers:
       shiki:
         specifier: ^3.21.0
         version: 3.21.0
+      sonner:
+        specifier: ^2.0.7
+        version: 2.0.7(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       tailwind-merge:
         specifier: ^2.6.0
         version: 2.6.0
@@ -439,6 +442,9 @@ importers:
       remotion:
         specifier: 4.0.462
         version: 4.0.462(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      sonner:
+        specifier: ^2.0.7
+        version: 2.0.7(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       tailwind-merge:
         specifier: ^2.6.0
         version: 2.6.0
@@ -5489,6 +5495,12 @@ packages:
 
   sisteransi@1.0.5:
     resolution: {integrity: sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==}
+
+  sonner@2.0.7:
+    resolution: {integrity: sha512-W6ZN4p58k8aDKA4XPcx2hpIQXBRAgyiWVkYhT7CvK6D3iAu7xjvVyhQHg2/iaKJZ1XVJ4r7XuwGL+WGEK37i9w==}
+    peerDependencies:
+      react: ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+      react-dom: ^18.0.0 || ^19.0.0 || ^19.0.0-rc
 
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
@@ -11515,6 +11527,11 @@ snapshots:
   signal-exit@4.1.0: {}
 
   sisteransi@1.0.5: {}
+
+  sonner@2.0.7(react-dom@19.2.0(react@19.2.0))(react@19.2.0):
+    dependencies:
+      react: 19.2.0
+      react-dom: 19.2.0(react@19.2.0)
 
   source-map-js@1.2.1: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -282,9 +282,6 @@ importers:
       shiki:
         specifier: ^3.21.0
         version: 3.21.0
-      sonner:
-        specifier: ^2.0.7
-        version: 2.0.7(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       tailwind-merge:
         specifier: ^2.6.0
         version: 2.6.0


### PR DESCRIPTION
## Summary

- Add a share button to the canvas bottom menu that copies the Studio URL with particle hover, share→check animation, and top-center Sonner toasts.
- Move replay and center-chart actions into the canvas menu; consolidate SVG/recording export into a collapsible Export section on the right sidebar.
- Group canvas menu tooltips under a single Base UI `TooltipProvider` via `EditorMenuBarTooltipItem` for smoother hover transitions between items.

## Test plan

- [x] `pnpm lint` passes at repo root
- [x] `pnpm registry:build` run; no registry output changes
- [x] `apps/web` production build succeeds
- [ ] Open `/studio` — share icon in bottom menu copies link and shows top-center toast
- [ ] Replay (R) and center-chart buttons work in canvas menu after zoom-to-fit
- [ ] Export section toggles SVG/Recording and triggers export or recording
- [ ] Get code remains alone in the properties header