### PR TITLE
Add Strava Widget to showcase

### DIFF
--- a/apps/web/lib/showcase/projects.ts
+++ b/apps/web/lib/showcase/projects.ts
@@ -33,4 +33,11 @@ export const showcaseProjects: ShowcaseProject[] = [
       "https://github.com/user-attachments/assets/d704e860-f7b5-428d-b950-9991d95b9dc3",
     imageAlt: "Cyberwiz GRC platform website",
   },
+  {
+    title: "Strava Widget",
+    url: "https://strava-widget.com/",
+    image:
+      "https://github.com/user-attachments/assets/c04c9d4b-4339-4504-8a3d-9ffd9df5821a",
+    imageAlt: "Strava Widget activity charts",
+  },
 ];


### PR DESCRIPTION
## Summary

- Add Strava Widget (https://strava-widget.com/) to the community showcase from [discussion #82](https://github.com/bklit/bklit-ui/discussions/82)
- Uses the screenshot and URL submitted by @uixmat

## Test plan

- [x] `pnpm lint` passes at repo root
- [x] `pnpm registry:build` run; no registry output changes
- [x] Production build succeeds (`apps/web` build)
- [ ] Strava Widget card appears on `/showcase` and homepage showcase section
- [ ] Card links to https://strava-widget.com/