### PR TITLE
feat(web): add Better-T-Stack to showcase

### DIFF
--- a/apps/web/lib/showcase/projects.ts
+++ b/apps/web/lib/showcase/projects.ts
@@ -40,4 +40,11 @@ export const showcaseProjects: ShowcaseProject[] = [
       "https://github.com/user-attachments/assets/c04c9d4b-4339-4504-8a3d-9ffd9df5821a",
     imageAlt: "Strava Widget activity charts",
   },
+  {
+    title: "Better-T-Stack",
+    url: "https://www.better-t-stack.dev/",
+    image:
+      "https://github.com/user-attachments/assets/1139c9a5-75c5-44f9-acb0-12aeb883d76c",
+    imageAlt: "Better-T-Stack starter website",
+  },
 ];


### PR DESCRIPTION
## Summary

- Add Better-T-Stack (https://www.better-t-stack.dev/) to the community showcase from [discussion #82](https://github.com/bklit/bklit-ui/discussions/82#discussioncomment-17501869).
- Uses the screenshot and metadata submitted by @uixmat.

## Test plan

- [x] `pnpm lint` passes at repo root
- [x] `pnpm registry:build` run; no registry output changes
- [x] Production build succeeds (`apps/web` build)
- [ ] Better-T-Stack card appears on `/showcase` and homepage showcase section
- [ ] Card links to https://www.better-t-stack.dev/ and screenshot loads