### PR TITLE
Hide reference area by default in Studio cartesian charts

### DIFF
--- a/packages/studio/src/components/studio-state-provider.tsx
+++ b/packages/studio/src/components/studio-state-provider.tsx
@@ -44,6 +44,7 @@ const STUDIO_Y_AXIS_CHART_PREFIX: Partial<Record<ChartSlug, string>> = {
   "composed-chart": "composed",
   "bar-chart": "bar",
   "candlestick-chart": "candlestick",
+  "live-line-chart": "live-line",
 };
 
 function finiteFrameDimension(value: number, fallback: number) {

--- a/packages/studio/src/lib/studio-component-visibility.ts
+++ b/packages/studio/src/lib/studio-component-visibility.ts
@@ -19,11 +19,12 @@ export function serializeHiddenStudioComponents(ids: Iterable<string>): string {
   return [...ids].filter(Boolean).join(HIDDEN_SEP);
 }
 
-/** Both Y axes hidden until toggled in the components tree. */
+/** Y axes and reference area hidden until toggled in the components tree. */
 export function chartDefaultHiddenYAxes(chartPrefix: string): string {
   return serializeHiddenStudioComponents([
     `${chartPrefix}.yaxis.left`,
     `${chartPrefix}.yaxis.right`,
+    `${chartPrefix}.reference-area`,
   ]);
 }
 


### PR DESCRIPTION
## Summary

- Reference area layers are hidden by default in Studio for all cartesian charts (line, area, bar, scatter, composed, candlestick, live line)
- Users opt in via the components tree eye toggle; generated code omits `ReferenceArea` until the layer is shown
- Live line chart now receives the same default hidden-layer treatment on chart switch

## Test plan

- [x] `pnpm lint` passes at repo root
- [x] `pnpm registry:build` run; no registry output changes
- [x] `pnpm build` succeeds
- [ ] Open `/studio?chart=line-chart` — reference area band not visible; eye toggle shows it
- [ ] Switch to area, bar, scatter, composed, candlestick, live-line — reference area hidden on each