### PR TITLE
feat(web): redesign blocks page to match homepage grid layout

### DIFF
--- a/apps/web/app/(site)/(home)/blocks/page.tsx
+++ b/apps/web/app/(site)/(home)/blocks/page.tsx
@@ -3,17 +3,21 @@ import { BlocksHero } from "@/components/blocks/blocks-hero";
 
 export default function BlocksPage() {
   return (
-    <>
-      <section className="flex flex-col items-center px-4 py-18 text-center">
-        <BlocksHero />
+    <main className="flex flex-1 flex-col space-y-24">
+      <section className="relative w-full">
+        <div className="container mx-auto w-full overflow-visible">
+          <BlocksHero />
+        </div>
       </section>
 
-      <div
-        className="mx-auto w-full max-w-7xl scroll-mt-14 px-6 py-8"
+      <section
+        className="relative w-full pt-8 pb-16 md:pt-12 md:pb-24"
         id="blocks"
       >
-        <BlockExamplesGrid />
-      </div>
-    </>
+        <div className="container mx-auto w-full overflow-visible">
+          <BlockExamplesGrid />
+        </div>
+      </section>
+    </main>
   );
 }

--- a/apps/web/blocks/index.tsx
+++ b/apps/web/blocks/index.tsx
@@ -17,9 +17,10 @@ export function getFeaturedBlockElements() {
   );
 
   return [
-    <StatCardAreaBlock files={areaFiles} key="stat-card-area-01" />,
-    <StatCardLineBlock files={lineFiles} key="stat-card-line-01" />,
+    <StatCardAreaBlock embedded files={areaFiles} key="stat-card-area-01" />,
+    <StatCardLineBlock embedded files={lineFiles} key="stat-card-line-01" />,
     <StatCardChoroplethBlock
+      embedded
       files={choroplethFiles}
       key="stat-card-choropleth-01"
     />,

--- a/apps/web/blocks/stat-card-area-01/index.tsx
+++ b/apps/web/blocks/stat-card-area-01/index.tsx
@@ -5,11 +5,12 @@ import type { BlockDisplayProps } from "./meta";
 import { statCardArea01Meta } from "./meta";
 import { StatCardAreaPreview } from "./preview";
 
-export function StatCardAreaBlock(props: BlockDisplayProps) {
+export function StatCardAreaBlock({ embedded, ...props }: BlockDisplayProps) {
   return (
     <BlockViewer
       {...statCardArea01Meta}
       {...props}
+      embedded={embedded}
       preview={<StatCardAreaPreview />}
     />
   );

--- a/apps/web/blocks/stat-card-area-01/meta.ts
+++ b/apps/web/blocks/stat-card-area-01/meta.ts
@@ -10,4 +10,5 @@ export const statCardArea01Meta = {
 
 export interface BlockDisplayProps {
   files: BlockFile[];
+  embedded?: boolean;
 }

--- a/apps/web/blocks/stat-card-choropleth-01/index.tsx
+++ b/apps/web/blocks/stat-card-choropleth-01/index.tsx
@@ -5,11 +5,15 @@ import type { BlockDisplayProps } from "./meta";
 import { statCardChoropleth01Meta } from "./meta";
 import { StatCardChoroplethPreview } from "./preview";
 
-export function StatCardChoroplethBlock(props: BlockDisplayProps) {
+export function StatCardChoroplethBlock({
+  embedded,
+  ...props
+}: BlockDisplayProps) {
   return (
     <BlockViewer
       {...statCardChoropleth01Meta}
       {...props}
+      embedded={embedded}
       preview={<StatCardChoroplethPreview />}
     />
   );

--- a/apps/web/blocks/stat-card-choropleth-01/meta.ts
+++ b/apps/web/blocks/stat-card-choropleth-01/meta.ts
@@ -10,4 +10,5 @@ export const statCardChoropleth01Meta = {
 
 export interface BlockDisplayProps {
   files: BlockFile[];
+  embedded?: boolean;
 }

--- a/apps/web/blocks/stat-card-line-01/index.tsx
+++ b/apps/web/blocks/stat-card-line-01/index.tsx
@@ -5,11 +5,12 @@ import type { BlockDisplayProps } from "./meta";
 import { statCardLine01Meta } from "./meta";
 import { StatCardLinePreview } from "./preview";
 
-export function StatCardLineBlock(props: BlockDisplayProps) {
+export function StatCardLineBlock({ embedded, ...props }: BlockDisplayProps) {
   return (
     <BlockViewer
       {...statCardLine01Meta}
       {...props}
+      embedded={embedded}
       preview={<StatCardLinePreview />}
     />
   );

--- a/apps/web/blocks/stat-card-line-01/meta.ts
+++ b/apps/web/blocks/stat-card-line-01/meta.ts
@@ -10,4 +10,5 @@ export const statCardLine01Meta = {
 
 export interface BlockDisplayProps {
   files: BlockFile[];
+  embedded?: boolean;
 }

--- a/apps/web/components/blocks/block-examples.tsx
+++ b/apps/web/components/blocks/block-examples.tsx
@@ -2,9 +2,5 @@ import { getFeaturedBlockElements } from "@/blocks";
 import { FeaturedBlocks } from "@/components/blocks/featured-blocks";
 
 export function BlockExamplesGrid() {
-  return (
-    <div className="space-y-6">
-      <FeaturedBlocks blocks={getFeaturedBlockElements()} />
-    </div>
-  );
+  return <FeaturedBlocks blocks={getFeaturedBlockElements()} />;
 }

--- a/apps/web/components/blocks/block-panel.tsx
+++ b/apps/web/components/blocks/block-panel.tsx
@@ -1,0 +1,27 @@
+import type { ReactNode } from "react";
+import { cn } from "@/lib/utils";
+
+export function BlockPanel({
+  children,
+  className,
+}: {
+  children: ReactNode;
+  className?: string;
+}) {
+  return (
+    <div
+      className={cn(
+        "relative overflow-visible border-border border-r border-b",
+        className
+      )}
+    >
+      <div
+        aria-hidden
+        className="absolute inset-0 z-0 bg-white dark:bg-black"
+      />
+      <div className="relative z-2 flex size-full min-h-[inherit] flex-col">
+        {children}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/components/blocks/block-viewer.tsx
+++ b/apps/web/components/blocks/block-viewer.tsx
@@ -84,7 +84,8 @@ export function BlockViewer({
   preview,
   previewHeight = DEFAULT_PREVIEW_HEIGHT,
   mobilePreviewWidth = DEFAULT_MOBILE_WIDTH,
-}: BlockDefinition) {
+  embedded = false,
+}: BlockDefinition & { embedded?: boolean }) {
   const [view, setView] = useState<BlockView>("preview");
   const [viewport, setViewport] = useState<BlockViewport>("desktop");
   const [previewKey, setPreviewKey] = useState(0);
@@ -99,7 +100,14 @@ export function BlockViewer({
 
   return (
     <TooltipProvider>
-      <div className="overflow-hidden rounded-xl border border-border bg-card/70">
+      <div
+        className={cn(
+          "overflow-hidden",
+          embedded
+            ? "bg-transparent"
+            : "rounded-xl border border-border bg-card/70"
+        )}
+      >
         <div className="flex flex-col gap-3 px-4 py-3 lg:flex-row lg:items-center lg:gap-4">
           <div className="flex min-w-0 flex-1 items-center gap-3">
             <Tabs

--- a/apps/web/components/blocks/blocks-hero.tsx
+++ b/apps/web/components/blocks/blocks-hero.tsx
@@ -1,30 +1,12 @@
 "use client";
 
-import {
-  HeroActions,
-  HeroBadgeRow,
-  HeroDescription,
-  HeroShell,
-  HeroStudioPill,
-  HeroTitle,
-} from "@/components/hero";
+import { GridPageHero } from "@/components/design/grid-page-hero";
 import { Button } from "@/components/ui/button";
 
 export function BlocksHero() {
   return (
-    <HeroShell>
-      <HeroBadgeRow>
-        <HeroStudioPill />
-      </HeroBadgeRow>
-
-      <HeroTitle>Ready to go Blocks</HeroTitle>
-
-      <HeroDescription>
-        Beautiful open-source chart blocks for dashboards and analytics. Copy
-        and paste into your apps. Works with any React framework.
-      </HeroDescription>
-
-      <HeroActions>
+    <GridPageHero
+      action={
         <Button
           onClick={() => {
             document
@@ -34,9 +16,11 @@ export function BlocksHero() {
           size="lg"
           variant="white"
         >
-          Browse Blocks
+          Browse blocks
         </Button>
-      </HeroActions>
-    </HeroShell>
+      }
+      subtitle="Ready-to-go chart blocks for dashboards and analytics"
+      title="Blocks"
+    />
   );
 }

--- a/apps/web/components/blocks/featured-blocks.tsx
+++ b/apps/web/components/blocks/featured-blocks.tsx
@@ -1,5 +1,23 @@
-import type { ReactNode } from "react";
+import { Children, type ReactNode } from "react";
+import { BlockPanel } from "@/components/blocks/block-panel";
+import { DesignSectionRulers } from "@/components/design/design-section-rulers";
+import { GridCornerDots } from "@/components/design/line-grid";
 
 export function FeaturedBlocks({ blocks }: { blocks: ReactNode[] }) {
-  return <div className="flex flex-col gap-16">{blocks}</div>;
+  return (
+    <section aria-label="Blocks" className="w-full">
+      <div className="flex w-full flex-col space-y-24">
+        {Children.toArray(blocks).map((block) => (
+          <div
+            className="relative w-full overflow-visible border-border border-t border-l"
+            key={block.key}
+          >
+            <BlockPanel>{block}</BlockPanel>
+            <GridCornerDots className="z-3" columns={1} rows={1} />
+            <DesignSectionRulers />
+          </div>
+        ))}
+      </div>
+    </section>
+  );
 }

--- a/apps/web/components/blocks/featured-blocks.tsx
+++ b/apps/web/components/blocks/featured-blocks.tsx
@@ -1,4 +1,4 @@
-import { Children, type ReactNode } from "react";
+import { Children, isValidElement, type ReactNode } from "react";
 import { BlockPanel } from "@/components/blocks/block-panel";
 import { DesignSectionRulers } from "@/components/design/design-section-rulers";
 import { GridCornerDots } from "@/components/design/line-grid";
@@ -7,16 +7,22 @@ export function FeaturedBlocks({ blocks }: { blocks: ReactNode[] }) {
   return (
     <section aria-label="Blocks" className="w-full">
       <div className="flex w-full flex-col space-y-24">
-        {Children.toArray(blocks).map((block) => (
-          <div
-            className="relative w-full overflow-visible border-border border-t border-l"
-            key={block.key}
-          >
-            <BlockPanel>{block}</BlockPanel>
-            <GridCornerDots className="z-3" columns={1} rows={1} />
-            <DesignSectionRulers />
-          </div>
-        ))}
+        {Children.toArray(blocks).map((block, index) => {
+          if (!isValidElement(block)) {
+            return null;
+          }
+
+          return (
+            <div
+              className="relative w-full overflow-visible border-border border-t border-l"
+              key={block.key ?? index}
+            >
+              <BlockPanel>{block}</BlockPanel>
+              <GridCornerDots className="z-3" columns={1} rows={1} />
+              <DesignSectionRulers />
+            </div>
+          );
+        })}
       </div>
     </section>
   );

--- a/apps/web/components/design/grid-cell-pulse.tsx
+++ b/apps/web/components/design/grid-cell-pulse.tsx
@@ -15,6 +15,8 @@ interface GridCell {
   row: number;
 }
 
+export type GridCellPulseCell = GridCell;
+
 function cellId({ col, row }: GridCell) {
   return `${col}-${row}`;
 }
@@ -118,6 +120,7 @@ export function GridCellPulse({
   className,
   minRandomActive = 1,
   maxRandomActive = 3,
+  staticCells = [],
 }: {
   columns: number;
   rows: number;
@@ -126,6 +129,8 @@ export function GridCellPulse({
   minRandomActive?: number;
   /** Maximum number of randomly pulsing cells at once. */
   maxRandomActive?: number;
+  /** Cells that always show the diagonal pattern (no random pulse). */
+  staticCells?: GridCell[];
 }) {
   const reducedMotion = useReducedMotion();
   const { ref: visibilityRef, paused: offscreen } = usePauseWhenOffscreen();
@@ -133,6 +138,7 @@ export function GridCellPulse({
   const [randomCells, setRandomCells] = useState<GridCell[]>([]);
   const spawnTimerRef = useRef<number | undefined>(undefined);
   const randomCellsRef = useRef<GridCell[]>([]);
+  const randomPulseEnabled = maxRandomActive > 0;
 
   const effectiveMin = Math.min(minRandomActive, maxRandomActive);
 
@@ -190,7 +196,12 @@ export function GridCellPulse({
   }, [randomCells]);
 
   useEffect(() => {
-    if (reducedMotion || offscreen || randomCells.length >= effectiveMin) {
+    if (
+      !randomPulseEnabled ||
+      reducedMotion ||
+      offscreen ||
+      randomCells.length >= effectiveMin
+    ) {
       return;
     }
 
@@ -200,11 +211,18 @@ export function GridCellPulse({
     fillToMinimum,
     offscreen,
     randomCells.length,
+    randomPulseEnabled,
     reducedMotion,
   ]);
 
   useEffect(() => {
-    if (reducedMotion || offscreen || columns < 1 || rows < 1) {
+    if (
+      !randomPulseEnabled ||
+      reducedMotion ||
+      offscreen ||
+      columns < 1 ||
+      rows < 1
+    ) {
       return;
     }
 
@@ -240,6 +258,7 @@ export function GridCellPulse({
     effectiveMin,
     fillToMinimum,
     offscreen,
+    randomPulseEnabled,
     reducedMotion,
     rows,
     spawnRandomCell,
@@ -271,6 +290,7 @@ export function GridCellPulse({
     : { duration: 1, ease: easeOutQuint };
 
   const randomCellIds = new Set(randomCells.map((cell) => cellId(cell)));
+  const staticCellIds = new Set(staticCells.map((cell) => cellId(cell)));
 
   return (
     <div
@@ -291,11 +311,17 @@ export function GridCellPulse({
         const id = cellId({ col, row });
         const isHovered = hoveredCell?.col === col && hoveredCell?.row === row;
         const isRandom = randomCellIds.has(id);
+        const isStatic = staticCellIds.has(id);
         const isActive = isHovered || isRandom;
         const preset = presetForCell(col, row);
 
         return (
           <div className="relative min-h-0 min-w-0" key={id}>
+            {isStatic ? (
+              <div className="pointer-events-none absolute inset-0">
+                <GridCellPulsePattern preset={preset} />
+              </div>
+            ) : null}
             <AnimatePresence mode="wait">
               {isActive ? (
                 <motion.div

--- a/apps/web/components/design/grid-page-hero.tsx
+++ b/apps/web/components/design/grid-page-hero.tsx
@@ -1,0 +1,53 @@
+"use client";
+
+import type { ReactNode } from "react";
+import { HomeHeroSection } from "@/components/design/home-hero-section";
+import { LineGrid } from "@/components/design/line-grid";
+
+export function GridPageHero({
+  title,
+  subtitle,
+  action,
+}: {
+  title: string;
+  subtitle: string;
+  action?: ReactNode;
+}) {
+  return (
+    <HomeHeroSection>
+      <div className="w-full overflow-visible pt-8 md:pt-16">
+        <LineGrid
+          className="aspect-3/1 [--grid-cell-height:calc(100%/1)] [--grid-cell-width:calc(100%/3)] md:aspect-4/1 md:[--grid-cell-width:calc(100%/4)]"
+          columns={3}
+          columnsMd={4}
+          pulse
+          pulseMaxActive={0}
+          pulseMinActive={0}
+          pulseStaticCells={[{ col: 0, row: 0 }]}
+          rows={1}
+          variant="solid"
+        >
+          <div
+            className="pointer-events-none absolute inset-0 flex min-h-0 min-w-0 flex-col justify-center px-4 text-left sm:px-8 md:px-12"
+            data-grid-fill
+          >
+            <div className="flex flex-col items-start gap-3 sm:gap-4">
+              <div className="flex max-w-full flex-col items-start">
+                <h1 className="font-bold text-2xl tracking-tight sm:text-4xl md:text-5xl">
+                  {title}
+                </h1>
+                <p className="font-mono text-muted-foreground text-xs uppercase tracking-widest sm:text-sm md:text-base">
+                  {subtitle}
+                  <span className="animate-caret-blink">_</span>
+                </p>
+              </div>
+              {action ? (
+                <div className="pointer-events-auto">{action}</div>
+              ) : null}
+            </div>
+          </div>
+        </LineGrid>
+      </div>
+    </HomeHeroSection>
+  );
+}

--- a/apps/web/components/design/line-grid.tsx
+++ b/apps/web/components/design/line-grid.tsx
@@ -173,6 +173,7 @@ function ResponsiveGridCellPulse({
   pulseMinActive,
   pulseMinActiveLg,
   pulseMinActiveMd,
+  pulseStaticCells,
   tabletColumns,
   tabletRows,
 }: {
@@ -188,6 +189,7 @@ function ResponsiveGridCellPulse({
   pulseMinActive?: number;
   pulseMinActiveLg?: number;
   pulseMinActiveMd?: number;
+  pulseStaticCells?: GridCellPulseCell[];
   tabletColumns: number;
   tabletRows: number;
 }) {
@@ -217,6 +219,7 @@ function ResponsiveGridCellPulse({
           maxRandomActive={mobileMax}
           minRandomActive={mobileMin}
           rows={mobileRows}
+          staticCells={pulseStaticCells}
         />
         <GridCellPulse
           className="hidden md:grid lg:hidden"
@@ -224,6 +227,7 @@ function ResponsiveGridCellPulse({
           maxRandomActive={tabletMax}
           minRandomActive={tabletMin}
           rows={tabletRows}
+          staticCells={pulseStaticCells}
         />
         <GridCellPulse
           className="hidden lg:grid"
@@ -231,6 +235,7 @@ function ResponsiveGridCellPulse({
           maxRandomActive={desktopMax}
           minRandomActive={desktopMin}
           rows={desktopRows}
+          staticCells={pulseStaticCells}
         />
       </>
     );
@@ -245,6 +250,7 @@ function ResponsiveGridCellPulse({
           maxRandomActive={mobileMax}
           minRandomActive={mobileMin}
           rows={mobileRows}
+          staticCells={pulseStaticCells}
         />
         <GridCellPulse
           className="hidden md:grid"
@@ -252,6 +258,7 @@ function ResponsiveGridCellPulse({
           maxRandomActive={tabletMax}
           minRandomActive={tabletMin}
           rows={desktopRows}
+          staticCells={pulseStaticCells}
         />
       </>
     );
@@ -263,6 +270,7 @@ function ResponsiveGridCellPulse({
       maxRandomActive={mobileMax}
       minRandomActive={mobileMin}
       rows={desktopRows}
+      staticCells={pulseStaticCells}
     />
   );
 }
@@ -392,6 +400,7 @@ export function LineGrid({
   pulseMaxActive,
   pulseMaxActiveMd,
   pulseMaxActiveLg,
+  pulseStaticCells,
   className,
   children,
 }: {
@@ -420,6 +429,8 @@ export function LineGrid({
   pulseMaxActiveMd?: number;
   /** Max randomly pulsing cells from the `lg` breakpoint up. */
   pulseMaxActiveLg?: number;
+  /** Cells that always show the diagonal pattern (no random pulse). */
+  pulseStaticCells?: GridCellPulseCell[];
   className?: string;
   children?: ReactNode;
 }) {
@@ -472,6 +483,7 @@ export function LineGrid({
             pulseMinActive={pulseMinActive}
             pulseMinActiveLg={pulseMinActiveLg}
             pulseMinActiveMd={pulseMinActiveMd}
+            pulseStaticCells={pulseStaticCells}
             tabletColumns={tabletColumns}
             tabletRows={tabletRows}
           />

--- a/apps/web/components/design/line-grid.tsx
+++ b/apps/web/components/design/line-grid.tsx
@@ -1,5 +1,8 @@
 import type { CSSProperties, ReactNode } from "react";
-import { GridCellPulse } from "@/components/design/grid-cell-pulse";
+import {
+  GridCellPulse,
+  type GridCellPulseCell,
+} from "@/components/design/grid-cell-pulse";
 import { cn } from "@/lib/utils";
 
 const gridDotSize = "10px";

--- a/apps/web/components/showcase/showcase-hero.tsx
+++ b/apps/web/components/showcase/showcase-hero.tsx
@@ -1,55 +1,25 @@
 "use client";
 
 import Link from "fumadocs-core/link";
-import { HomeHeroSection } from "@/components/design/home-hero-section";
-import { LineGrid } from "@/components/design/line-grid";
+import { GridPageHero } from "@/components/design/grid-page-hero";
 import { Button } from "@/components/ui/button";
 import { showcaseSubmitUrl } from "@/lib/showcase/constants";
 
 export function ShowcaseHero() {
   return (
-    <HomeHeroSection>
-      <div className="w-full overflow-visible pt-8 md:pt-16">
-        <LineGrid
-          className="aspect-3/1 [--grid-cell-height:calc(100%/1)] [--grid-cell-width:calc(100%/3)] md:aspect-4/1 md:[--grid-cell-width:calc(100%/4)]"
-          columns={3}
-          columnsMd={4}
-          pulse
-          pulseMaxActive={2}
-          pulseMaxActiveMd={3}
-          pulseMinActive={1}
-          pulseMinActiveMd={2}
-          rows={1}
-          variant="solid"
+    <GridPageHero
+      action={
+        <Button
+          nativeButton={false}
+          render={<Link external href={showcaseSubmitUrl} />}
+          size="lg"
+          variant="white"
         >
-          <div
-            className="pointer-events-none absolute inset-0 flex min-h-0 min-w-0 flex-col justify-center px-4 text-left sm:px-8 md:px-12"
-            data-grid-fill
-          >
-            <div className="flex flex-col items-start gap-3 sm:gap-4">
-              <div className="flex max-w-full flex-col items-start">
-                <h1 className="font-bold text-2xl tracking-tight sm:text-4xl md:text-5xl">
-                  Showcase
-                </h1>
-                <p className="font-mono text-muted-foreground text-xs uppercase tracking-widest sm:text-sm md:text-base">
-                  Real dashboards and data experiences built with Bklit UI
-                  <span className="animate-caret-blink">_</span>
-                </p>
-              </div>
-              <div className="pointer-events-auto">
-                <Button
-                  nativeButton={false}
-                  render={<Link external href={showcaseSubmitUrl} />}
-                  size="lg"
-                  variant="white"
-                >
-                  Submit yours
-                </Button>
-              </div>
-            </div>
-          </div>
-        </LineGrid>
-      </div>
-    </HomeHeroSection>
+          Submit yours
+        </Button>
+      }
+      subtitle="Real dashboards and data experiences built with Bklit UI"
+      title="Showcase"
+    />
   );
 }


### PR DESCRIPTION
## Summary

- Redesign the blocks page to match the homepage/showcase grid language: shared `GridPageHero`, per-block corner framing, and embedded block viewers in grid panels.
- Extract `GridPageHero` for showcase and blocks sub-pages with a static first-cell pattern and hover-only pulse (no random animations).
- Add `staticCells` support to `GridCellPulse` and wire it through `LineGrid`.

## Test plan

- [x] `pnpm lint` passes at repo root
- [x] `pnpm registry:build` run; no registry output changes
- [x] `apps/web` production build succeeds
- [ ] `/blocks` hero uses line grid with static first-cell pattern and hover on other cells
- [ ] Each block section has its own corner dots and section rulers
- [ ] `/showcase` hero still renders via shared `GridPageHero`