### PR TITLE
fix(web): show reference area bands on docs page

### DIFF
--- a/apps/web/components/docs/line-chart-demo-data.ts
+++ b/apps/web/components/docs/line-chart-demo-data.ts
@@ -3,8 +3,9 @@
 export const LINE_DEMO_POINT_COUNT = 10;
 
 export const REFERENCE_AREA_DEMO = {
-  y1: 250,
-  y2: 300,
+  /** Upper band on shared trending demo data (~141–200); Studio projection preset uses 250–300 with projections. */
+  y1: 160,
+  y2: 200,
   pattern: "diagonal" as const,
   patternColor: "oklch(0.76 0.144 180.392 / 0.17)",
   patternScale: 0.75,

--- a/apps/web/content/docs/utility/reference-area.mdx
+++ b/apps/web/content/docs/utility/reference-area.mdx
@@ -105,8 +105,8 @@ Open [Studio with the line chart](/studio?chart=line-chart) and select **Referen
 <ComponentShowcase code={`<LineChart data={data}>
   <Grid horizontal />
   <ReferenceArea
-    y1={250}
-    y2={300}
+    y1={160}
+    y2={200}
     pattern="diagonal"
     patternColor="oklch(0.76 0.144 180.392 / 0.17)"
     patternScale={0.75}


### PR DESCRIPTION
## Summary

- Align `REFERENCE_AREA_DEMO` bounds (`y1=160`, `y2=200`) with the shared line-chart demo data (~141–200).
- The previous bounds (`250–300`) only worked in Studio when projection lines expanded the Y domain, so docs previews rendered invisible.
- Update the pattern-fill code sample on the Reference Area docs page to match.

## Test plan

- [x] `pnpm lint` passes at repo root
- [x] `pnpm registry:build` run; no registry diff
- [x] `apps/web` production build succeeds
- [x] `/docs/utility/reference-area` preview and examples show shaded reference bands