### PR TITLE
Align reference area and projection demos with Studio preset

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 <p align="center">
 	<h1 align="center"><b><a href="https://ui.bklit.com">Bklit UI</a></b></h1>
+  <br />
+<a href="https://vercel.com/open-source-program">
+  <img alt="Vercel OSS Program" src="https://vercel.com/oss/program-badge-2026.svg" />
+</a>
 <p align="center">
     A collection of Open Source charts and utility components that you can customize and extend.
     <br />
@@ -14,9 +18,14 @@
   </p>
 </p>
 
+
 ## Premium Sponsors
 
 Bklit UI is supported by our premium sponsors.
+
+<a href="https://openpanel.dev">
+<img alt="OpenPanel" src="https://github.com/user-attachments/assets/279ef3ca-ed28-4a75-bac7-3fb90db4954d" />
+</a>
 
 **[OpenPanel](https://openpanel.dev)** — OpenPanel is an open source analytics platform that combines web analytics and product analytics in one privacy-first tool. Track pageviews, events, funnels, retention, and user journeys — all without cookies.
 

--- a/apps/web/components/charts/chart-examples.tsx
+++ b/apps/web/components/charts/chart-examples.tsx
@@ -127,6 +127,10 @@ import {
 import { LineChartStudioTrioDemo } from "@/components/charts/line-chart-studio-trio-demo";
 import { CopyButton } from "@/components/copy-button";
 import {
+  buildLineChartDemoData,
+  REFERENCE_AREA_DEMO,
+} from "@/components/docs/line-chart-demo-data";
+import {
   PROFIT_LOSS_DATA_KEY,
   profitLossLineDocsData,
 } from "@/components/docs/profit-loss-line-docs-data";
@@ -2354,30 +2358,47 @@ function makeLineExamples(): ChartExample[] {
     {
       title: "Line Chart - Projection",
       description:
-        "Auto forecast from the last segment with a terminal marker and dashed bezier horizon",
+        "Target and auto forecasts with gradient dashed beziers and a terminal marker",
       code: `import {
   buildProjectionPath,
   LineSeriesTerminalMarker,
   ProjectionLine,
 } from "@bklitui/ui/charts";
 
-const projectionPath = buildProjectionPath({
+const targetProjectionPath = buildProjectionPath({
   sourceData: chartData,
-  seriesKey: "desktop",
+  seriesKey: "value",
+  mode: "target",
+  pathDensity: "endpoints",
+  horizonPoints: 6,
+  endValue: 301,
+});
+
+const autoProjectionPath = buildProjectionPath({
+  sourceData: chartData,
+  seriesKey: "value",
   mode: "auto",
   autoMethod: "lastSegment",
   pathDensity: "endpoints",
-  horizonPoints: 8,
+  horizonPoints: 6,
 });
 
 <LineChart data={chartData}>
   <Grid horizontal />
-  <Line dataKey="desktop" strokeWidth={2} />
-  <LineSeriesTerminalMarker dataKey="desktop" />
+  <Line dataKey="value" strokeWidth={2} />
+  <LineSeriesTerminalMarker dataKey="value" />
   <ProjectionLine
-    data={projectionPath}
-    strokeDasharray="6,4"
+    data={targetProjectionPath}
+    strokeDasharray="1,4"
     curveKind="bezier"
+    strokeStyle="gradient"
+    showEndMarker
+  />
+  <ProjectionLine
+    data={autoProjectionPath}
+    strokeDasharray="1,4"
+    curveKind="bezier"
+    strokeStyle="gradient"
     showEndMarker
   />
   <XAxis />
@@ -2693,16 +2714,18 @@ const projectionPath = buildProjectionPath({
     }),
     ...makeCartesianReferenceAreaExamples({
       titlePrefix: "Line Chart",
+      y1: REFERENCE_AREA_DEMO.y1,
+      y2: REFERENCE_AREA_DEMO.y2,
       chartOpen:
         "<LineChart margin={{ top: 8, right: 8, bottom: 40, left: 8 }} data={chartData}>",
       chartClose: "</LineChart>",
-      seriesSnippet: `<Line dataKey="desktop" strokeWidth={2} />
+      seriesSnippet: `<Line dataKey="value" strokeWidth={2} />
   <XAxis />
   <ChartTooltip />`,
       render: (referenceArea) => (
-        <LineExampleChart data={lineData}>
+        <LineExampleChart data={buildLineChartDemoData()}>
           {referenceArea}
-          <Line dataKey="desktop" strokeWidth={2} />
+          <Line dataKey="value" strokeWidth={2} />
           <XAxis />
           <ChartTooltip />
         </LineExampleChart>

--- a/apps/web/components/docs/line-chart-demo-data.ts
+++ b/apps/web/components/docs/line-chart-demo-data.ts
@@ -1,0 +1,40 @@
+/** Shared line-chart demo data and styling aligned with the Studio reference preset. */
+
+export const LINE_DEMO_POINT_COUNT = 10;
+
+export const REFERENCE_AREA_DEMO = {
+  y1: 250,
+  y2: 300,
+  pattern: "diagonal" as const,
+  patternColor: "oklch(0.76 0.144 180.392 / 0.17)",
+  patternScale: 0.75,
+  patternStrokeWidth: 1.5,
+  stroke: "oklch(0.841 0.142 159.667 / 0.49)",
+  axisLabelColor: "oklch(0.795 0.152 164.722)",
+  showMarkers: false,
+};
+
+function trendingLineValue(index: number, seriesIndex = 0): number {
+  const base = 120 + seriesIndex * 18;
+  const trend = (5.5 + seriesIndex * 1.25) * index;
+  const i = index + seriesIndex * 9;
+  const swell = Math.sin(i / 4.4 + seriesIndex * 1.2) * (24 + seriesIndex * 3);
+  const ripple =
+    Math.cos(i / 1.65 + seriesIndex * 0.85) * (16 + seriesIndex * 2);
+  const jitter = Math.sin(i / 0.68 + seriesIndex * 2.4) * (10 + seriesIndex);
+  const wobble = Math.cos(i / 2.95 + seriesIndex * 1.6) * 7;
+
+  return Math.max(
+    10,
+    Math.floor(base + trend + swell + ripple + jitter + wobble)
+  );
+}
+
+export function buildLineChartDemoData(
+  pointCount = LINE_DEMO_POINT_COUNT
+): { date: Date; value: number }[] {
+  return Array.from({ length: pointCount }, (_, index) => ({
+    date: new Date(2024, 0, index + 1),
+    value: trendingLineValue(index),
+  }));
+}

--- a/apps/web/components/docs/projection-line-demo.tsx
+++ b/apps/web/components/docs/projection-line-demo.tsx
@@ -10,22 +10,26 @@ import {
   ProjectionLine,
   XAxis,
 } from "@bklitui/ui/charts";
+import { buildLineChartDemoData } from "@/components/docs/line-chart-demo-data";
 
-const chartData = Array.from({ length: 14 }, (_, index) => {
-  const date = new Date(2025, 0, 1 + index);
-  return {
-    date,
-    value: Math.round(140 + index * 8 + Math.sin(index / 2) * 18),
-  };
+const chartData = buildLineChartDemoData();
+
+const targetProjectionPath = buildProjectionPath({
+  sourceData: chartData,
+  seriesKey: "value",
+  mode: "target",
+  pathDensity: "endpoints",
+  horizonPoints: 6,
+  endValue: 301,
 });
 
-const projectionPath = buildProjectionPath({
+const autoProjectionPath = buildProjectionPath({
   sourceData: chartData,
   seriesKey: "value",
   mode: "auto",
   autoMethod: "lastSegment",
   pathDensity: "endpoints",
-  horizonPoints: 8,
+  horizonPoints: 6,
 });
 
 export function ProjectionLineDemo() {
@@ -36,15 +40,29 @@ export function ProjectionLineDemo() {
         <Line dataKey="value" stroke="var(--chart-1)" strokeWidth={2} />
         <LineSeriesTerminalMarker
           dataKey="value"
-          ringGap={2}
+          ringGap={6}
           stroke="var(--chart-1)"
         />
         <ProjectionLine
           curveKind="bezier"
-          data={projectionPath}
+          data={targetProjectionPath}
+          gradientEnd="oklch(0.59 0.17 166.38)"
+          gradientStart="oklch(0.979 0.037 110.273)"
           showEndMarker
           stroke="var(--chart-3)"
-          strokeDasharray="6,4"
+          strokeDasharray="1,4"
+          strokeStyle="gradient"
+          strokeWidth={2}
+        />
+        <ProjectionLine
+          curveKind="bezier"
+          data={autoProjectionPath}
+          gradientEnd="oklch(0.849 0.232 16.498)"
+          gradientStart="oklch(0.926 0.128 16.866 / 0.73)"
+          showEndMarker
+          stroke="oklch(0.926 0.128 32.86 / 0.73)"
+          strokeDasharray="1,4"
+          strokeStyle="gradient"
           strokeWidth={2}
         />
         <XAxis />
@@ -62,14 +80,14 @@ export function ProjectionLineGradientDemo() {
         <Line dataKey="value" stroke="var(--chart-1)" strokeWidth={2} />
         <LineSeriesTerminalMarker dataKey="value" stroke="var(--chart-1)" />
         <ProjectionLine
-          curveKind="linear"
-          data={projectionPath}
-          gradientEnd="var(--chart-5)"
-          gradientStart="var(--chart-3)"
+          curveKind="bezier"
+          data={autoProjectionPath}
+          gradientEnd="oklch(0.849 0.232 16.498)"
+          gradientStart="oklch(0.926 0.128 16.866 / 0.73)"
           showEndMarker={false}
-          stroke="var(--chart-3)"
+          stroke="oklch(0.926 0.128 32.86 / 0.73)"
           strokeStyle="gradient"
-          strokeWidth={2.5}
+          strokeWidth={2}
         />
         <XAxis />
         <ChartTooltip />

--- a/apps/web/components/docs/reference-area-demo.tsx
+++ b/apps/web/components/docs/reference-area-demo.tsx
@@ -8,23 +8,25 @@ import {
   ReferenceArea,
   XAxis,
 } from "@bklitui/ui/charts";
+import {
+  buildLineChartDemoData,
+  REFERENCE_AREA_DEMO,
+} from "@/components/docs/line-chart-demo-data";
 
-const chartData = [
-  { date: new Date(2024, 0, 1), value: 186 },
-  { date: new Date(2024, 1, 1), value: 305 },
-  { date: new Date(2024, 2, 1), value: 237 },
-  { date: new Date(2024, 3, 1), value: 73 },
-  { date: new Date(2024, 4, 1), value: 209 },
-  { date: new Date(2024, 5, 1), value: 214 },
-];
+const chartData = buildLineChartDemoData();
 
 export function ReferenceAreaBandDemo() {
   return (
     <div className="w-full">
       <LineChart data={chartData}>
         <Grid horizontal />
-        <ReferenceArea showMarkers strokeStyle="dashed" y1={160} y2={220} />
-        <Line dataKey="value" />
+        <ReferenceArea
+          showMarkers
+          strokeStyle="dashed"
+          y1={REFERENCE_AREA_DEMO.y1}
+          y2={REFERENCE_AREA_DEMO.y2}
+        />
+        <Line dataKey="value" strokeWidth={2} />
         <XAxis />
         <ChartTooltip />
       </LineChart>
@@ -38,14 +40,17 @@ export function ReferenceAreaPatternDemo() {
       <LineChart data={chartData}>
         <Grid horizontal />
         <ReferenceArea
-          axisLabelColor="var(--chart-1)"
-          fillOpacity={0.85}
-          pattern="diagonal"
-          patternColor="var(--chart-foreground-muted)"
-          y1={160}
-          y2={220}
+          axisLabelColor={REFERENCE_AREA_DEMO.axisLabelColor}
+          pattern={REFERENCE_AREA_DEMO.pattern}
+          patternColor={REFERENCE_AREA_DEMO.patternColor}
+          patternScale={REFERENCE_AREA_DEMO.patternScale}
+          patternStrokeWidth={REFERENCE_AREA_DEMO.patternStrokeWidth}
+          showMarkers={REFERENCE_AREA_DEMO.showMarkers}
+          stroke={REFERENCE_AREA_DEMO.stroke}
+          y1={REFERENCE_AREA_DEMO.y1}
+          y2={REFERENCE_AREA_DEMO.y2}
         />
-        <Line dataKey="value" />
+        <Line dataKey="value" strokeWidth={2} />
         <XAxis />
         <ChartTooltip />
       </LineChart>
@@ -63,10 +68,10 @@ export function ReferenceAreaMarkersDemo() {
           showMarkers
           stroke="var(--chart-1)"
           strokeStyle="dashed"
-          y1={160}
-          y2={220}
+          y1={REFERENCE_AREA_DEMO.y1}
+          y2={REFERENCE_AREA_DEMO.y2}
         />
-        <Line dataKey="value" />
+        <Line dataKey="value" strokeWidth={2} />
         <XAxis />
         <ChartTooltip />
       </LineChart>

--- a/apps/web/content/docs/utility/projection-line.mdx
+++ b/apps/web/content/docs/utility/projection-line.mdx
@@ -3,7 +3,7 @@ title: Projection Line
 description: Forecast segment extending a line series past the last data point — dashed stroke, gradient, and horizon marker
 ---
 
-import { studioChartHref } from "@bklitui/studio";
+import { studioLineReferenceProjectionHref } from "@bklitui/studio";
 import {
   buildProjectionPath,
   ChartTooltip,
@@ -49,21 +49,23 @@ import {
 const projectionPath = buildProjectionPath({
   sourceData: chartData,
   seriesKey: "value",
-  mode: "auto",
-  autoMethod: "lastSegment",
+  mode: "target",
   pathDensity: "endpoints",
-  horizonPoints: 8,
+  horizonPoints: 6,
+  endValue: 301,
 });
 
 <LineChart data={chartData}>
   <Grid horizontal />
   <Line dataKey="value" strokeWidth={2} />
-  <LineSeriesTerminalMarker dataKey="value" stroke="var(--chart-1)" />
+  <LineSeriesTerminalMarker dataKey="value" />
   <ProjectionLine
     data={projectionPath}
-    stroke="var(--chart-3)"
-    strokeDasharray="6,4"
+    strokeDasharray="1,4"
     curveKind="bezier"
+    strokeStyle="gradient"
+    gradientStart="oklch(0.979 0.037 110.273)"
+    gradientEnd="oklch(0.59 0.17 166.38)"
     showEndMarker
   />
   <XAxis />
@@ -126,7 +128,7 @@ The chart extends its x-domain to fit the projection horizon. Projections are in
     Edit in Studio
   </h3>
   <OpenInStudioButton
-    href={studioChartHref("line-chart", { projectionCount: 1 })}
+    href={studioLineReferenceProjectionHref()}
     slug="line-chart"
   />
 </div>
@@ -155,13 +157,14 @@ Open [Studio with a projection](/studio?chart=line-chart) and use **Settings →
 
 ### Gradient stroke
 
-<ComponentShowcase code={`<ProjectionLine
-  data={projectionPath}
-  strokeStyle="gradient"
-  gradientStart="var(--chart-3)"
-  gradientEnd="var(--chart-5)"
-  curveKind="linear"
-/>`}>
+<ComponentShowcase code={`  <ProjectionLine
+    data={projectionPath}
+    strokeStyle="gradient"
+    gradientStart="oklch(0.926 0.128 16.866 / 0.73)"
+    gradientEnd="oklch(0.849 0.232 16.498)"
+    curveKind="bezier"
+    strokeDasharray="1,4"
+  />`}>
   <ProjectionLineGradientDemo />
 </ComponentShowcase>
 

--- a/apps/web/content/docs/utility/reference-area.mdx
+++ b/apps/web/content/docs/utility/reference-area.mdx
@@ -3,7 +3,7 @@ title: Reference Area
 description: Shaded Y band for target ranges and thresholds on cartesian charts — solid or pattern fill, dashed edges, and Y-axis tick coloring
 ---
 
-import { studioChartHref } from "@bklitui/studio";
+import { studioLineReferenceProjectionHref } from "@bklitui/studio";
 import { LineChart, Line, Grid, ReferenceArea, ChartTooltip, XAxis } from "@bklitui/ui/charts";
 import {
   ReferenceAreaBandDemo,
@@ -13,7 +13,7 @@ import {
 import { OpenInStudioButton } from "@/components/docs/open-in-studio-button";
 
 <ComponentPreview registryName="reference-area">
-  <ReferenceAreaBandDemo />
+  <ReferenceAreaPatternDemo />
 </ComponentPreview>
 
 ## Installation
@@ -79,7 +79,7 @@ Pattern presets match [`Background`](/docs/utility/background) (`diagonal`, `dot
     Edit in Studio
   </h3>
   <OpenInStudioButton
-    href={studioChartHref("line-chart")}
+    href={studioLineReferenceProjectionHref()}
     slug="line-chart"
   />
 </div>
@@ -105,12 +105,14 @@ Open [Studio with the line chart](/studio?chart=line-chart) and select **Referen
 <ComponentShowcase code={`<LineChart data={data}>
   <Grid horizontal />
   <ReferenceArea
-    y1={160}
-    y2={220}
+    y1={250}
+    y2={300}
     pattern="diagonal"
-    patternColor="var(--chart-foreground-muted)"
-    axisLabelColor="var(--chart-1)"
-    fillOpacity={0.85}
+    patternColor="oklch(0.76 0.144 180.392 / 0.17)"
+    patternScale={0.75}
+    patternStrokeWidth={1.5}
+    stroke="oklch(0.841 0.142 159.667 / 0.49)"
+    axisLabelColor="oklch(0.795 0.152 164.722)"
   />
   <Line dataKey="value" />
   <XAxis />

--- a/packages/studio/src/components/charts/line-chart-studio-standard-preview.tsx
+++ b/packages/studio/src/components/charts/line-chart-studio-standard-preview.tsx
@@ -27,6 +27,7 @@ import { getStudioCssRevealPropsForPreview } from "@/lib/chart-animation";
 import { resolveCurve } from "@/lib/curves";
 import {
   clampStudioSeriesCount,
+  generateStudioCartesianData,
   generateStudioTrendingData,
   STUDIO_SERIES_KEYS,
 } from "@/lib/demo-data";
@@ -280,17 +281,30 @@ export function LineChartStudioStandardPreview({
 }) {
   const isLoading = state.lineChartState === "loading";
   const seriesCount = clampStudioSeriesCount(state.dataSeries);
+  const projectionCount = getProjectionCount(state);
   const data = useMemo(
     () =>
-      generateStudioTrendingData({
-        direction: state.lineDataTrend,
-        seriesCount,
-        pointCount: state.dataPoints,
-        xAxis: "date",
-      }),
-    [seriesCount, state.dataPoints, state.lineDataTrend]
+      projectionCount > 0
+        ? generateStudioTrendingData({
+            direction: state.lineDataTrend,
+            seriesCount,
+            pointCount: state.dataPoints,
+            xAxis: "date",
+          })
+        : generateStudioCartesianData({
+            seriesCount,
+            pointCount: state.dataPoints,
+            xAxis: "date",
+            seed: ctx.dataSeed,
+          }),
+    [
+      ctx.dataSeed,
+      projectionCount,
+      seriesCount,
+      state.dataPoints,
+      state.lineDataTrend,
+    ]
   );
-  const projectionCount = getProjectionCount(state);
   const brushXExtentMax = useMemo(
     () => studioBrushXExtentMax(state, data, projectionCount),
     [state, data, projectionCount]

--- a/packages/studio/src/index.ts
+++ b/packages/studio/src/index.ts
@@ -111,6 +111,10 @@ export { chartTooltipPropsFromState } from "./lib/studio-chart-overlays";
 export { STUDIO_EMBED_DEFAULT_HEIGHT } from "./lib/studio-embed";
 export { studioCartesianLegendItems } from "./lib/studio-legend-items";
 export {
+  lineReferenceProjectionStudioState,
+  studioLineReferenceProjectionHref,
+} from "./lib/studio-line-presets";
+export {
   STUDIO_OG_CAPTURE_ROOT_ATTR,
   STUDIO_OG_CHART_PERSPECTIVE_PX,
   STUDIO_OG_CHART_ROTATE_X_DEG,

--- a/packages/studio/src/lib/codegen-helpers.ts
+++ b/packages/studio/src/lib/codegen-helpers.ts
@@ -129,7 +129,7 @@ export function studioTrendingDataSnippet(
   const seriesLines = keys
     .map(
       (key, s) =>
-        `  ${key}: Math.max(10, Math.floor(${120 + s * 18} + ${sign} * (${5.5 + s * 1.25}) * i + Math.sin((i + ${s * 5}) / 2.2) * 5 + Math.cos((i + ${s * 3}) / 1.4) * 2.5)),`
+        `  ${key}: Math.max(10, Math.floor(${120 + s * 18} + ${sign} * (${5.5 + s * 1.25}) * i + Math.sin((i + ${s * 9}) / 4.4 + ${s * 1.2}) * ${24 + s * 3} + Math.cos((i + ${s * 9}) / 1.65 + ${s * 0.85}) * ${16 + s * 2} + Math.sin((i + ${s * 9}) / 0.68 + ${s * 2.4}) * ${10 + s} + Math.cos((i + ${s * 9}) / 2.95 + ${s * 1.6}) * 7)),`
     )
     .join("\n");
   return `const chartData = Array.from({ length: ${points} }, (_, i) => ({
@@ -1081,10 +1081,11 @@ export function scatterChartDataSnippet() {
 }
 
 export function lineChartDataSnippet(state: StudioUrlState) {
-  return (
-    studioTrendingDataSnippet(state, "date") +
-    projectionCodegenDataSnippets(state)
-  );
+  const dataSnippet =
+    getProjectionCount(state) > 0
+      ? studioTrendingDataSnippet(state, "date")
+      : studioCartesianDataSnippet(state, "date");
+  return dataSnippet + projectionCodegenDataSnippets(state);
 }
 
 export function areaChartDataSnippet(state: StudioUrlState) {

--- a/packages/studio/src/lib/demo-data.ts
+++ b/packages/studio/src/lib/demo-data.ts
@@ -616,10 +616,19 @@ function trendingSeriesValue(
   const sign = direction === "up" ? 1 : -1;
   const base = 120 + seriesIndex * 18;
   const trend = sign * (5.5 + seriesIndex * 1.25) * index;
-  const noise =
-    Math.sin((index + seriesIndex * 5) / 2.2) * 5 +
-    Math.cos((index + seriesIndex * 3) / 1.4) * 2.5;
-  return Math.max(10, Math.floor(base + trend + noise));
+  const i = index + seriesIndex * 9;
+
+  // Layered waves at multiple scales — trend stays readable, line feels organic.
+  const swell = Math.sin(i / 4.4 + seriesIndex * 1.2) * (24 + seriesIndex * 3);
+  const ripple =
+    Math.cos(i / 1.65 + seriesIndex * 0.85) * (16 + seriesIndex * 2);
+  const jitter = Math.sin(i / 0.68 + seriesIndex * 2.4) * (10 + seriesIndex);
+  const wobble = Math.cos(i / 2.95 + seriesIndex * 1.6) * 7;
+
+  return Math.max(
+    10,
+    Math.floor(base + trend + swell + ripple + jitter + wobble)
+  );
 }
 
 /** Deterministic up/down trending cartesian rows for projection exploration. */

--- a/packages/studio/src/lib/studio-line-presets.ts
+++ b/packages/studio/src/lib/studio-line-presets.ts
@@ -1,5 +1,5 @@
+import { studioStateHref } from "./chart-links";
 import { defaultStudioState, type StudioUrlState } from "./studio-parsers";
-import { studioStateHref } from "./studio-url-codec";
 
 /** Canonical line-chart Studio preset for reference area + projection demos. */
 export function lineReferenceProjectionStudioState(

--- a/packages/studio/src/lib/studio-line-presets.ts
+++ b/packages/studio/src/lib/studio-line-presets.ts
@@ -1,0 +1,41 @@
+import { defaultStudioState, type StudioUrlState } from "./studio-parsers";
+import { studioStateHref } from "./studio-url-codec";
+
+/** Canonical line-chart Studio preset for reference area + projection demos. */
+export function lineReferenceProjectionStudioState(
+  overrides: Partial<StudioUrlState> = {}
+): StudioUrlState {
+  return defaultStudioState({
+    chart: "line-chart",
+    dataPoints: 10,
+    referenceAreaY1: 250,
+    referenceAreaY2: 300,
+    referenceAreaPattern: "diagonal",
+    referenceAreaPatternColor: "oklch(0.76 0.144 180.392 / 0.17)",
+    referenceAreaPatternScale: 0.75,
+    referenceAreaPatternStrokeWidth: 1.5,
+    referenceAreaStroke: "oklch(0.841 0.142 159.667 / 0.49)",
+    referenceAreaAxisLabelColor: "oklch(0.795 0.152 164.722)",
+    referenceAreaShowMarkers: false,
+    projectionCount: 2,
+    projectionSeriesIndices: "0|0",
+    projectionModes: "target|auto",
+    projectionHorizons: "6|6",
+    projectionEndValues: "301",
+    projectionCurves: "bezier|bezier",
+    projectionStrokes: "var(--chart-3)|oklch(0.926 0.128 32.86 / 0.73)",
+    projectionStrokeStyles: "gradient|gradient",
+    projectionStrokeGradientStarts:
+      "oklch(0.979 0.037 110.273)|oklch(0.926 0.128 16.866 / 0.73)",
+    projectionStrokeGradientEnds:
+      "oklch(0.59 0.17 166.38)|oklch(0.849 0.232 16.498)",
+    projectionDashArrays: "1,4|1,4",
+    hiddenComponents:
+      "line.yaxis.left|line.yaxis.right|line.brush|line.series.1|line.legend",
+    ...overrides,
+  });
+}
+
+export function studioLineReferenceProjectionHref(): string {
+  return studioStateHref(lineReferenceProjectionStudioState());
+}


### PR DESCRIPTION
## Summary

- Decode and codify the canonical line-chart Studio preset (diagonal reference band at y1=250/y2=300, two gradient projection lines) via `studioLineReferenceProjectionHref()` and shared demo data
- Update docs, gallery, and Studio trending data to use organic wavy line data that pairs with the reference band and target/auto projections
- Line chart Studio preview uses cartesian seed data when no projections are active, trending data when projections are enabled

## Test plan

- [x] `pnpm lint` passes at repo root
- [x] `pnpm registry:build` run; registry outputs unchanged
- [x] Production build succeeds (`apps/web` build)
- [ ] Open `/docs/utility/reference-area` — pattern preview shows diagonal band at 250–300
- [ ] Open `/docs/utility/projection-line` — two gradient dashed projections on wavy data
- [ ] Open Studio via "Edit in Studio" on either doc page — matches reference + projection preset
- [ ] Line chart gallery reference band examples use the same bounds and demo data