### PR TITLE
fix(web): restore nuqs adapter context for Studio SSR

### DIFF
--- a/apps/studio-docs/app/layout.tsx
+++ b/apps/studio-docs/app/layout.tsx
@@ -42,9 +42,9 @@ export default function RootLayout({ children }: { children: ReactNode }) {
             enableSystem: true,
           }}
         >
-          <Suspense fallback={null}>
-            <StudioNuqsAdapter>{children}</StudioNuqsAdapter>
-          </Suspense>
+          <StudioNuqsAdapter>
+            <Suspense fallback={null}>{children}</Suspense>
+          </StudioNuqsAdapter>
         </RootProvider>
       </body>
     </html>

--- a/apps/web/app/studio/layout.tsx
+++ b/apps/web/app/studio/layout.tsx
@@ -10,8 +10,8 @@ export const metadata: Metadata = {
 
 export default function StudioLayout({ children }: { children: ReactNode }) {
   return (
-    <Suspense fallback={null}>
-      <StudioNuqsAdapter>{children}</StudioNuqsAdapter>
-    </Suspense>
+    <StudioNuqsAdapter>
+      <Suspense fallback={null}>{children}</Suspense>
+    </StudioNuqsAdapter>
   );
 }


### PR DESCRIPTION
## Summary

- Fix production Studio crash (`Application error: a client-side exception has occurred`) on bklit.com/studio
- PR #182 wrapped `NuqsAdapter` inside `Suspense`, which prevented nuqs context from being available during Vercel SSR (`[nuqs] nuqs requires an adapter`)
- Move `Suspense` inside `StudioNuqsAdapter` so the adapter is always mounted before children that call `useQueryState`

## Test plan

- [x] `pnpm lint` passes at repo root
- [x] `pnpm registry:build` run (no output changes)
- [x] `apps/web` production build succeeds
- [ ] https://bklit.com/studio loads after deploy
- [ ] https://bklit.com/studio/embed loads after deploy