### PR TITLE
fix(web): show decorative ruler on initial homepage load

### DIFF
--- a/apps/web/components/design/page-canvas-shell.tsx
+++ b/apps/web/components/design/page-canvas-shell.tsx
@@ -19,7 +19,8 @@ export function PageCanvasShell({ children }: { children: ReactNode }) {
     }
 
     let frameId: number | undefined;
-    let lastHeight = element.offsetHeight;
+    // Start below zero so the first measurement always syncs state (useState(0)).
+    let lastHeight = -1;
 
     const update = () => {
       frameId = undefined;


### PR DESCRIPTION
## Summary

- Fix `PageCanvasShell` height measurement so the first sync always updates ruler state when content is already laid out on initial load.
- Prevents the decorative ruler from staying empty until a client-side navigation triggers a resize.

## Test plan

- [x] `pnpm lint` passes at repo root
- [x] `pnpm registry:build` run; no registry output changes
- [x] `apps/web` production build succeeds
- [ ] Load homepage on a fresh visit — ruler ticks and numbers visible immediately
- [ ] Navigate away and back — ruler still renders correctly