### PR TITLE
fix(studio): stack line curve label above style picker

### DIFF
--- a/packages/studio/src/components/controls/control-field-helpers.tsx
+++ b/packages/studio/src/components/controls/control-field-helpers.tsx
@@ -37,7 +37,6 @@ export const studioInputSurfaceClass = cn(
 
 const GROUP_LABELED_TYPES = new Set<StudioControl["type"]>([
   "pattern",
-  "curve",
   "pieFill",
   "orientation",
   "lineCap",

--- a/packages/studio/src/components/controls/control-field-inputs.tsx
+++ b/packages/studio/src/components/controls/control-field-inputs.tsx
@@ -16,7 +16,7 @@ import {
 import { YesNoSwitch } from "@/ui/yes-no-switch";
 import { studioControlInputClass } from "./control-field-helpers";
 import { CrosshairFadePicker } from "./crosshair-fade-picker";
-import { CurvePicker } from "./curve-picker";
+import { CurvePickerField } from "./curve-picker";
 import { type FadeEdgesOption, FadeEdgesPicker } from "./fade-edges-picker";
 import { FunnelEdgesPicker } from "./funnel-edges-picker";
 import { GraticuleToggle } from "./graticule-toggle";
@@ -86,7 +86,8 @@ export function ControlFieldInputs({
       );
     case "curve":
       return (
-        <CurvePicker
+        <CurvePickerField
+          label={control.label}
           onChange={(v) => onChange(control.key, v as StudioUrlState["curve"])}
           value={value as CurveId}
         />

--- a/packages/studio/src/components/controls/control-field.tsx
+++ b/packages/studio/src/components/controls/control-field.tsx
@@ -524,6 +524,21 @@ export function ControlField({
     );
   }
 
+  if (control.type === "curve") {
+    return (
+      <ControlFieldInputs
+        control={control}
+        onChange={(nextKey, nextValue) =>
+          commitValue(
+            nextKey,
+            nextValue as StudioUrlState[keyof StudioUrlState]
+          )
+        }
+        value={value}
+      />
+    );
+  }
+
   if (isGroupLabeledControlType(control.type)) {
     return (
       <div className="space-y-2">

--- a/packages/studio/src/components/controls/curve-picker.tsx
+++ b/packages/studio/src/components/controls/curve-picker.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { studioFieldLabelClass } from "@/components/controls/control-field-helpers";
 import { IconToggleGroup } from "@/components/controls/icon-toggle-group";
 import { StudioToggleGroupItem } from "@/components/controls/studio-toggle-group";
 import type { CurveId } from "@/lib/curves";
@@ -35,7 +36,29 @@ export function CurvePicker({
   );
 }
 
-export function LineGroupHeaderCurve({
+export function CurvePickerField({
+  label = "Curve",
+  value,
+  onChange,
+}: {
+  label?: string;
+  value: CurveId;
+  onChange: (v: CurveId) => void;
+}) {
+  const selectedName =
+    CURVE_OPTIONS.find((opt) => opt.value === value)?.label ?? value;
+
+  return (
+    <div className="flex flex-col gap-2">
+      <span className={studioFieldLabelClass}>
+        {label}: {selectedName}
+      </span>
+      <CurvePicker onChange={onChange} value={value} />
+    </div>
+  );
+}
+
+export function LineCurveField({
   control,
   state,
   onChange,
@@ -54,7 +77,8 @@ export function LineGroupHeaderCurve({
       : getSeriesScopedControlValue(state, "curve", seriesIndex);
 
   return (
-    <CurvePicker
+    <CurvePickerField
+      label={control.label}
       onChange={(next) => {
         if (seriesIndex !== undefined) {
           const updates = buildSeriesScopedControlUpdate(

--- a/packages/studio/src/components/studio-control-groups.tsx
+++ b/packages/studio/src/components/studio-control-groups.tsx
@@ -2,7 +2,7 @@
 
 import { ControlField } from "@/components/controls/control-field";
 import { isGroupLabeledControlType } from "@/components/controls/control-field-helpers";
-import { LineGroupHeaderCurve } from "@/components/controls/curve-picker";
+import { LineCurveField } from "@/components/controls/curve-picker";
 import { MotionControl } from "@/components/controls/motion-control";
 import { MotionResetButton } from "@/components/controls/motion-reset-button";
 import { StudioControlGroup } from "@/components/studio-control-group";
@@ -78,7 +78,7 @@ export function StudioControlGroups({
         const fieldControls = curveControl
           ? visibleControls.filter((control) => control !== curveControl)
           : visibleControls;
-        const showLineCurveHeader =
+        const showLineCurveField =
           group.title === "Line" && curveControl !== undefined;
 
         return (
@@ -87,16 +87,14 @@ export function StudioControlGroups({
             defaultOpen={group.defaultOpen ?? true}
             key={group.title}
             title={group.title}
-            titleTrailing={
-              showLineCurveHeader ? (
-                <LineGroupHeaderCurve
-                  control={curveControl}
-                  onChange={onChange}
-                  state={state}
-                />
-              ) : null
-            }
           >
+            {showLineCurveField ? (
+              <LineCurveField
+                control={curveControl}
+                onChange={onChange}
+                state={state}
+              />
+            ) : null}
             {fieldControls.map((control) => (
               <ControlField
                 control={control}


### PR DESCRIPTION
## Summary
- Move line curve style picker from the LINE group header into the group body
- Show `Curve: {name}` label stacked above toggle icons (matches motion preset layout)
- Add `CurvePickerField` / `LineCurveField` and dedicated `curve` control branch

## Test plan
- [ ] Open `/studio` with a Cartesian line chart
- [ ] Select a series and expand the Line group
- [ ] Confirm curve label appears above icons, not inline with "LINE" header
- [ ] Toggle curve styles and verify chart updates