### PR TITLE
Remove deprecated @bklit/sdk dependency

### DIFF
--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -1,6 +1,3 @@
-BKLIT_API_KEY=
-BKLIT_PROJECT_ID=
-
 # OpenPanel analytics (https://openpanel.dev)
 OPENPANEL_CLIENT_ID=
 OPENPANEL_CLIENT_SECRET=

--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -1,6 +1,5 @@
 import { GithubStatsProvider } from "@/components/providers/github-stats-provider";
 import "./globals.css";
-import { BklitComponent } from "@bklit/sdk/nextjs";
 import { OpenPanelComponent } from "@openpanel/nextjs";
 import { RootProvider } from "fumadocs-ui/provider";
 import { GeistMono } from "geist/font/mono";
@@ -57,10 +56,6 @@ export default function RootLayout({ children }: { children: ReactNode }) {
       suppressHydrationWarning
     >
       <body className="flex min-h-screen flex-col">
-        <BklitComponent
-          apiKey={process.env.BKLIT_API_KEY ?? ""}
-          projectId={process.env.BKLIT_PROJECT_ID ?? ""}
-        />
         {openPanelClientId ? (
           <OpenPanelComponent
             apiUrl="/api/op"

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -15,7 +15,6 @@
   },
   "dependencies": {
     "@base-ui/react": "^1.1.0",
-    "@bklit/sdk": "^1.0.1",
     "@bklitui/studio": "workspace:*",
     "@bklitui/ui": "workspace:*",
     "@heroicons/react": "^2.2.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -165,9 +165,6 @@ importers:
       '@base-ui/react':
         specifier: ^1.1.0
         version: 1.1.0(@types/react@19.2.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@bklit/sdk':
-        specifier: ^1.0.1
-        version: 1.0.1(next@15.5.9(@babel/core@7.29.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0)
       '@bklitui/studio':
         specifier: workspace:*
         version: link:../../packages/studio
@@ -883,15 +880,6 @@ packages:
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [win32]
-
-  '@bklit/sdk@1.0.1':
-    resolution: {integrity: sha512-NXBlj/ouCSL2qEZC7gWiLxjjQHrDL7yaOf2yrRqQ/aQfsrA2+oelBEcJBWuOg1lR8owci9iOwWFBGfX7+0YOhQ==}
-    peerDependencies:
-      next: '>=13.0.0'
-      react: '>=18.0.0'
-    peerDependenciesMeta:
-      next:
-        optional: true
 
   '@bramus/specificity@2.4.2':
     resolution: {integrity: sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==}
@@ -6416,12 +6404,6 @@ snapshots:
 
   '@biomejs/cli-win32-x64@2.3.11':
     optional: true
-
-  '@bklit/sdk@1.0.1(next@15.5.9(@babel/core@7.29.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0)':
-    dependencies:
-      react: 19.2.0
-    optionalDependencies:
-      next: 15.5.9(@babel/core@7.29.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
 
   '@bramus/specificity@2.4.2':
     dependencies:

--- a/turbo.json
+++ b/turbo.json
@@ -2,8 +2,6 @@
   "$schema": "https://turborepo.dev/schema.json",
   "ui": "tui",
   "globalEnv": [
-    "BKLIT_API_KEY",
-    "BKLIT_PROJECT_ID",
     "OPENPANEL_CLIENT_ID",
     "OPENPANEL_CLIENT_SECRET",
     "CLIENT_ID",


### PR DESCRIPTION
## Summary

- Remove `@bklit/sdk` and the `BklitComponent` analytics integration from the web app root layout
- Drop unused `BKLIT_API_KEY` / `BKLIT_PROJECT_ID` env vars from `.env.example` and `turbo.json`
- OpenPanel remains the site analytics provider

## Test plan

- [x] `pnpm lint` passes at repo root
- [x] `pnpm registry:build` run; no registry output changes
- [x] `apps/web` production build succeeds
- [ ] Site loads without SDK script; OpenPanel still works when configured