### PR TITLE
fix(web): restore OpenPanel tracking on bklit.com

### DIFF
--- a/apps/web/app/api/og/studio/route.tsx
+++ b/apps/web/app/api/og/studio/route.tsx
@@ -42,7 +42,7 @@ function chartSubtitle(state: ReturnType<typeof loadStudioStateFromRequest>) {
   if (state.preset !== "default") {
     return `${state.preset} preset`;
   }
-  return "ui.bklit.com";
+  return "bklit.com";
 }
 
 export function GET(request: Request) {

--- a/apps/web/app/api/op/[[...path]]/route.ts
+++ b/apps/web/app/api/op/[[...path]]/route.ts
@@ -1,3 +1,51 @@
 import { createRouteHandler } from "@openpanel/nextjs/server";
 
-export const { GET, POST } = createRouteHandler();
+import { SITE_URL } from "@/lib/site-url";
+
+const { GET: baseGET, POST: basePOST } = createRouteHandler();
+
+const canonicalOrigin = new URL(SITE_URL).origin;
+
+/** Production hosts that should proxy with the OpenPanel-registered origin. */
+const productionOrigins = new Set([
+  canonicalOrigin,
+  "https://bklit.com",
+  "https://www.bklit.com",
+]);
+
+function shouldNormalizeOrigin(request: Request) {
+  const { pathname } = new URL(request.url);
+  if (!pathname.includes("/track") || request.method !== "POST") {
+    return false;
+  }
+
+  const origin =
+    request.headers.get("origin") ??
+    `${new URL(request.url).protocol}//${new URL(request.url).host}`;
+
+  return productionOrigins.has(origin) || origin.endsWith(".vercel.app");
+}
+
+function withCanonicalOrigin(request: Request) {
+  if (!shouldNormalizeOrigin(request)) {
+    return request;
+  }
+
+  const headers = new Headers(request.headers);
+  headers.set("origin", canonicalOrigin);
+
+  return new Request(request.url, {
+    method: request.method,
+    headers,
+    body: request.body,
+    duplex: "half",
+  } as RequestInit);
+}
+
+export function GET(request: Request) {
+  return baseGET(request);
+}
+
+export function POST(request: Request) {
+  return basePOST(withCanonicalOrigin(request));
+}

--- a/apps/web/app/api/op/[[...path]]/route.ts
+++ b/apps/web/app/api/op/[[...path]]/route.ts
@@ -6,10 +6,10 @@ const { GET: baseGET, POST: basePOST } = createRouteHandler();
 
 const canonicalOrigin = new URL(SITE_URL).origin;
 
-/** Production hosts that should proxy with the OpenPanel-registered origin. */
+/** Legacy/alternate hosts that should proxy with the canonical origin. */
 const productionOrigins = new Set([
   canonicalOrigin,
-  "https://bklit.com",
+  "https://ui.bklit.com",
   "https://www.bklit.com",
 ]);
 

--- a/apps/web/lib/site-url.ts
+++ b/apps/web/lib/site-url.ts
@@ -1,2 +1,2 @@
 /** Canonical site origin for metadata, sitemaps, and Open Graph. */
-export const SITE_URL = "https://ui.bklit.com";
+export const SITE_URL = "https://bklit.com";

--- a/packages/studio/src/lib/__tests__/chart-links.test.ts
+++ b/packages/studio/src/lib/__tests__/chart-links.test.ts
@@ -48,7 +48,7 @@ describe("chart-links", () => {
     const encoded = href.split("url=")[1];
     assert.equal(
       decodeURIComponent(encoded ?? ""),
-      "https://ui.bklit.com/r/area-chart-example.json"
+      "https://bklit.com/r/area-chart-example.json"
     );
   });
 
@@ -74,14 +74,14 @@ describe("chart-links", () => {
 
   it("studioShareStudioUrl builds an absolute studio link", () => {
     const state = defaultStudioState({ chart: "pie-chart" });
-    const url = studioShareStudioUrl(state, "https://ui.bklit.com");
-    assert.ok(url.startsWith("https://ui.bklit.com/studio?s=v1."));
+    const url = studioShareStudioUrl(state, "https://bklit.com");
+    assert.ok(url.startsWith("https://bklit.com/studio?s=v1."));
   });
 
   it("studioEmbedIframeMarkup includes the embed src", () => {
     const state = defaultStudioState({ chart: "line-chart" });
     const markup = studioEmbedIframeMarkup(state, {
-      origin: "https://ui.bklit.com",
+      origin: "https://bklit.com",
       height: 520,
     });
     assert.match(markup, IFRAME_TAG_RE);

--- a/packages/studio/src/lib/__tests__/chart-links.test.ts
+++ b/packages/studio/src/lib/__tests__/chart-links.test.ts
@@ -17,7 +17,7 @@ import { defaultStudioState } from "../studio-parsers";
 
 const FLAT_CHART_PARAM_RE = /chart=/;
 const IFRAME_TAG_RE = /^<iframe /;
-const EMBED_SRC_RE = /src="https:\/\/ui\.bklit\.com\/studio\/embed\?s=v1\./;
+const EMBED_SRC_RE = /src="https:\/\/bklit\.com\/studio\/embed\?s=v1\./;
 const IFRAME_HEIGHT_RE = /height="520"/;
 
 describe("chart-links", () => {

--- a/packages/studio/src/lib/__tests__/studio-og.test.ts
+++ b/packages/studio/src/lib/__tests__/studio-og.test.ts
@@ -35,7 +35,7 @@ describe("studio OG state", () => {
       const state = ogStateForChart(slug);
       const serialized = studioSerializedParam(state);
       const url = new URL(
-        `https://ui.bklit.com/studio/og-preview?s=${encodeURIComponent(serialized)}`
+        `https://bklit.com/studio/og-preview?s=${encodeURIComponent(serialized)}`
       );
       const loaded = normalizeStudioStateForOg(loadStudioStateFromRequest(url));
       assert.equal(loaded.chart, slug);

--- a/packages/studio/src/lib/__tests__/studio-url-codec.test.ts
+++ b/packages/studio/src/lib/__tests__/studio-url-codec.test.ts
@@ -57,7 +57,7 @@ describe("studio-url-codec", () => {
     });
     const encoded = encodeStudioUrlState(state);
     const url = new URL(
-      `https://ui.bklit.com/studio?s=${encodeURIComponent(encoded)}&chart=area-chart`
+      `https://bklit.com/studio?s=${encodeURIComponent(encoded)}&chart=area-chart`
     );
     assert.deepEqual(loadStudioStateFromRequest(url), state);
   });
@@ -90,7 +90,7 @@ describe("studio-url-codec", () => {
 
   it("loadStudioStateFromRequest reads legacy flat params", () => {
     const url = new URL(
-      "https://ui.bklit.com/studio?chart=bar-chart&barOrientation=horizontal"
+      "https://bklit.com/studio?chart=bar-chart&barOrientation=horizontal"
     );
     const state = loadStudioStateFromRequest(url);
     assert.equal(state.chart, "bar-chart");

--- a/packages/studio/src/lib/chart-links.ts
+++ b/packages/studio/src/lib/chart-links.ts
@@ -7,7 +7,7 @@ import {
 } from "./studio-url-codec";
 import type { ChartSlug } from "./types";
 
-export const REGISTRY_ORIGIN = "https://ui.bklit.com";
+export const REGISTRY_ORIGIN = "https://bklit.com";
 
 export const STUDIO_EMBED_PATH = "/studio/embed";
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

OpenPanel was **not** removed when `@bklit/sdk` was dropped in #173 — the SDK, proxy route, and custom events are still in place. Tracking stopped because the live site runs on **`bklit.com`** while OpenPanel was still configured for **`ui.bklit.com`**.

This PR aligns the codebase with `bklit.com` as the canonical domain and normalizes proxied `/track` requests from legacy hosts (`ui.bklit.com`, `*.vercel.app`) to that origin.

### Code changes
- `SITE_URL` → `https://bklit.com`
- Registry / studio share links → `https://bklit.com`
- OpenPanel proxy normalizes alternate production hosts to the canonical origin

### OpenPanel dashboard (required)
In your OpenPanel project settings, set the allowed site domain to **`https://bklit.com`**. You can remove `ui.bklit.com` once redirects are fully settled.

## Test plan

- [x] `pnpm lint` passes at repo root
- [ ] OpenPanel dashboard updated to allow `https://bklit.com`
- [ ] Deploy preview: `POST /api/op/track` with `Origin: https://bklit.com` returns `{ deviceId, sessionId }`
- [ ] Verify `screen_view` and custom events appear in OpenPanel after browsing the site
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d3a605bb-6737-49c9-aa89-c33016d43656"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d3a605bb-6737-49c9-aa89-c33016d43656"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

