### PR TITLE
Fix Studio light mode when site is dark

### DIFF
--- a/packages/studio/src/styles/studio-theme.css
+++ b/packages/studio/src/styles/studio-theme.css
@@ -1,8 +1,44 @@
 /*
  * Chart + editor tokens scoped to `.studio-shell`.
- * UI chrome uses default shadcn theme variables from `shadcn/tailwind.css`.
+ * Shadcn UI chrome vars are re-declared here so Studio light/dark stays
+ * independent of the host page theme on `document.documentElement`.
  */
 .studio-shell {
+  color-scheme: light;
+
+  /* Shadcn light variables (keep in sync with apps/web/app/globals.css :root) */
+  --background: oklch(1 0 0);
+  --foreground: oklch(0.148 0.004 228.8);
+  --card: oklch(1 0 0);
+  --card-foreground: oklch(0.148 0.004 228.8);
+  --popover: oklch(1 0 0);
+  --popover-foreground: oklch(0.148 0.004 228.8);
+  --primary: oklch(0.218 0.008 223.9);
+  --primary-foreground: oklch(0.987 0.002 197.1);
+  --secondary: oklch(0.963 0.002 197.1);
+  --secondary-foreground: oklch(0.218 0.008 223.9);
+  --muted: oklch(0.963 0.002 197.1);
+  --muted-foreground: oklch(0.56 0.021 213.5);
+  --accent: oklch(0.963 0.002 197.1);
+  --accent-foreground: oklch(0.218 0.008 223.9);
+  --destructive: oklch(0.577 0.245 27.325);
+  --border: oklch(0.925 0.005 214.3);
+  --input: oklch(0.925 0.005 214.3);
+  --ring: oklch(0.723 0.014 214.4);
+  --chart-1: oklch(0.865 0.127 207.078);
+  --chart-2: oklch(0.715 0.143 215.221);
+  --chart-3: oklch(0.609 0.126 221.723);
+  --chart-4: oklch(0.52 0.105 223.128);
+  --chart-5: oklch(0.45 0.085 224.283);
+  --sidebar: oklch(0.987 0.002 197.1);
+  --sidebar-foreground: oklch(0.148 0.004 228.8);
+  --sidebar-primary: oklch(0.218 0.008 223.9);
+  --sidebar-primary-foreground: oklch(0.987 0.002 197.1);
+  --sidebar-accent: oklch(0.963 0.002 197.1);
+  --sidebar-accent-foreground: oklch(0.218 0.008 223.9);
+  --sidebar-border: oklch(0.925 0.005 214.3);
+  --sidebar-ring: oklch(0.723 0.014 214.4);
+
   --studio-input-background: var(--background);
   --studio-label: var(--muted-foreground);
   --studio-section-label: var(--muted-foreground);
@@ -48,6 +84,41 @@
 }
 
 .studio-shell.dark {
+  color-scheme: dark;
+
+  /* Shadcn dark variables (keep in sync with apps/web/app/globals.css .dark) */
+  --background: oklch(0.14 0.0047 263.79);
+  --foreground: oklch(0.987 0.002 197.1);
+  --card: oklch(0.17 0.0065 271.01);
+  --card-foreground: oklch(0.987 0.002 197.1);
+  --popover: oklch(0.21 0.0058 285.9);
+  --popover-foreground: oklch(0.987 0.002 197.1);
+  --primary: oklch(0.925 0.005 214.3);
+  --primary-foreground: oklch(0.218 0.008 223.9);
+  --secondary: oklch(0.26 0.0134 272.84);
+  --secondary-foreground: oklch(0.987 0.002 197.1);
+  --muted: oklch(0.26 0.0134 272.84);
+  --muted-foreground: oklch(0.723 0.014 214.4);
+  --accent: oklch(0.26 0.0134 272.84);
+  --accent-foreground: oklch(0.987 0.002 197.1);
+  --destructive: oklch(0.704 0.191 22.216);
+  --border: oklch(0.56 0.0195 267.65 / 0.1);
+  --input: oklch(0.53 0.0251 265.6 / 0.2);
+  --ring: oklch(0.56 0.021 213.5);
+  --chart-1: oklch(0.865 0.127 207.078);
+  --chart-2: oklch(0.715 0.143 215.221);
+  --chart-3: oklch(0.609 0.126 221.723);
+  --chart-4: oklch(0.52 0.105 223.128);
+  --chart-5: oklch(0.45 0.085 224.283);
+  --sidebar: oklch(0.218 0.008 223.9);
+  --sidebar-foreground: oklch(0.987 0.002 197.1);
+  --sidebar-primary: oklch(0.488 0.243 264.376);
+  --sidebar-primary-foreground: oklch(0.987 0.002 197.1);
+  --sidebar-accent: oklch(0.275 0.011 216.9);
+  --sidebar-accent-foreground: oklch(0.987 0.002 197.1);
+  --sidebar-border: oklch(1 0 0 / 10%);
+  --sidebar-ring: oklch(0.56 0.021 213.5);
+
   --chart-background: var(--background);
   --chart-foreground: oklch(0.45 0 0);
   --chart-foreground-muted: oklch(0.65 0.01 260);


### PR DESCRIPTION
## Summary

- Re-declare shadcn light/dark CSS variables on `.studio-shell` so Studio theme stays independent of the host page `document.documentElement` theme
- Fixes Studio light mode appearing broken (dark chrome inherited from site dark mode) reported in #197
- Studio dark mode continues to work when the site header is in light mode

## Test plan

- [x] `pnpm lint` passes at repo root
- [x] `pnpm registry:build` run; no registry output changes
- [x] `apps/web` production build succeeds
- [x] Manual: `/studio` with site dark + Studio light shows light sidebars/canvas
- [x] Manual: `/studio` with site light + Studio dark shows dark sidebars/canvas
- [x] Manual: Studio theme toggle (D shortcut / toolbar button) switches correctly

Fixes #197