### PR TITLE
fix(web): align testimonial grid dots and fix mobile nav scroll

### DIFF
--- a/apps/web/components/design/home-testimonials-grid.tsx
+++ b/apps/web/components/design/home-testimonials-grid.tsx
@@ -15,6 +15,14 @@ import { DesignTestimonialPanel } from "./testimonial-panel";
 
 const columnsPerRow = 3;
 
+function chunkItems<T>(items: T[], size: number): T[][] {
+  const rows: T[][] = [];
+  for (let index = 0; index < items.length; index += size) {
+    rows.push(items.slice(index, index + size));
+  }
+  return rows;
+}
+
 function Avatar({
   src,
   alt,
@@ -111,28 +119,34 @@ export function HomeTestimonialsGrid({
   const [expanded, setExpanded] = useState(false);
   const hasMore = items.length > collapsedCount;
   const visibleItems = expanded ? items : items.slice(0, collapsedCount);
-  const desktopRows = Math.ceil(visibleItems.length / columnsPerRow);
+  const itemRows = chunkItems(visibleItems, columnsPerRow);
 
   return (
     <section aria-label="Testimonials" className="w-full">
-      <div className="relative w-full overflow-visible border-border border-t border-l">
-        <div className="grid grid-cols-1 overflow-visible md:grid-cols-3">
-          {visibleItems.map((testimonial) => (
-            <DesignTestimonialPanel className="min-w-0" key={testimonial.id}>
-              <TestimonialPanelContent testimonial={testimonial} />
-            </DesignTestimonialPanel>
-          ))}
-        </div>
-        <GridCornerDots
-          className="z-3 md:hidden"
-          columns={1}
-          rows={visibleItems.length}
-        />
-        <GridCornerDots
-          className="z-3 hidden md:block"
-          columns={columnsPerRow}
-          rows={desktopRows}
-        />
+      <div className="relative flex w-full flex-col overflow-visible border-border border-t border-l">
+        {itemRows.map((rowItems) => (
+          <div
+            className="relative w-full overflow-visible"
+            key={rowItems.map((item) => item.id).join("-")}
+          >
+            <div className="grid grid-cols-1 overflow-visible md:grid-cols-3">
+              {rowItems.map((testimonial) => (
+                <DesignTestimonialPanel
+                  className="min-w-0"
+                  key={testimonial.id}
+                  showMobileCornerDots
+                >
+                  <TestimonialPanelContent testimonial={testimonial} />
+                </DesignTestimonialPanel>
+              ))}
+            </div>
+            <GridCornerDots
+              className="z-3 hidden md:block"
+              columns={rowItems.length}
+              rows={1}
+            />
+          </div>
+        ))}
         <div
           aria-hidden
           className="pointer-events-none absolute inset-0 -z-10"

--- a/apps/web/components/design/testimonial-panel.tsx
+++ b/apps/web/components/design/testimonial-panel.tsx
@@ -1,11 +1,15 @@
 import type { ReactNode } from "react";
 import { cn } from "@/lib/utils";
+import { GridCornerDots } from "./line-grid";
+
 export function DesignTestimonialPanel({
   children,
   className,
+  showMobileCornerDots = false,
 }: {
   children: ReactNode;
   className?: string;
+  showMobileCornerDots?: boolean;
 }) {
   return (
     <div
@@ -21,6 +25,9 @@ export function DesignTestimonialPanel({
       <div className="relative z-2 flex min-w-0 flex-col p-5 sm:p-8">
         {children}
       </div>
+      {showMobileCornerDots ? (
+        <GridCornerDots className="z-3 md:hidden" columns={1} rows={1} />
+      ) : null}
     </div>
   );
 }

--- a/apps/web/components/docs/site-header.tsx
+++ b/apps/web/components/docs/site-header.tsx
@@ -120,6 +120,19 @@ function MobileMenu({
   onClose,
   staggerDelay,
 }: MobileMenuProps) {
+  useEffect(() => {
+    if (!isOpen) {
+      return;
+    }
+
+    const previousOverflow = document.body.style.overflow;
+    document.body.style.overflow = "hidden";
+
+    return () => {
+      document.body.style.overflow = previousOverflow;
+    };
+  }, [isOpen]);
+
   const getBlurStyle = (index: number) => ({
     filter: isOpen ? "blur(0px)" : "blur(2px)",
     transitionDelay: isOpen ? `${index * staggerDelay}ms` : "0ms",
@@ -147,16 +160,15 @@ function MobileMenu({
 
       {/* Sheet */}
       <div
-        className={`fixed top-14 right-0 left-0 z-50 max-h-[calc(100vh-3.5rem)] overflow-y-auto overscroll-contain border-border border-b bg-background/95 backdrop-blur-xl transition-all duration-300 ease-out md:hidden ${
+        className={`fixed inset-x-0 top-18 bottom-0 z-50 flex flex-col overflow-hidden border-border border-b bg-background/95 backdrop-blur-xl transition-all duration-300 ease-out md:hidden ${
           isOpen
             ? "translate-y-0 opacity-100"
             : "pointer-events-none -translate-y-4 opacity-0"
         }`}
-        style={{ WebkitOverflowScrolling: "touch", touchAction: "pan-y" }}
       >
-        <nav className="flex flex-col px-6 py-4 pb-8">
+        <nav className="flex min-h-0 flex-1 flex-col overflow-y-auto overscroll-contain px-4 py-3 pb-[max(1.5rem,env(safe-area-inset-bottom))] [-webkit-overflow-scrolling:touch]">
           {/* Main links */}
-          <div className="flex flex-col gap-1">
+          <div className="flex flex-col gap-0.5">
             {links.map((link, index) => (
               <Link
                 className="transition-[filter] duration-300 ease-out"
@@ -166,7 +178,7 @@ function MobileMenu({
                 style={getBlurStyle(index)}
               >
                 <Button
-                  className="w-full justify-start"
+                  className="h-10 w-full justify-start px-3"
                   size="default"
                   variant="ghost"
                 >
@@ -177,14 +189,14 @@ function MobileMenu({
           </div>
 
           {/* Components section */}
-          <div className="mt-4 border-border border-t pt-4">
+          <div className="mt-3 border-border border-t pt-3">
             <span
-              className="mb-2 block px-3 font-medium text-muted-foreground text-xs uppercase tracking-wider transition-[filter] duration-300 ease-out"
+              className="mb-1 block px-3 font-medium text-muted-foreground text-xs uppercase tracking-wider transition-[filter] duration-300 ease-out"
               style={getBlurStyle(links.length)}
             >
               Components
             </span>
-            <div className="flex flex-col gap-1">
+            <div className="flex flex-col gap-0.5">
               {components.map((component, index) => (
                 <Link
                   className="transition-[filter] duration-300 ease-out"
@@ -194,7 +206,7 @@ function MobileMenu({
                   style={getBlurStyle(componentsStartIndex + index)}
                 >
                   <Button
-                    className="w-full justify-start"
+                    className="h-10 w-full justify-start px-3"
                     size="default"
                     variant="ghost"
                   >
@@ -206,14 +218,14 @@ function MobileMenu({
           </div>
 
           {/* Utility section */}
-          <div className="mt-4 border-border border-t pt-4">
+          <div className="mt-3 border-border border-t pt-3">
             <span
-              className="mb-2 block px-3 font-medium text-muted-foreground text-xs uppercase tracking-wider transition-[filter] duration-300 ease-out"
+              className="mb-1 block px-3 font-medium text-muted-foreground text-xs uppercase tracking-wider transition-[filter] duration-300 ease-out"
               style={getBlurStyle(utilitiesStartIndex - 1)}
             >
               Utility
             </span>
-            <div className="flex flex-col gap-1">
+            <div className="flex flex-col gap-0.5">
               {utilities.flatMap((utility, i) => {
                 if ("children" in utility && utility.children) {
                   return [
@@ -242,7 +254,7 @@ function MobileMenu({
                         )}
                       >
                         <Button
-                          className="w-full justify-start"
+                          className="h-10 w-full justify-start px-3"
                           size="default"
                           variant="ghost"
                         >
@@ -266,7 +278,7 @@ function MobileMenu({
                     style={getBlurStyle(utilitiesStartIndex + 1 + flatIndex)}
                   >
                     <Button
-                      className="w-full justify-start"
+                      className="h-10 w-full justify-start px-3"
                       size="default"
                       variant="ghost"
                     >
@@ -280,7 +292,7 @@ function MobileMenu({
 
           {/* External links */}
           {(githubUrl || discordUrl) && (
-            <div className="mt-4 flex flex-col gap-1 border-border border-t pt-4">
+            <div className="mt-3 flex flex-col gap-0.5 border-border border-t pt-3">
               {githubUrl && (
                 <Link
                   aria-label="GitHub"
@@ -378,14 +390,21 @@ export function SiteHeader({
   // Only use resolved theme after mount to avoid hydration mismatch
   const logoTheme = mounted && resolvedTheme === "dark" ? "dark" : "light";
 
+  let headerBackgroundClass =
+    "bg-transparent hover:bg-background/85 hover:backdrop-blur-md";
+  if (mobileMenuOpen) {
+    headerBackgroundClass = "bg-background/95 backdrop-blur-xl";
+  } else if (isScrolled) {
+    headerBackgroundClass =
+      "bg-background/60 backdrop-blur-md hover:bg-background/90";
+  }
+
   return (
     <>
       <header
         className={cn(
-          "fixed top-0 right-0 left-0 z-50 flex h-18 items-center transition-[background-color,backdrop-filter] duration-300 ease-out",
-          isScrolled || mobileMenuOpen
-            ? "bg-background/60 backdrop-blur-md hover:bg-background/90"
-            : "bg-transparent hover:bg-background/85 hover:backdrop-blur-md"
+          "fixed top-0 right-0 left-0 z-50 flex h-18 items-center px-2.5 transition-[background-color,backdrop-filter] duration-300 ease-out sm:px-0",
+          headerBackgroundClass
         )}
       >
         <div className="container mx-auto">


### PR DESCRIPTION
## Summary

- Fix testimonial grid corner dots for variable-height cards by rendering per-row dots on desktop and per-panel dots on mobile (matching the showcase grid pattern).
- Fix mobile nav scroll on iOS: correct header offset (`top-18`), inner scroll container, body scroll lock, safe-area padding, and tighter tap targets.
- Match site header background to the open mobile menu sheet (`bg-background/95 backdrop-blur-xl`).

## Test plan

- [x] `pnpm lint` passes at repo root
- [x] `pnpm registry:build` run; no registry output changes
- [x] `apps/web` production build succeeds
- [ ] Homepage testimonials: grid dots align at cell corners with mixed card heights (desktop + mobile)
- [ ] Mobile menu: scroll to bottom items (`Custom Indicator`, `useChart`) on iPhone; header bg matches menu when open