### PR TITLE
docs(charts): clarify smooth data updates without reinitialization

### DIFF
--- a/apps/web/components/docs/line-chart-date-range-demo.tsx
+++ b/apps/web/components/docs/line-chart-date-range-demo.tsx
@@ -1,0 +1,79 @@
+"use client";
+
+import {
+  ChartTooltip,
+  Grid,
+  Line,
+  LineChart,
+  XAxis,
+} from "@bklitui/ui/charts";
+import { useMemo, useState } from "react";
+
+const fullData = Array.from({ length: 90 }, (_, index) => {
+  const date = new Date();
+  date.setDate(date.getDate() - (89 - index));
+  return {
+    date,
+    revenue: Math.round(
+      15000 + Math.sin(index * 0.15) * 3000 + Math.random() * 2000 + index * 50
+    ),
+  };
+});
+
+type DateRange = "7d" | "30d" | "90d";
+
+export function LineChartDateRangeDemo() {
+  const [range, setRange] = useState<DateRange>("30d");
+
+  const filteredData = useMemo(() => {
+    const daysMap = { "7d": 7, "30d": 30, "90d": 90 };
+    const days = daysMap[range];
+    return fullData.slice(-days);
+  }, [range]);
+
+  return (
+    <div className="w-full space-y-4">
+      <div className="flex gap-2">
+        <button
+          className={`rounded-md px-3 py-1.5 font-medium text-sm transition-colors ${
+            range === "7d"
+              ? "bg-foreground text-background"
+              : "bg-muted text-muted-foreground hover:bg-muted/80"
+          }`}
+          onClick={() => setRange("7d")}
+          type="button"
+        >
+          Last 7 days
+        </button>
+        <button
+          className={`rounded-md px-3 py-1.5 font-medium text-sm transition-colors ${
+            range === "30d"
+              ? "bg-foreground text-background"
+              : "bg-muted text-muted-foreground hover:bg-muted/80"
+          }`}
+          onClick={() => setRange("30d")}
+          type="button"
+        >
+          Last 30 days
+        </button>
+        <button
+          className={`rounded-md px-3 py-1.5 font-medium text-sm transition-colors ${
+            range === "90d"
+              ? "bg-foreground text-background"
+              : "bg-muted text-muted-foreground hover:bg-muted/80"
+          }`}
+          onClick={() => setRange("90d")}
+          type="button"
+        >
+          Last 90 days
+        </button>
+      </div>
+      <LineChart data={filteredData} yDomainTween>
+        <Grid horizontal />
+        <Line dataKey="revenue" stroke="var(--chart-line-primary)" />
+        <XAxis />
+        <ChartTooltip />
+      </LineChart>
+    </div>
+  );
+}

--- a/apps/web/components/docs/line-chart-date-range-demo.tsx
+++ b/apps/web/components/docs/line-chart-date-range-demo.tsx
@@ -1,12 +1,6 @@
 "use client";
 
-import {
-  ChartTooltip,
-  Grid,
-  Line,
-  LineChart,
-  XAxis,
-} from "@bklitui/ui/charts";
+import { ChartTooltip, Grid, Line, LineChart, XAxis } from "@bklitui/ui/charts";
 import { useMemo, useState } from "react";
 
 const fullData = Array.from({ length: 90 }, (_, index) => {
@@ -15,7 +9,7 @@ const fullData = Array.from({ length: 90 }, (_, index) => {
   return {
     date,
     revenue: Math.round(
-      15000 + Math.sin(index * 0.15) * 3000 + Math.random() * 2000 + index * 50
+      15_000 + Math.sin(index * 0.15) * 3000 + Math.random() * 2000 + index * 50
     ),
   };
 });

--- a/apps/web/content/docs/components/line-chart.mdx
+++ b/apps/web/content/docs/components/line-chart.mdx
@@ -7,6 +7,7 @@ import { studioChartHref } from "@bklitui/studio";
 import { LineChart, Line, Grid, XAxis, ChartTooltip, ChartBrush, ChartBrushLayout, ChartMarkers } from "@bklitui/ui/charts";
 import { LineChartBrushDemo } from "@/components/docs/line-chart-brush-demo";
 import { LineChartYDomainDemo } from "@/components/docs/line-chart-y-domain-demo";
+import { LineChartDateRangeDemo } from "@/components/docs/line-chart-date-range-demo";
 import { ProjectionLineDemo } from "@/components/docs/projection-line-demo";
 import { MarkerContentDemo } from "@/components/docs/marker-content-demo";
 import { OpenInStudioButton } from "@/components/docs/open-in-studio-button";
@@ -58,6 +59,34 @@ export default function SimpleChart() {
   );
 }
 ```
+
+## Updating data smoothly
+
+When your data changes (e.g. filtering by date range, refreshing from an API), the chart automatically updates smoothly without replaying the enter animation. The y-domain tweens to the new scale via `yDomainTween` (enabled by default).
+
+**Do not** change or pass the `revealSignature` prop when updating data — that prop is only for manually replaying the reveal animation (used in Studio's replay button).
+
+<ComponentShowcase
+  code={`const [range, setRange] = useState<"7d" | "30d" | "90d">("30d");
+const filteredData = useMemo(() => {
+  const daysMap = { "7d": 7, "30d": 30, "90d": 90 };
+  const days = daysMap[range];
+  return fullData.slice(-days);
+}, [range]);
+
+<LineChart data={filteredData} yDomainTween>
+  <Grid horizontal />
+  <Line dataKey="revenue" />
+  <XAxis />
+  <ChartTooltip />
+</LineChart>`}
+  liveChartPreview
+  previewMinHeight={360}
+>
+  <LineChartDateRangeDemo />
+</ComponentShowcase>
+
+Click the date range buttons — the chart line and y-axis smoothly update without reinitialization.
 
 ## Components
 

--- a/apps/web/content/docs/components/scatter-chart.mdx
+++ b/apps/web/content/docs/components/scatter-chart.mdx
@@ -105,7 +105,6 @@ Color dots by vertical position with a chart-space gradient — lower values tow
 | `margin` | `Partial<Margin>` | `40` all sides | Chart margins |
 | `animationDuration` | `number` | `1100` | Enter animation duration (ms) |
 | `enterTransition` | `Transition` | line-chart default | Motion tween for enter |
-| `revealSignature` | `string` | — | Change to replay enter animation |
 | `aspectRatio` | `string` | `"2 / 1"` | Container aspect ratio |
 
 ### Scatter


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Add date range filter example to line chart docs demonstrating smooth updates when data changes
- Users were reporting charts reinitializing on data updates due to incorrectly changing `revealSignature`
- Document that `revealSignature` should remain stable and is only for manual replay (Studio use)
- Removed `revealSignature` from scatter-chart props table for consistency

## Context

Addresses user feedback about charts reinitializing when filtering data (e.g., changing date ranges). The issue was developers incorrectly changing the `revealSignature` prop on data updates, which triggers a full reveal replay animation instead of smoothly updating the curve.

## Test plan

- [x] `pnpm lint` passes at repo root
- [x] `pnpm registry:build` run; no registry outputs changed
- [x] `pnpm build` succeeds (web-only build)
- [ ] Line chart docs page renders correctly at `/docs/components/line-chart`
- [ ] New date range demo shows smooth transitions without reinitialization
- [ ] Interactive date range buttons (7d/30d/90d) work correctly
- [ ] Chart y-axis smoothly tweens when data range changes
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f2421-15d6-7ebc-99bf-66da006beb20"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f2421-15d6-7ebc-99bf-66da006beb20"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

