### PR TITLE
fix(web): improve docs showcase code panels with indentation

### DIFF
--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -292,3 +292,23 @@
 .component-preview-dark {
   @apply bg-background;
 }
+
+/* Docs ComponentShowcase code panels */
+.showcase-code-block {
+  --showcase-code-line-height: 1.625;
+
+  & .fd-scroll-container {
+    @apply text-sm;
+    line-height: var(--showcase-code-line-height);
+  }
+
+  & pre {
+    tab-size: 2;
+  }
+
+  & .line {
+    min-height: calc(1em * var(--showcase-code-line-height));
+    line-height: var(--showcase-code-line-height);
+    white-space: pre;
+  }
+}

--- a/apps/web/components/docs/component-showcase.tsx
+++ b/apps/web/components/docs/component-showcase.tsx
@@ -1,21 +1,19 @@
 "use client";
 
-import { DynamicCodeBlock } from "fumadocs-ui/components/dynamic-codeblock";
 import { type ReactNode, useState } from "react";
 import { DocsChartPreviewShell } from "@/components/docs/docs-chart-preview-shell";
+import { ShowcaseCodeBlock } from "@/components/docs/showcase-code-block";
+import { Button } from "@/components/ui/button";
 import {
   Card,
   CardContent,
   previewCardClassName,
   previewCardContentClassName,
 } from "@/components/ui/card";
-import {
-  Collapsible,
-  CollapsibleContent,
-  CollapsibleTrigger,
-} from "@/components/ui/collapsible";
-import { codeThemes } from "@/lib/code-theme";
 import { cn } from "@/lib/utils";
+
+/** ~3 lines at showcase line-height when the panel is collapsed. */
+const collapsedCodeMaxHeightClassName = "max-h-[5.75rem]";
 
 interface ComponentShowcaseProps {
   /** The live preview component to render */
@@ -35,8 +33,7 @@ interface ComponentShowcaseProps {
 }
 
 const codePanelContentClassName = cn(
-  "relative overflow-hidden transition-all duration-300",
-  "data-[state=closed]:max-h-[120px]",
+  "relative overflow-hidden transition-[max-height] duration-300",
   "[&_figure]:my-0! [&_figure]:rounded-none! [&_figure]:border-0!",
   "[&_pre]:my-0! [&_pre]:rounded-none! [&_pre]:border-0!",
   "[&_[data-rehype-pretty-code-figure]]:mt-0!"
@@ -84,46 +81,53 @@ export function ComponentShowcase({
       </CardContent>
 
       {hasCode ? (
-        <Collapsible
-          className="group/collapsible relative border-border border-t"
-          onOpenChange={setIsOpen}
-          open={isOpen}
-        >
-          <CollapsibleContent className={codePanelContentClassName} keepMounted>
-            {codeBlock || (
-              <DynamicCodeBlock
-                code={code || ""}
-                lang={lang}
-                options={{ themes: codeThemes }}
+        <div className="relative border-border border-t p-3">
+          <div
+            className={cn(
+              codePanelContentClassName,
+              isOpen ? "" : collapsedCodeMaxHeightClassName
+            )}
+          >
+            {codeBlock || <ShowcaseCodeBlock code={code || ""} lang={lang} />}
+          </div>
+
+          {isOpen ? null : (
+            <>
+              <div
+                aria-hidden
+                className={cn(
+                  "pointer-events-none absolute inset-0 z-10",
+                  "bg-linear-to-t from-card via-card/80 to-transparent"
+                )}
               />
-            )}
-          </CollapsibleContent>
+              <div
+                className={cn(
+                  "absolute inset-0 z-20 flex items-center justify-center"
+                )}
+              >
+                <Button onClick={() => setIsOpen(true)} variant="secondary">
+                  View Code
+                </Button>
+              </div>
+            </>
+          )}
 
-          <CollapsibleTrigger
-            className={cn(
-              "absolute inset-x-0 -bottom-px flex h-16 items-center justify-center",
-              "bg-linear-to-t from-card via-card/80 to-transparent",
-              "font-medium text-muted-foreground text-sm",
-              "cursor-pointer rounded-b-xl",
-              "group-data-[state=open]/collapsible:hidden"
-            )}
-          >
-            View Code
-          </CollapsibleTrigger>
-
-          <CollapsibleTrigger
-            className={cn(
-              "absolute right-3 bottom-3 z-10",
-              "rounded-md px-2.5 py-1 font-medium text-xs",
-              "text-muted-foreground hover:text-foreground",
-              "bg-muted/80 hover:bg-muted",
-              "cursor-pointer transition-colors",
-              "group-data-[state=closed]/collapsible:hidden"
-            )}
-          >
-            Collapse
-          </CollapsibleTrigger>
-        </Collapsible>
+          {isOpen ? (
+            <button
+              className={cn(
+                "absolute right-3 bottom-3 z-10",
+                "rounded-md px-2.5 py-1 font-medium text-xs",
+                "text-muted-foreground hover:text-foreground",
+                "bg-muted/80 hover:bg-muted",
+                "cursor-pointer transition-colors"
+              )}
+              onClick={() => setIsOpen(false)}
+              type="button"
+            >
+              Collapse
+            </button>
+          ) : null}
+        </div>
       ) : null}
     </Card>
   );

--- a/apps/web/components/docs/docs-code-block.tsx
+++ b/apps/web/components/docs/docs-code-block.tsx
@@ -1,8 +1,9 @@
 "use client";
 
-import { DynamicCodeBlock } from "fumadocs-ui/components/dynamic-codeblock";
+import { useMemo } from "react";
 import { CopyButton } from "@/components/copy-button";
-import { codeThemes } from "@/lib/code-theme";
+import { DocsHighlightedCodeBlock } from "@/components/docs/docs-highlighted-code-block";
+import { formatDocsCode } from "@/lib/format-showcase-code";
 import { cn } from "@/lib/utils";
 
 /**
@@ -19,21 +20,26 @@ export function DocsCodeBlock({
   className?: string;
   showCopy?: boolean;
 }) {
+  const formattedCode = useMemo(() => formatDocsCode(code), [code]);
+
   return (
     <div
       className={cn(
-        "relative overflow-hidden [&_figure]:my-0! [&_pre]:my-0!",
+        "showcase-code-block relative overflow-hidden [&_figure]:my-0! [&_pre]:my-0!",
         className
       )}
     >
-      <DynamicCodeBlock
+      <DocsHighlightedCodeBlock
+        allowCopy={false}
         code={code}
-        codeblock={{ allowCopy: false, className: "my-0" }}
         lang={lang}
-        options={{ themes: codeThemes }}
+        showLineNumbers
       />
       {showCopy ? (
-        <CopyButton className="absolute top-2 right-2 z-10" text={code} />
+        <CopyButton
+          className="absolute top-2 right-2 z-10"
+          text={formattedCode}
+        />
       ) : null}
     </div>
   );

--- a/apps/web/components/docs/docs-highlighted-code-block.tsx
+++ b/apps/web/components/docs/docs-highlighted-code-block.tsx
@@ -1,0 +1,42 @@
+"use client";
+
+import { DynamicCodeBlock } from "fumadocs-ui/components/dynamic-codeblock";
+import { useMemo } from "react";
+import { codeThemes } from "@/lib/code-theme";
+import { formatDocsCode } from "@/lib/format-showcase-code";
+import { cn } from "@/lib/utils";
+
+export function DocsHighlightedCodeBlock({
+  code,
+  lang = "tsx",
+  className,
+  showLineNumbers = true,
+  allowCopy = false,
+}: {
+  code: string;
+  lang?: string;
+  className?: string;
+  showLineNumbers?: boolean;
+  allowCopy?: boolean;
+}) {
+  const formattedCode = useMemo(() => formatDocsCode(code), [code]);
+
+  return (
+    <div className={cn("showcase-code-block", className)}>
+      <DynamicCodeBlock
+        code={formattedCode}
+        codeblock={{
+          allowCopy,
+          ...(showLineNumbers ? { "data-line-numbers": true } : {}),
+          className:
+            "my-0 rounded-none border-0 bg-transparent shadow-none text-sm",
+          viewportProps: {
+            className: "max-h-none overflow-visible py-0",
+          },
+        }}
+        lang={lang}
+        options={{ themes: codeThemes }}
+      />
+    </div>
+  );
+}

--- a/apps/web/components/docs/showcase-code-block.tsx
+++ b/apps/web/components/docs/showcase-code-block.tsx
@@ -1,0 +1,22 @@
+"use client";
+
+import { DocsHighlightedCodeBlock } from "@/components/docs/docs-highlighted-code-block";
+import { cn } from "@/lib/utils";
+
+export function ShowcaseCodeBlock({
+  code,
+  lang = "tsx",
+  className,
+}: {
+  code: string;
+  lang?: string;
+  className?: string;
+}) {
+  return (
+    <DocsHighlightedCodeBlock
+      className={cn(className)}
+      code={code}
+      lang={lang}
+    />
+  );
+}

--- a/apps/web/lib/format-showcase-code.ts
+++ b/apps/web/lib/format-showcase-code.ts
@@ -126,11 +126,16 @@ function startsPendingTag(trimmed: string): boolean {
   );
 }
 
+interface IndentLineResult {
+  level: number;
+  pendingTag: boolean;
+}
+
 function applyPendingTagLine(
   trimmed: string,
   level: number,
   output: string[]
-): { level: number; pendingTag: boolean } {
+): IndentLineResult {
   if (trimmed === ">") {
     output.push(" ".repeat(level * INDENT_SIZE) + trimmed);
     return { level: level + 1, pendingTag: false };
@@ -153,7 +158,7 @@ function applyNormalLine(
   trimmed: string,
   level: number,
   output: string[]
-): { level: number; pendingTag: boolean } {
+): IndentLineResult {
   output.push(" ".repeat(level * INDENT_SIZE) + trimmed);
 
   if (startsPendingTag(trimmed)) {
@@ -203,7 +208,7 @@ function indentStrippedCode(code: string): string {
       level = Math.max(0, level - 1);
     }
 
-    const result = pendingTag
+    const result: IndentLineResult = pendingTag
       ? applyPendingTagLine(trimmed, level, output)
       : applyNormalLine(trimmed, level, output);
 

--- a/apps/web/lib/format-showcase-code.ts
+++ b/apps/web/lib/format-showcase-code.ts
@@ -1,0 +1,240 @@
+const INDENT_SIZE = 2;
+const TRAILING_WHITESPACE_RE = /\s+$/;
+const LEADING_WHITESPACE_RE = /^\s+/;
+const LINE_PARTS_RE = /^(\s*)(.*)$/;
+const STRING_LITERAL_RE = /"(?:\\.|[^"\\])*"|'(?:\\.|[^'\\])*'/g;
+const JSX_SELF_CLOSING_RE = /^<[A-Za-z][\w.-]*(?:\s[^>]*)?\/>\s*$/;
+const JSX_CLOSE_TAG_RE = /^<\/[\w.-]+>\s*$/;
+const JSX_TAG_START_RE =
+  /^<[A-Za-z][\w.-]*(?:\s[\w.-]+(?:=(?:"[^"]*"|'[^']*'|\{[^}]*\}))?)*\s*$/;
+const JSX_PROP_LINE_RE = /^[\w.-]+=/;
+const JSX_BOOLEAN_PROP_RE = /^[\w.-]+$/;
+
+function gcd(a: number, b: number): number {
+  return b === 0 ? a : gcd(b, a % b);
+}
+
+function stripStringLiterals(line: string): string {
+  return line.replace(STRING_LITERAL_RE, '""');
+}
+
+function hasPreservedIndentation(lines: string[]): boolean {
+  return lines.some(
+    (line) => line.length > 0 && LEADING_WHITESPACE_RE.test(line)
+  );
+}
+
+function normalizeExistingIndent(lines: string[]): string {
+  const nonEmpty = lines.filter((line) => line.trim().length > 0);
+  if (nonEmpty.length === 0) {
+    return "";
+  }
+
+  const minIndent = Math.min(
+    ...nonEmpty.map(
+      (line) => line.match(LEADING_WHITESPACE_RE)?.[0].length ?? 0
+    )
+  );
+
+  const dedented = lines.map((line) =>
+    line.trim().length === 0 ? "" : line.slice(minIndent)
+  );
+
+  const indentSizes = dedented
+    .filter((line) => line.trim().length > 0)
+    .map((line) => line.match(LEADING_WHITESPACE_RE)?.[0].length ?? 0)
+    .filter((size) => size > 0);
+
+  const unit =
+    indentSizes.length > 0
+      ? indentSizes.reduce((acc, size) => gcd(acc, size), indentSizes[0] ?? 2)
+      : INDENT_SIZE;
+
+  const indentUnit = unit > 0 && unit % INDENT_SIZE === 0 ? unit : INDENT_SIZE;
+
+  return dedented
+    .map((line) => {
+      if (line.trim().length === 0) {
+        return "";
+      }
+
+      const match = line.match(LINE_PARTS_RE);
+      if (!match) {
+        return line;
+      }
+
+      const spaces = match[1] ?? "";
+      const content = match[2] ?? "";
+      const level = Math.round(spaces.length / indentUnit);
+      return " ".repeat(level * INDENT_SIZE) + content;
+    })
+    .join("\n")
+    .trimEnd();
+}
+
+function lineStartsCloser(trimmed: string): boolean {
+  return (
+    trimmed.startsWith("</") ||
+    trimmed.startsWith("}") ||
+    trimmed.startsWith("]") ||
+    trimmed.startsWith(")")
+  );
+}
+
+function isJsxOpenLine(trimmed: string): boolean {
+  return (
+    trimmed.startsWith("<") &&
+    !trimmed.startsWith("</") &&
+    trimmed.endsWith(">") &&
+    !trimmed.endsWith("/>")
+  );
+}
+
+function bracketBalance(trimmed: string): number {
+  const stripped = stripStringLiterals(trimmed);
+  let balance = 0;
+
+  for (const char of stripped) {
+    if (char === "{" || char === "(" || char === "[") {
+      balance += 1;
+    }
+    if (char === "}" || char === ")" || char === "]") {
+      balance -= 1;
+    }
+  }
+
+  return balance;
+}
+
+function isAttrContinuationLine(trimmed: string): boolean {
+  return JSX_PROP_LINE_RE.test(trimmed) || JSX_BOOLEAN_PROP_RE.test(trimmed);
+}
+
+function closesPendingTag(trimmed: string): boolean {
+  return (
+    trimmed.endsWith("/>") ||
+    trimmed === ">" ||
+    (trimmed.endsWith(">") && !trimmed.endsWith("/>"))
+  );
+}
+
+function startsPendingTag(trimmed: string): boolean {
+  return (
+    JSX_TAG_START_RE.test(trimmed) &&
+    !trimmed.endsWith(">") &&
+    !trimmed.endsWith("/>")
+  );
+}
+
+function applyPendingTagLine(
+  trimmed: string,
+  level: number,
+  output: string[]
+): { level: number; pendingTag: boolean } {
+  if (trimmed === ">") {
+    output.push(" ".repeat(level * INDENT_SIZE) + trimmed);
+    return { level: level + 1, pendingTag: false };
+  }
+
+  output.push(" ".repeat((level + 1) * INDENT_SIZE) + trimmed);
+
+  if (closesPendingTag(trimmed)) {
+    const nextLevel = isJsxOpenLine(trimmed) ? level + 1 : level;
+    return { level: nextLevel, pendingTag: false };
+  }
+
+  return {
+    level: Math.max(0, level + bracketBalance(trimmed)),
+    pendingTag: true,
+  };
+}
+
+function applyNormalLine(
+  trimmed: string,
+  level: number,
+  output: string[]
+): { level: number; pendingTag: boolean } {
+  output.push(" ".repeat(level * INDENT_SIZE) + trimmed);
+
+  if (startsPendingTag(trimmed)) {
+    return { level, pendingTag: true };
+  }
+
+  if (JSX_SELF_CLOSING_RE.test(trimmed) || JSX_CLOSE_TAG_RE.test(trimmed)) {
+    return { level, pendingTag: false };
+  }
+
+  if (isJsxOpenLine(trimmed)) {
+    return { level: level + 1, pendingTag: false };
+  }
+
+  return {
+    level: Math.max(0, level + bracketBalance(trimmed)),
+    pendingTag: false,
+  };
+}
+
+/**
+ * Re-indent JSX/TSX after MDX strips leading whitespace from template literals.
+ */
+function indentStrippedCode(code: string): string {
+  const lines = code.split("\n");
+  let level = 0;
+  let pendingTag = false;
+  const output: string[] = [];
+
+  for (const rawLine of lines) {
+    const trimmed = rawLine.trim();
+
+    if (!trimmed) {
+      output.push("");
+      continue;
+    }
+
+    if (
+      pendingTag &&
+      !isAttrContinuationLine(trimmed) &&
+      !closesPendingTag(trimmed)
+    ) {
+      pendingTag = false;
+    }
+
+    if (!pendingTag && lineStartsCloser(trimmed)) {
+      level = Math.max(0, level - 1);
+    }
+
+    const result = pendingTag
+      ? applyPendingTagLine(trimmed, level, output)
+      : applyNormalLine(trimmed, level, output);
+
+    level = result.level;
+    pendingTag = result.pendingTag;
+  }
+
+  return output.join("\n").trimEnd();
+}
+
+/**
+ * Normalize docs code snippets to consistent 2-space indentation.
+ * MDX attribute template literals lose leading whitespace at compile time,
+ * so flat snippets are structurally re-indented before render.
+ */
+export function formatShowcaseCode(code: string): string {
+  const lines = code
+    .replace(/\t/g, " ".repeat(INDENT_SIZE))
+    .split("\n")
+    .map((line) => line.replace(TRAILING_WHITESPACE_RE, ""));
+
+  if (lines.every((line) => line.trim().length === 0)) {
+    return "";
+  }
+
+  if (hasPreservedIndentation(lines)) {
+    return normalizeExistingIndent(lines);
+  }
+
+  return indentStrippedCode(lines.join("\n"));
+}
+
+/** @alias formatShowcaseCode */
+export const formatDocsCode = formatShowcaseCode;


### PR DESCRIPTION
## Summary

- Fix docs `ComponentShowcase` code panels so nested JSX renders with consistent 2-space indentation after MDX strips leading whitespace from template literals
- Add shared highlighted code block with line numbers, relaxed line-height, and improved collapsed preview UX (peek + centered View Code button)
- Apply the same formatting to `DocsCodeBlock` copy text so copied snippets match displayed indentation

## Test plan

- [x] `pnpm lint` passes at repo root
- [x] `pnpm registry:build` run; no registry output changes
- [x] `apps/web` production build succeeds
- [ ] Collapsed showcase shows ~3 lines with gradient fade and View Code button
- [ ] Expanded showcase shows 2-space nested indent and line numbers (e.g. `/docs/utility/tooltip`)
- [ ] DocsCodeBlock copy button copies formatted indented code