### PR TITLE
fix(studio): open motion curve popover to the right

### DIFF
--- a/packages/studio/src/components/controls/motion-curve-editor.tsx
+++ b/packages/studio/src/components/controls/motion-curve-editor.tsx
@@ -640,7 +640,7 @@ export function MotionCurveEditor({
         className="w-[min(calc(100vw-2rem),18rem)] gap-0 p-3"
         collisionAvoidance={studioSidebarPopoverCollisionAvoidance}
         positionMethod="fixed"
-        side="left"
+        side="right"
         sideOffset={studioSidebarPopoverSideOffset}
       >
         <MotionCurveEditorContent


### PR DESCRIPTION
## Summary

- Open the left-sidebar animation bezier editor popover on the **right** (`side="right"`) so it opens toward the canvas instead of clipping off the screen edge.
- Reuses the existing `studioSidebarPopoverCollisionAvoidance` and `studioSidebarPopoverSideOffset` helpers (same pattern as `chart-type-selector`).

## Test plan

- [x] `pnpm lint` passes at repo root
- [x] `pnpm --filter @bklitui/studio check-types` passes
- [x] `pnpm registry:build` run (no registry diff)
- [x] `pnpm build` succeeds
- [ ] Open Studio → left sidebar Animation panel → click motion curve trigger → popover opens to the right of the sidebar