### PR TITLE
fix(web): prevent mobile header shift when menu toggles

### DIFF
--- a/apps/web/components/docs/site-header.tsx
+++ b/apps/web/components/docs/site-header.tsx
@@ -433,7 +433,7 @@ export function SiteHeader({
       <header
         className={cn(
           "fixed top-0 right-0 left-0 z-50 px-2.5",
-          mobileMenuOpen && "max-md:bg-background max-md:px-0"
+          mobileMenuOpen && "max-md:bg-background"
         )}
         data-scrolled={isScrolled ? "" : undefined}
         ref={headerRef}
@@ -451,7 +451,7 @@ export function SiteHeader({
                 ? "translate-y-4 border border-border bg-background/80 px-4 shadow-sm backdrop-blur-sm md:mx-14"
                 : "translate-y-0 border border-transparent bg-transparent",
               mobileMenuOpen &&
-                "max-md:mx-0 max-md:translate-y-0 max-md:border-transparent max-md:bg-background max-md:px-4 max-md:shadow-none max-md:backdrop-blur-none"
+                "max-md:mx-0 max-md:translate-y-0 max-md:border-transparent max-md:bg-background max-md:shadow-none max-md:backdrop-blur-none"
             )}
             style={{ viewTransitionName: "site-header" }}
           >


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Remove the mobile menu padding swap that changed horizontal inset when opening the nav (`px-2.5` on `<header>` → `px-0`, plus `px-4` on the inner bar).
- Logo and right-side header controls (theme toggle, menu button) now stay fixed when the mobile menu opens, at both the top of the page and when scrolled.

## Test plan

- [x] `pnpm lint` passes at repo root
- [x] `pnpm registry:build` run (no registry output changes)
- [x] `apps/web` production build succeeds
- [x] Playwright check at 390px viewport: logo and menu button `deltaX = 0` with menu open/closed (top of page and scrolled)
- [ ] Manual check on a real device: open/close mobile nav and confirm no horizontal nudge on logo or header actions

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ddde575a-96ef-402b-8c25-f3249b0cde47"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ddde575a-96ef-402b-8c25-f3249b0cde47"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

