### PR TITLE
fix(studio): restore theme provider on embed shell

### DIFF
--- a/packages/studio/src/components/studio-embed-shell.tsx
+++ b/packages/studio/src/components/studio-embed-shell.tsx
@@ -4,6 +4,7 @@ import { StudioEmbedLayout } from "@/components/studio-embed-layout";
 import type { StudioAnalytics } from "@/providers/studio-analytics-context";
 import { StudioAnalyticsProvider } from "@/providers/studio-analytics-context";
 import { StudioNuqsAdapter } from "@/providers/studio-nuqs-adapter";
+import { StudioThemeProvider } from "@/providers/studio-theme-provider";
 import { Toaster } from "@/ui/sonner";
 import { StudioStateProvider } from "./studio-state-provider";
 
@@ -16,10 +17,12 @@ export function StudioEmbedShell({
     <StudioNuqsAdapter>
       <StudioAnalyticsProvider value={analytics ?? {}}>
         <StudioStateProvider>
-          <div className="relative flex h-full min-h-0 flex-1 flex-col overflow-hidden">
-            <StudioEmbedLayout />
-            <Toaster position="top-center" />
-          </div>
+          <StudioThemeProvider>
+            <div className="relative flex h-full min-h-0 flex-1 flex-col overflow-hidden">
+              <StudioEmbedLayout />
+              <Toaster position="top-center" />
+            </div>
+          </StudioThemeProvider>
         </StudioStateProvider>
       </StudioAnalyticsProvider>
     </StudioNuqsAdapter>


### PR DESCRIPTION
## Summary

- Wrap `StudioEmbedShell` in `StudioThemeProvider` so embed toolbar components (e.g. Open in Studio) can call `useStudioTheme`.
- Fixes client-side crashes on `/studio/embed?s=…` that made shared links and iframe embeds appear broken even though URL serialization was valid.
- Main `/studio` serialized URLs were unaffected; this restores embed parity with `StudioShell`.

## Test plan

- [x] `pnpm lint` passes at repo root
- [x] `pnpm registry:build` run (no registry output changes)
- [x] `apps/web` production build succeeds
- [x] `/studio/embed?s=v1.…` loads pie chart locally (no application error)
- [x] `/studio?s=v1.…` still restores chart state locally